### PR TITLE
Phase 4b: cup mode UI + classic pick planner + payment claim flow

### DIFF
--- a/drizzle/0001_mute_nova.sql
+++ b/drizzle/0001_mute_nova.sql
@@ -1,0 +1,2 @@
+ALTER TYPE "public"."payment_status" ADD VALUE 'claimed' BEFORE 'paid';--> statement-breakpoint
+ALTER TABLE "payment" ADD COLUMN "claimed_at" timestamp;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1555 @@
+{
+  "id": "8cb88f44-8d50-4faf-9d0e-7bc82e3445b2",
+  "prevId": "cf2518e7-3125-476c-b875-d879c77c9b27",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition": {
+      "name": "competition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "competition_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_source": {
+          "name": "data_source",
+          "type": "competition_data_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "season": {
+          "name": "season",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fixture": {
+      "name": "fixture",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_team_id": {
+          "name": "home_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "away_team_id": {
+          "name": "away_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kickoff": {
+          "name": "kickoff",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_score": {
+          "name": "home_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "away_score": {
+          "name": "away_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "fixture_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fixture_round_id_round_id_fk": {
+          "name": "fixture_round_id_round_id_fk",
+          "tableFrom": "fixture",
+          "tableTo": "round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fixture_home_team_id_team_id_fk": {
+          "name": "fixture_home_team_id_team_id_fk",
+          "tableFrom": "fixture",
+          "tableTo": "team",
+          "columnsFrom": [
+            "home_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fixture_away_team_id_team_id_fk": {
+          "name": "fixture_away_team_id_team_id_fk",
+          "tableFrom": "fixture",
+          "tableTo": "team",
+          "columnsFrom": [
+            "away_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.round": {
+      "name": "round",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "round_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upcoming'"
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "round_competition_id_competition_id_fk": {
+          "name": "round_competition_id_competition_id_fk",
+          "tableFrom": "round",
+          "tableTo": "competition",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team": {
+      "name": "team",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_url": {
+          "name": "badge_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_color": {
+          "name": "primary_color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ids": {
+          "name": "external_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_form": {
+      "name": "team_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recent_results": {
+          "name": "recent_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "home_form": {
+          "name": "home_form",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "away_form": {
+          "name": "away_form",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "league_position": {
+          "name": "league_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_form_team_comp_idx": {
+          "name": "team_form_team_comp_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_form_team_id_team_id_fk": {
+          "name": "team_form_team_id_team_id_fk",
+          "tableFrom": "team_form",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_form_competition_id_competition_id_fk": {
+          "name": "team_form_competition_id_competition_id_fk",
+          "tableFrom": "team_form",
+          "tableTo": "competition",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game": {
+      "name": "game",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "game_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'setup'"
+        },
+        "game_mode": {
+          "name": "game_mode",
+          "type": "game_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode_config": {
+          "name": "mode_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_players": {
+          "name": "max_players",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_round_id": {
+          "name": "current_round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_competition_id_competition_id_fk": {
+          "name": "game_competition_id_competition_id_fk",
+          "tableFrom": "game",
+          "tableTo": "competition",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_current_round_id_round_id_fk": {
+          "name": "game_current_round_id_round_id_fk",
+          "tableFrom": "game",
+          "tableTo": "round",
+          "columnsFrom": [
+            "current_round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "game_invite_code_unique": {
+          "name": "game_invite_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_player": {
+      "name": "game_player",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "player_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'alive'"
+        },
+        "eliminated_round_id": {
+          "name": "eliminated_round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lives_remaining": {
+          "name": "lives_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_player_unique_idx": {
+          "name": "game_player_unique_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_player_game_id_game_id_fk": {
+          "name": "game_player_game_id_game_id_fk",
+          "tableFrom": "game_player",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_player_eliminated_round_id_round_id_fk": {
+          "name": "game_player_eliminated_round_id_round_id_fk",
+          "tableFrom": "game_player",
+          "tableTo": "round",
+          "columnsFrom": [
+            "eliminated_round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pick": {
+      "name": "pick",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_player_id": {
+          "name": "game_player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fixture_id": {
+          "name": "fixture_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_rank": {
+          "name": "confidence_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "predicted_result": {
+          "name": "predicted_result",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "pick_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "goals_scored": {
+          "name": "goals_scored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_submitted": {
+          "name": "auto_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pick_player_round_idx": {
+          "name": "pick_player_round_idx",
+          "columns": [
+            {
+              "expression": "game_player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "round_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "confidence_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pick_game_id_game_id_fk": {
+          "name": "pick_game_id_game_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_game_player_id_game_player_id_fk": {
+          "name": "pick_game_player_id_game_player_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "game_player",
+          "columnsFrom": [
+            "game_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_round_id_round_id_fk": {
+          "name": "pick_round_id_round_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_team_id_team_id_fk": {
+          "name": "pick_team_id_team_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_fixture_id_fixture_id_fk": {
+          "name": "pick_fixture_id_fixture_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "fixture",
+          "columnsFrom": [
+            "fixture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planned_pick": {
+      "name": "planned_pick",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_player_id": {
+          "name": "game_player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_submit": {
+          "name": "auto_submit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "planned_pick_unique_idx": {
+          "name": "planned_pick_unique_idx",
+          "columns": [
+            {
+              "expression": "game_player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "round_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "planned_pick_game_player_id_game_player_id_fk": {
+          "name": "planned_pick_game_player_id_game_player_id_fk",
+          "tableFrom": "planned_pick",
+          "tableTo": "game_player",
+          "columnsFrom": [
+            "game_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "planned_pick_round_id_round_id_fk": {
+          "name": "planned_pick_round_id_round_id_fk",
+          "tableFrom": "planned_pick",
+          "tableTo": "round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "planned_pick_team_id_team_id_fk": {
+          "name": "planned_pick_team_id_team_id_fk",
+          "tableFrom": "planned_pick",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment": {
+      "name": "payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payment_game_id_game_id_fk": {
+          "name": "payment_game_id_game_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payout": {
+      "name": "payout",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_split": {
+          "name": "is_split",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "payout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payout_game_id_game_id_fk": {
+          "name": "payout_game_id_game_id_fk",
+          "tableFrom": "payout",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.competition_data_source": {
+      "name": "competition_data_source",
+      "schema": "public",
+      "values": [
+        "fpl",
+        "football_data",
+        "manual"
+      ]
+    },
+    "public.competition_type": {
+      "name": "competition_type",
+      "schema": "public",
+      "values": [
+        "league",
+        "knockout",
+        "group_knockout"
+      ]
+    },
+    "public.fixture_status": {
+      "name": "fixture_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "live",
+        "finished",
+        "postponed"
+      ]
+    },
+    "public.round_status": {
+      "name": "round_status",
+      "schema": "public",
+      "values": [
+        "upcoming",
+        "open",
+        "active",
+        "completed"
+      ]
+    },
+    "public.game_mode": {
+      "name": "game_mode",
+      "schema": "public",
+      "values": [
+        "classic",
+        "turbo",
+        "cup"
+      ]
+    },
+    "public.game_status": {
+      "name": "game_status",
+      "schema": "public",
+      "values": [
+        "setup",
+        "open",
+        "active",
+        "completed"
+      ]
+    },
+    "public.pick_result": {
+      "name": "pick_result",
+      "schema": "public",
+      "values": [
+        "pending",
+        "win",
+        "loss",
+        "draw",
+        "saved_by_life"
+      ]
+    },
+    "public.player_status": {
+      "name": "player_status",
+      "schema": "public",
+      "values": [
+        "alive",
+        "eliminated",
+        "winner"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "manual",
+        "mangopay"
+      ]
+    },
+    "public.payment_status": {
+      "name": "payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "claimed",
+        "paid",
+        "refunded"
+      ]
+    },
+    "public.payout_status": {
+      "name": "payout_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1776196064419,
       "tag": "0000_military_jack_power",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1776976690339,
+      "tag": "0001_mute_nova",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -393,15 +393,24 @@ async function seed() {
 			turboRoundNumber: 6, // completed round — full standings
 			turboState: 'completed',
 		},
+		{
+			name: 'Cup Tuesday (GW7)',
+			mode: 'cup',
+			creatorEmail: 'dev@example.com',
+			players: ['dev@example.com', 'dave@example.com', 'mike@example.com', 'rich@example.com'],
+			entryFee: '10.00',
+			turboRoundNumber: 7, // reuse the turbo seed's single-round model
+			turboState: 'live',
+		},
 	]
 
 	for (const seed of gameSeeds) {
 		const creatorId = userIds[seed.creatorEmail]
 
-		// Turbo games are tied to a single specific round; classic uses the open round.
+		// Turbo/Cup games are tied to a single specific round; classic uses the open round.
 		let gameRoundId = openRound.id
 		let gameStatus: 'setup' | 'open' | 'active' | 'completed' = 'active'
-		if (seed.mode === 'turbo' && seed.turboRoundNumber) {
+		if ((seed.mode === 'turbo' || seed.mode === 'cup') && seed.turboRoundNumber) {
 			const r = rounds.find((x) => x.number === seed.turboRoundNumber)
 			if (r) {
 				gameRoundId = r.id
@@ -416,7 +425,12 @@ async function seed() {
 				createdBy: creatorId,
 				competitionId: pl.id,
 				gameMode: seed.mode,
-				modeConfig: seed.mode === 'classic' ? {} : { numberOfPicks: 10 },
+				modeConfig:
+					seed.mode === 'classic'
+						? {}
+						: seed.mode === 'turbo'
+							? { numberOfPicks: 10 }
+							: { startingLives: 3, numberOfPicks: 6 },
 				entryFee: seed.entryFee ?? null,
 				inviteCode: generateInviteCode(),
 				status: gameStatus,
@@ -429,7 +443,12 @@ async function seed() {
 			const userId = userIds[email]
 			const [gp] = await db
 				.insert(gamePlayer)
-				.values({ gameId: newGame.id, userId, status: 'alive' })
+				.values({
+					gameId: newGame.id,
+					userId,
+					status: 'alive',
+					livesRemaining: seed.mode === 'cup' ? 3 : 0,
+				})
 				.returning()
 			playerRowsByEmail[email] = { id: gp.id, userId }
 
@@ -619,6 +638,61 @@ async function seed() {
 						gameId: newGame.id,
 						gamePlayerId: playerRow.id,
 						roundId: turboRound.id,
+						teamId: f.homeTeamId,
+						fixtureId: f.id,
+						confidenceRank: i + 1,
+						predictedResult,
+						result,
+						goalsScored: goals,
+					})
+				}
+			}
+		}
+
+		if (seed.mode === 'cup') {
+			// Cup is single-week with ranked picks — seed picks only for this game's specific round.
+			// Cup mode will functionally behave like turbo (since dev runs against PL with tier diff = 0).
+			const cupRound = rounds.find((r) => r.id === gameRoundId)
+			if (!cupRound) continue
+			const roundFixtures = fixturesByRound.get(cupRound.id) ?? []
+			const isCompleted = seed.turboState === 'completed'
+			const numberOfPicksToSeed = 6 // from modeConfig.numberOfPicks
+
+			for (const email of seed.players) {
+				const playerRow = playerRowsByEmail[email]
+				// For a live game, only some players have submitted picks yet —
+				// everyone else shows as "no pick" so we can see the nudge UX.
+				// Always skip the viewer (dev user) so they can actually make picks.
+				const isViewer = email === 'dev@example.com'
+				const shouldSubmit = isCompleted || (!isViewer && rng() < 0.65)
+				if (!shouldSubmit) continue
+
+				for (let i = 0; i < Math.min(numberOfPicksToSeed, roundFixtures.length); i++) {
+					const f = roundFixtures[i]
+					const predIdx = (i + cupRound.number + email.length) % 3
+					const predictedResult = predIdx === 0 ? 'home_win' : predIdx === 1 ? 'draw' : 'away_win'
+
+					let result: 'win' | 'loss' | 'pending' = isCompleted ? 'loss' : 'pending'
+					let goals = 0
+					if (isCompleted && f.homeScore != null && f.awayScore != null) {
+						const actual =
+							f.homeScore === f.awayScore
+								? 'draw'
+								: f.homeScore > f.awayScore
+									? 'home_win'
+									: 'away_win'
+						if (actual === predictedResult) {
+							result = 'win'
+							if (predictedResult === 'home_win') goals = f.homeScore
+							else if (predictedResult === 'away_win') goals = f.awayScore
+							else goals = f.homeScore + f.awayScore
+						}
+					}
+
+					await db.insert(pick).values({
+						gameId: newGame.id,
+						gamePlayerId: playerRow.id,
+						roundId: cupRound.id,
 						teamId: f.homeTeamId,
 						fixtureId: f.id,
 						confidenceRank: i + 1,

--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -1,6 +1,8 @@
 import { notFound } from 'next/navigation'
 import { GameDetailView } from '@/components/game/game-detail-view'
 import { ClassicPick } from '@/components/picks/classic-pick'
+import type { CupPickFixture, CupPickSlot } from '@/components/picks/cup-pick'
+import { CupPickForm } from '@/components/picks/cup-pick-form'
 import { TurboPick } from '@/components/picks/turbo-pick'
 import { requireSession } from '@/lib/auth-helpers'
 import {
@@ -10,6 +12,23 @@ import {
 	getTurboPickData,
 	getTurboStandingsData,
 } from '@/lib/game/detail-queries'
+
+// TODO(task-7): replace with computeTierDifference from '@/lib/game-logic/cup-tier'.
+// Kept inline here so Task 6 doesn't depend on Task 7's helper landing first.
+type TeamWithExternalIds = {
+	externalIds: Record<string, string | number> | null | undefined
+}
+function computeTierDifference(
+	home: TeamWithExternalIds,
+	away: TeamWithExternalIds,
+	competitionType: 'league' | 'knockout' | 'group_knockout',
+): number {
+	if (competitionType !== 'group_knockout') return 0
+	const homePot = Number(home.externalIds?.fifa_pot)
+	const awayPot = Number(away.externalIds?.fifa_pot)
+	if (!Number.isFinite(homePot) || !Number.isFinite(awayPot)) return 0
+	return homePot - awayPot
+}
 
 export default async function GameDetailPage({ params }: { params: Promise<{ id: string }> }) {
 	const session = await requireSession()
@@ -36,8 +55,11 @@ export default async function GameDetailPage({ params }: { params: Promise<{ id:
 			? await getTurboPickData(game.id, game.currentRound.id, game.myMembership.id)
 			: null
 
-	const numberOfPicks =
-		(game as unknown as { modeConfig?: { numberOfPicks?: number } }).modeConfig?.numberOfPicks ?? 10
+	const modeConfig = (
+		game as unknown as { modeConfig?: { numberOfPicks?: number; startingLives?: number } }
+	).modeConfig
+	const numberOfPicks = modeConfig?.numberOfPicks ?? 10
+	const startingLives = modeConfig?.startingLives ?? 3
 
 	const classicGrid =
 		game.gameMode === 'classic' ? await getProgressGridData(game.id, session.user.id) : null
@@ -46,6 +68,43 @@ export default async function GameDetailPage({ params }: { params: Promise<{ id:
 
 	const isAlive = game.myMembership?.status === 'alive'
 	const aliveCount = game.players.filter((p) => p.status === 'alive').length
+
+	// Build cup pick props inline from the data already fetched by getGameDetail.
+	// (Kept here rather than in detail-queries.ts because all source fields are already loaded.)
+	let cupFixtures: CupPickFixture[] = []
+	let cupInitialSlots: CupPickSlot[] = []
+	if (game.gameMode === 'cup' && game.currentRound && game.myMembership) {
+		cupFixtures = game.currentRound.fixtures.map((f) => ({
+			id: f.id,
+			homeTeamId: f.homeTeamId,
+			awayTeamId: f.awayTeamId,
+			homeShort: f.homeTeam.shortName,
+			homeName: f.homeTeam.name,
+			homeColor: f.homeTeam.primaryColor,
+			homeBadgeUrl: f.homeTeam.badgeUrl,
+			awayShort: f.awayTeam.shortName,
+			awayName: f.awayTeam.name,
+			awayColor: f.awayTeam.primaryColor,
+			awayBadgeUrl: f.awayTeam.badgeUrl,
+			kickoff: f.kickoff,
+			tierDifference: computeTierDifference(f.homeTeam, f.awayTeam, game.competition.type),
+		}))
+
+		const myPlayerId = game.myMembership.id
+		cupInitialSlots = game.picks
+			.filter(
+				(p) =>
+					p.gamePlayerId === myPlayerId &&
+					p.roundId === game.currentRound?.id &&
+					p.fixtureId != null &&
+					p.confidenceRank != null,
+			)
+			.map((p) => ({
+				confidenceRank: p.confidenceRank as number,
+				fixtureId: p.fixtureId as string,
+				pickedSide: (p.predictedResult === 'away_win' ? 'away' : 'home') as 'home' | 'away',
+			}))
+	}
 
 	const pickSection =
 		game.currentRound && isAlive ? (
@@ -68,6 +127,18 @@ export default async function GameDetailPage({ params }: { params: Promise<{ id:
 					fixtures={turboPickData.fixtures}
 					existingPicks={turboPickData.existingPicks}
 					numberOfPicks={numberOfPicks}
+				/>
+			) : game.gameMode === 'cup' && game.myMembership ? (
+				<CupPickForm
+					gameId={game.id}
+					roundId={game.currentRound.id}
+					fixtures={cupFixtures}
+					numberOfPicks={numberOfPicks}
+					livesRemaining={game.myMembership.livesRemaining}
+					maxLives={startingLives}
+					initialSlots={cupInitialSlots}
+					deadline={game.currentRound.deadline}
+					readonly={game.status !== 'open'}
 				/>
 			) : (
 				<div className="p-4 rounded-lg border border-border bg-card text-sm text-muted-foreground">

--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -174,6 +174,11 @@ export default async function GameDetailPage({ params }: { params: Promise<{ id:
 				aliveCount,
 				status: game.status,
 				inviteCode: game.inviteCode,
+				creatorName: game.creatorName,
+				isAdmin: game.isAdmin,
+				myPayment: game.myPayment,
+				otherPayments: game.otherPayments,
+				adminPayments: game.adminPayments,
 			}}
 			pickSection={pickSection}
 			classicGrid={classicGrid}

--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -8,6 +8,7 @@ import { requireSession } from '@/lib/auth-helpers'
 import { getCupLadderData } from '@/lib/game/cup-standings-queries'
 import {
 	getClassicPickData,
+	getClassicPlannerData,
 	getGameDetail,
 	getProgressGridData,
 	getTurboPickData,
@@ -33,6 +34,11 @@ export default async function GameDetailPage({ params }: { params: Promise<{ id:
 	const classicPickData =
 		game.currentRound && game.myMembership && game.gameMode === 'classic'
 			? await getClassicPickData(game.id, game.currentRound.id, game.myMembership.id)
+			: null
+
+	const classicPlannerData =
+		game.myMembership && game.gameMode === 'classic'
+			? await getClassicPlannerData(game.id, game.myMembership.id, game.currentRound?.id ?? null)
 			: null
 
 	const turboPickData =
@@ -104,6 +110,8 @@ export default async function GameDetailPage({ params }: { params: Promise<{ id:
 					fixtures={classicPickData.fixtures}
 					usedTeamsByRound={classicPickData.usedTeamsByRound}
 					existingPickTeamId={classicPickData.existingPickTeamId}
+					chain={classicPlannerData?.chain}
+					futureRounds={classicPlannerData?.futureRounds}
 				/>
 			) : game.gameMode === 'turbo' && turboPickData ? (
 				<TurboPick

--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -62,6 +62,15 @@ export default async function GameDetailPage({ params }: { params: Promise<{ id:
 	const isAlive = game.myMembership?.status === 'alive'
 	const aliveCount = game.players.filter((p) => p.status === 'alive').length
 
+	// Target = entryFee × playerCount (what the pot would be if everyone paid).
+	// Unpaid = headline sum of outstanding (not yet claimed) entries, computed
+	// directly from target − pot.total since pot includes both paid and claimed.
+	const entryFeeNum = game.entryFee ? Number.parseFloat(game.entryFee) : 0
+	const targetNum = entryFeeNum * game.players.length
+	const unpaidNum = Math.max(0, targetNum - Number.parseFloat(game.pot.total))
+	const target = targetNum.toFixed(2)
+	const unpaid = unpaidNum.toFixed(2)
+
 	// Build cup pick props inline from the data already fetched by getGameDetail.
 	// (Kept here rather than in detail-queries.ts because all source fields are already loaded.)
 	let cupFixtures: CupPickFixture[] = []
@@ -157,7 +166,9 @@ export default async function GameDetailPage({ params }: { params: Promise<{ id:
 				name: game.name,
 				gameMode: game.gameMode,
 				competition: game.competition.name,
-				pot: game.pot.total,
+				pot: game.pot,
+				target,
+				unpaid,
 				entryFee: game.entryFee,
 				playerCount: game.players.length,
 				aliveCount,

--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -5,6 +5,7 @@ import type { CupPickFixture, CupPickSlot } from '@/components/picks/cup-pick'
 import { CupPickForm } from '@/components/picks/cup-pick-form'
 import { TurboPick } from '@/components/picks/turbo-pick'
 import { requireSession } from '@/lib/auth-helpers'
+import { getCupLadderData } from '@/lib/game/cup-standings-queries'
 import {
 	getClassicPickData,
 	getGameDetail,
@@ -49,6 +50,8 @@ export default async function GameDetailPage({ params }: { params: Promise<{ id:
 		game.gameMode === 'classic' ? await getProgressGridData(game.id, session.user.id) : null
 	const turboStandingsData =
 		game.gameMode === 'turbo' ? await getTurboStandingsData(game.id, session.user.id) : null
+	const cupStandingsData =
+		game.gameMode === 'cup' ? await getCupLadderData(game.id, session.user.id) : null
 
 	const isAlive = game.myMembership?.status === 'alive'
 	const aliveCount = game.players.filter((p) => p.status === 'alive').length
@@ -158,6 +161,7 @@ export default async function GameDetailPage({ params }: { params: Promise<{ id:
 			turboStandings={
 				turboStandingsData ? { rounds: turboStandingsData.rounds, numberOfPicks } : null
 			}
+			cupStandings={cupStandingsData}
 		/>
 	)
 }

--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -157,7 +157,7 @@ export default async function GameDetailPage({ params }: { params: Promise<{ id:
 				name: game.name,
 				gameMode: game.gameMode,
 				competition: game.competition.name,
-				pot: game.pot,
+				pot: game.pot.total,
 				entryFee: game.entryFee,
 				playerCount: game.players.length,
 				aliveCount,

--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -12,23 +12,7 @@ import {
 	getTurboPickData,
 	getTurboStandingsData,
 } from '@/lib/game/detail-queries'
-
-// TODO(task-7): replace with computeTierDifference from '@/lib/game-logic/cup-tier'.
-// Kept inline here so Task 6 doesn't depend on Task 7's helper landing first.
-type TeamWithExternalIds = {
-	externalIds: Record<string, string | number> | null | undefined
-}
-function computeTierDifference(
-	home: TeamWithExternalIds,
-	away: TeamWithExternalIds,
-	competitionType: 'league' | 'knockout' | 'group_knockout',
-): number {
-	if (competitionType !== 'group_knockout') return 0
-	const homePot = Number(home.externalIds?.fifa_pot)
-	const awayPot = Number(away.externalIds?.fifa_pot)
-	if (!Number.isFinite(homePot) || !Number.isFinite(awayPot)) return 0
-	return homePot - awayPot
-}
+import { computeTierDifference } from '@/lib/game-logic/cup-tier'
 
 export default async function GameDetailPage({ params }: { params: Promise<{ id: string }> }) {
 	const session = await requireSession()

--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -46,11 +46,8 @@ export default async function GameDetailPage({ params }: { params: Promise<{ id:
 			? await getTurboPickData(game.id, game.currentRound.id, game.myMembership.id)
 			: null
 
-	const modeConfig = (
-		game as unknown as { modeConfig?: { numberOfPicks?: number; startingLives?: number } }
-	).modeConfig
-	const numberOfPicks = modeConfig?.numberOfPicks ?? 10
-	const startingLives = modeConfig?.startingLives ?? 3
+	const numberOfPicks = game.modeConfig?.numberOfPicks ?? 10
+	const startingLives = game.modeConfig?.startingLives ?? 3
 
 	const classicGrid =
 		game.gameMode === 'classic' ? await getProgressGridData(game.id, session.user.id) : null

--- a/src/app/api/cron/qstash-handler/route.test.ts
+++ b/src/app/api/cron/qstash-handler/route.test.ts
@@ -1,10 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { verifyMock, processGameRoundMock, writeEventMock } = vi.hoisted(() => ({
-	verifyMock: vi.fn(),
-	processGameRoundMock: vi.fn().mockResolvedValue({ processed: true }),
-	writeEventMock: vi.fn().mockResolvedValue(undefined),
-}))
+const { verifyMock, processGameRoundMock, writeEventMock, submitPlannedPickMock } = vi.hoisted(
+	() => ({
+		verifyMock: vi.fn(),
+		processGameRoundMock: vi.fn().mockResolvedValue({ processed: true }),
+		writeEventMock: vi.fn().mockResolvedValue(undefined),
+		submitPlannedPickMock: vi.fn().mockResolvedValue({ submitted: true }),
+	}),
+)
 
 vi.mock('@upstash/qstash/nextjs', () => ({
 	verifySignatureAppRouter: (fn: unknown) => fn,
@@ -14,6 +17,8 @@ vi.mock('@upstash/qstash/nextjs', () => ({
 vi.mock('@/lib/game/process-round', () => ({ processGameRound: processGameRoundMock }))
 
 vi.mock('@/lib/game/events', () => ({ writeEvent: writeEventMock }))
+
+vi.mock('@/lib/game/auto-submit', () => ({ submitPlannedPick: submitPlannedPickMock }))
 
 import { POST } from './route'
 
@@ -46,6 +51,14 @@ describe('qstash-handler', () => {
 			type: 'deadline_approaching',
 			payload: { roundId: 'r', window: '24h' },
 		})
+	})
+
+	it('dispatches auto_submit jobs', async () => {
+		const res = await POST(
+			req({ type: 'auto_submit', gamePlayerId: 'gp', roundId: 'r', teamId: 't' }),
+		)
+		expect(res.status).toBe(200)
+		expect(submitPlannedPickMock).toHaveBeenCalledWith('gp', 'r', 't')
 	})
 
 	it('rejects unknown job types', async () => {

--- a/src/app/api/cron/qstash-handler/route.ts
+++ b/src/app/api/cron/qstash-handler/route.ts
@@ -1,6 +1,7 @@
 import { verifySignatureAppRouter } from '@upstash/qstash/nextjs'
 import { NextResponse } from 'next/server'
 import type { QStashJob } from '@/lib/data/qstash'
+import { submitPlannedPick } from '@/lib/game/auto-submit'
 import { writeEvent } from '@/lib/game/events'
 import { processGameRound } from '@/lib/game/process-round'
 
@@ -17,6 +18,10 @@ async function handler(request: Request): Promise<Response> {
 				type: 'deadline_approaching',
 				payload: { roundId: body.roundId, window: body.window },
 			})
+			return NextResponse.json({ ok: true })
+		}
+		case 'auto_submit': {
+			await submitPlannedPick(body.gamePlayerId, body.roundId, body.teamId)
 			return NextResponse.json({ ok: true })
 		}
 		default:

--- a/src/app/api/games/[id]/admin/split-pot/route.ts
+++ b/src/app/api/games/[id]/admin/split-pot/route.ts
@@ -4,7 +4,7 @@ import { requireSession } from '@/lib/auth-helpers'
 import { db } from '@/lib/db'
 import { calculatePayouts, calculatePot } from '@/lib/game-logic/prizes'
 import { game, gamePlayer } from '@/lib/schema/game'
-import { payout } from '@/lib/schema/payment'
+import { payment, payout } from '@/lib/schema/payment'
 
 export async function POST(_request: Request, { params }: { params: Promise<{ id: string }> }) {
 	const session = await requireSession()
@@ -29,9 +29,12 @@ export async function POST(_request: Request, { params }: { params: Promise<{ id
 		return NextResponse.json({ error: 'Need at least 2 alive players to split' }, { status: 400 })
 	}
 
-	const pot = calculatePot(gameData.entryFee, gameData.players.length)
+	const payments = await db.query.payment.findMany({
+		where: eq(payment.gameId, id),
+	})
+	const pot = calculatePot(payments)
 	const winnerIds = alivePlayers.map((p) => p.userId)
-	const payoutEntries = calculatePayouts(pot, winnerIds)
+	const payoutEntries = calculatePayouts(pot.total, winnerIds)
 
 	// Mark players as winners
 	for (const player of alivePlayers) {

--- a/src/app/api/games/[id]/payments/[userId]/confirm/route.test.ts
+++ b/src/app/api/games/[id]/payments/[userId]/confirm/route.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/auth-helpers', () => ({
+	requireSession: vi.fn().mockResolvedValue({ user: { id: 'admin' } }),
+}))
+vi.mock('@/lib/db', () => ({
+	db: {
+		query: {
+			game: { findFirst: vi.fn() },
+			payment: { findFirst: vi.fn() },
+		},
+		update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })) })),
+	},
+}))
+
+import { db } from '@/lib/db'
+import { POST } from './route'
+
+const ctx = { params: Promise.resolve({ id: 'g1', userId: 'u1' }) }
+
+describe('confirm payment route', () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it('404s if game does not exist', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue(undefined as never)
+		const res = await POST(new Request('http://x', { method: 'POST' }), ctx)
+		expect(res.status).toBe(404)
+	})
+
+	it('403s if caller is not the admin', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({ createdBy: 'someone-else' } as never)
+		const res = await POST(new Request('http://x', { method: 'POST' }), ctx)
+		expect(res.status).toBe(403)
+	})
+
+	it('404s if payment row does not exist', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({ createdBy: 'admin' } as never)
+		vi.mocked(db.query.payment.findFirst).mockResolvedValue(undefined as never)
+		const res = await POST(new Request('http://x', { method: 'POST' }), ctx)
+		expect(res.status).toBe(404)
+	})
+
+	it('400s if payment is not in claimed state', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({ createdBy: 'admin' } as never)
+		vi.mocked(db.query.payment.findFirst).mockResolvedValue({
+			id: 'p1',
+			status: 'pending',
+		} as never)
+		const res = await POST(new Request('http://x', { method: 'POST' }), ctx)
+		expect(res.status).toBe(400)
+	})
+
+	it('200s for a claimed payment', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({ createdBy: 'admin' } as never)
+		vi.mocked(db.query.payment.findFirst).mockResolvedValue({
+			id: 'p1',
+			status: 'claimed',
+		} as never)
+		const res = await POST(new Request('http://x', { method: 'POST' }), ctx)
+		expect(res.status).toBe(200)
+	})
+})

--- a/src/app/api/games/[id]/payments/[userId]/confirm/route.ts
+++ b/src/app/api/games/[id]/payments/[userId]/confirm/route.ts
@@ -1,0 +1,32 @@
+import { and, eq } from 'drizzle-orm'
+import { NextResponse } from 'next/server'
+import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { game } from '@/lib/schema/game'
+import { payment } from '@/lib/schema/payment'
+
+type Ctx = { params: Promise<{ id: string; userId: string }> }
+
+export async function POST(_request: Request, ctx: Ctx): Promise<Response> {
+	const session = await requireSession()
+	const { id: gameId, userId } = await ctx.params
+
+	const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+	if (!g) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+	if (g.createdBy !== session.user.id) {
+		return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+	}
+
+	const existing = await db.query.payment.findFirst({
+		where: and(eq(payment.gameId, gameId), eq(payment.userId, userId)),
+	})
+	if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+	if (existing.status !== 'claimed') {
+		return NextResponse.json({ error: 'not-claimed' }, { status: 400 })
+	}
+	await db
+		.update(payment)
+		.set({ status: 'paid', paidAt: new Date() })
+		.where(eq(payment.id, existing.id))
+	return NextResponse.json({ ok: true })
+}

--- a/src/app/api/games/[id]/payments/[userId]/override/route.test.ts
+++ b/src/app/api/games/[id]/payments/[userId]/override/route.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/auth-helpers', () => ({
+	requireSession: vi.fn().mockResolvedValue({ user: { id: 'admin' } }),
+}))
+vi.mock('@/lib/db', () => ({
+	db: {
+		query: {
+			game: { findFirst: vi.fn() },
+			payment: { findFirst: vi.fn() },
+		},
+		update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })) })),
+	},
+}))
+
+import { db } from '@/lib/db'
+import { POST } from './route'
+
+const ctx = { params: Promise.resolve({ id: 'g1', userId: 'u1' }) }
+
+function makeReq(body: unknown): Request {
+	return new Request('http://x', {
+		method: 'POST',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify(body),
+	})
+}
+
+describe('override payment route', () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it('404s if game does not exist', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue(undefined as never)
+		const res = await POST(makeReq({ status: 'paid' }), ctx)
+		expect(res.status).toBe(404)
+	})
+
+	it('403s if caller is not the admin', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({ createdBy: 'someone-else' } as never)
+		const res = await POST(makeReq({ status: 'paid' }), ctx)
+		expect(res.status).toBe(403)
+	})
+
+	it('400s for an invalid status', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({ createdBy: 'admin' } as never)
+		const res = await POST(makeReq({ status: 'refunded' }), ctx)
+		expect(res.status).toBe(400)
+	})
+
+	it('404s if payment row does not exist', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({ createdBy: 'admin' } as never)
+		vi.mocked(db.query.payment.findFirst).mockResolvedValue(undefined as never)
+		const res = await POST(makeReq({ status: 'paid' }), ctx)
+		expect(res.status).toBe(404)
+	})
+
+	it('200s when forcing status to paid', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({ createdBy: 'admin' } as never)
+		vi.mocked(db.query.payment.findFirst).mockResolvedValue({
+			id: 'p1',
+			status: 'pending',
+		} as never)
+		const res = await POST(makeReq({ status: 'paid' }), ctx)
+		expect(res.status).toBe(200)
+	})
+
+	it('200s when forcing status to pending', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({ createdBy: 'admin' } as never)
+		vi.mocked(db.query.payment.findFirst).mockResolvedValue({
+			id: 'p1',
+			status: 'paid',
+		} as never)
+		const res = await POST(makeReq({ status: 'pending' }), ctx)
+		expect(res.status).toBe(200)
+	})
+
+	it('200s when forcing status to claimed', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({ createdBy: 'admin' } as never)
+		vi.mocked(db.query.payment.findFirst).mockResolvedValue({
+			id: 'p1',
+			status: 'pending',
+		} as never)
+		const res = await POST(makeReq({ status: 'claimed' }), ctx)
+		expect(res.status).toBe(200)
+	})
+})

--- a/src/app/api/games/[id]/payments/[userId]/override/route.ts
+++ b/src/app/api/games/[id]/payments/[userId]/override/route.ts
@@ -1,0 +1,55 @@
+import { and, eq } from 'drizzle-orm'
+import { NextResponse } from 'next/server'
+import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { game } from '@/lib/schema/game'
+import { payment } from '@/lib/schema/payment'
+
+type Ctx = { params: Promise<{ id: string; userId: string }> }
+
+type OverrideStatus = 'pending' | 'claimed' | 'paid'
+interface Body {
+	status: OverrideStatus
+}
+
+const ALLOWED_STATUSES: OverrideStatus[] = ['pending', 'claimed', 'paid']
+
+export async function POST(request: Request, ctx: Ctx): Promise<Response> {
+	const session = await requireSession()
+	const { id: gameId, userId } = await ctx.params
+
+	const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+	if (!g) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+	if (g.createdBy !== session.user.id) {
+		return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+	}
+
+	const body = (await request.json()) as Body
+	if (!ALLOWED_STATUSES.includes(body.status)) {
+		return NextResponse.json({ error: 'invalid-status' }, { status: 400 })
+	}
+
+	const existing = await db.query.payment.findFirst({
+		where: and(eq(payment.gameId, gameId), eq(payment.userId, userId)),
+	})
+	if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+	const update: {
+		status: OverrideStatus
+		claimedAt?: Date | null
+		paidAt?: Date | null
+	} = { status: body.status }
+	if (body.status === 'pending') {
+		update.claimedAt = null
+		update.paidAt = null
+	}
+	if (body.status === 'claimed') {
+		update.claimedAt = new Date()
+		update.paidAt = null
+	}
+	if (body.status === 'paid') {
+		update.paidAt = new Date()
+	}
+	await db.update(payment).set(update).where(eq(payment.id, existing.id))
+	return NextResponse.json({ ok: true })
+}

--- a/src/app/api/games/[id]/payments/[userId]/reject/route.test.ts
+++ b/src/app/api/games/[id]/payments/[userId]/reject/route.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/auth-helpers', () => ({
+	requireSession: vi.fn().mockResolvedValue({ user: { id: 'admin' } }),
+}))
+vi.mock('@/lib/db', () => ({
+	db: {
+		query: {
+			game: { findFirst: vi.fn() },
+			payment: { findFirst: vi.fn() },
+		},
+		update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })) })),
+	},
+}))
+
+import { db } from '@/lib/db'
+import { POST } from './route'
+
+const ctx = { params: Promise.resolve({ id: 'g1', userId: 'u1' }) }
+
+describe('reject payment route', () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it('404s if game does not exist', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue(undefined as never)
+		const res = await POST(new Request('http://x', { method: 'POST' }), ctx)
+		expect(res.status).toBe(404)
+	})
+
+	it('403s if caller is not the admin', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({ createdBy: 'someone-else' } as never)
+		const res = await POST(new Request('http://x', { method: 'POST' }), ctx)
+		expect(res.status).toBe(403)
+	})
+
+	it('404s if payment row does not exist', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({ createdBy: 'admin' } as never)
+		vi.mocked(db.query.payment.findFirst).mockResolvedValue(undefined as never)
+		const res = await POST(new Request('http://x', { method: 'POST' }), ctx)
+		expect(res.status).toBe(404)
+	})
+
+	it('400s if payment is not in claimed state', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({ createdBy: 'admin' } as never)
+		vi.mocked(db.query.payment.findFirst).mockResolvedValue({
+			id: 'p1',
+			status: 'paid',
+		} as never)
+		const res = await POST(new Request('http://x', { method: 'POST' }), ctx)
+		expect(res.status).toBe(400)
+	})
+
+	it('200s for a claimed payment', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({ createdBy: 'admin' } as never)
+		vi.mocked(db.query.payment.findFirst).mockResolvedValue({
+			id: 'p1',
+			status: 'claimed',
+		} as never)
+		const res = await POST(new Request('http://x', { method: 'POST' }), ctx)
+		expect(res.status).toBe(200)
+	})
+})

--- a/src/app/api/games/[id]/payments/[userId]/reject/route.ts
+++ b/src/app/api/games/[id]/payments/[userId]/reject/route.ts
@@ -1,0 +1,32 @@
+import { and, eq } from 'drizzle-orm'
+import { NextResponse } from 'next/server'
+import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { game } from '@/lib/schema/game'
+import { payment } from '@/lib/schema/payment'
+
+type Ctx = { params: Promise<{ id: string; userId: string }> }
+
+export async function POST(_request: Request, ctx: Ctx): Promise<Response> {
+	const session = await requireSession()
+	const { id: gameId, userId } = await ctx.params
+
+	const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+	if (!g) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+	if (g.createdBy !== session.user.id) {
+		return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+	}
+
+	const existing = await db.query.payment.findFirst({
+		where: and(eq(payment.gameId, gameId), eq(payment.userId, userId)),
+	})
+	if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+	if (existing.status !== 'claimed') {
+		return NextResponse.json({ error: 'not-claimed' }, { status: 400 })
+	}
+	await db
+		.update(payment)
+		.set({ status: 'pending', claimedAt: null })
+		.where(eq(payment.id, existing.id))
+	return NextResponse.json({ ok: true })
+}

--- a/src/app/api/games/[id]/payments/claim/route.test.ts
+++ b/src/app/api/games/[id]/payments/claim/route.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/auth-helpers', () => ({
+	requireSession: vi.fn().mockResolvedValue({ user: { id: 'u1' } }),
+}))
+vi.mock('@/lib/db', () => ({
+	db: {
+		query: { payment: { findFirst: vi.fn() } },
+		update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })) })),
+	},
+}))
+
+import { db } from '@/lib/db'
+import { POST } from './route'
+
+const ctx = { params: Promise.resolve({ id: 'g1' }) }
+
+describe('claim payment route', () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it('404s if no payment row exists', async () => {
+		vi.mocked(db.query.payment.findFirst).mockResolvedValue(undefined as never)
+		const res = await POST(new Request('http://x', { method: 'POST' }), ctx)
+		expect(res.status).toBe(404)
+	})
+
+	it('400s if payment is already claimed or paid', async () => {
+		vi.mocked(db.query.payment.findFirst).mockResolvedValue({ status: 'paid' } as never)
+		const res = await POST(new Request('http://x', { method: 'POST' }), ctx)
+		expect(res.status).toBe(400)
+	})
+
+	it('200s for a pending payment', async () => {
+		vi.mocked(db.query.payment.findFirst).mockResolvedValue({
+			id: 'p1',
+			status: 'pending',
+		} as never)
+		const res = await POST(new Request('http://x', { method: 'POST' }), ctx)
+		expect(res.status).toBe(200)
+	})
+})

--- a/src/app/api/games/[id]/payments/claim/route.ts
+++ b/src/app/api/games/[id]/payments/claim/route.ts
@@ -1,0 +1,25 @@
+import { and, eq } from 'drizzle-orm'
+import { NextResponse } from 'next/server'
+import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { payment } from '@/lib/schema/payment'
+
+type Ctx = { params: Promise<{ id: string }> }
+
+export async function POST(_request: Request, ctx: Ctx): Promise<Response> {
+	const session = await requireSession()
+	const { id: gameId } = await ctx.params
+
+	const existing = await db.query.payment.findFirst({
+		where: and(eq(payment.gameId, gameId), eq(payment.userId, session.user.id)),
+	})
+	if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+	if (existing.status !== 'pending') {
+		return NextResponse.json({ error: 'not-pending' }, { status: 400 })
+	}
+	await db
+		.update(payment)
+		.set({ status: 'claimed', claimedAt: new Date() })
+		.where(eq(payment.id, existing.id))
+	return NextResponse.json({ ok: true })
+}

--- a/src/app/api/games/[id]/planned-picks/[roundId]/route.ts
+++ b/src/app/api/games/[id]/planned-picks/[roundId]/route.ts
@@ -1,0 +1,20 @@
+import { and, eq } from 'drizzle-orm'
+import { NextResponse } from 'next/server'
+import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { gamePlayer, plannedPick } from '@/lib/schema/game'
+
+type Ctx = { params: Promise<{ id: string; roundId: string }> }
+
+export async function DELETE(_request: Request, ctx: Ctx): Promise<Response> {
+	const session = await requireSession()
+	const { id: gameId, roundId } = await ctx.params
+	const membership = await db.query.gamePlayer.findFirst({
+		where: and(eq(gamePlayer.gameId, gameId), eq(gamePlayer.userId, session.user.id)),
+	})
+	if (!membership) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+	await db
+		.delete(plannedPick)
+		.where(and(eq(plannedPick.gamePlayerId, membership.id), eq(plannedPick.roundId, roundId)))
+	return NextResponse.json({ ok: true })
+}

--- a/src/app/api/games/[id]/planned-picks/route.test.ts
+++ b/src/app/api/games/[id]/planned-picks/route.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/auth-helpers', () => ({
+	requireSession: vi.fn().mockResolvedValue({ user: { id: 'u1' } }),
+}))
+
+vi.mock('@/lib/db', () => ({
+	db: {
+		query: {
+			gamePlayer: { findFirst: vi.fn() },
+			game: { findFirst: vi.fn() },
+			round: { findFirst: vi.fn() },
+			pick: { findMany: vi.fn().mockResolvedValue([]) },
+			plannedPick: { findMany: vi.fn().mockResolvedValue([]) },
+		},
+		delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+		insert: vi.fn(() => ({
+			values: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([{ id: 'plan-1' }]) })),
+		})),
+	},
+}))
+
+import { db } from '@/lib/db'
+import { GET, POST } from './route'
+
+function makeReq(body: unknown, method: 'GET' | 'POST' = 'POST'): Request {
+	return new Request('http://x/api/games/g1/planned-picks', {
+		method,
+		headers: { 'content-type': 'application/json' },
+		body: method === 'POST' ? JSON.stringify(body) : undefined,
+	})
+}
+
+const ctx = { params: Promise.resolve({ id: 'g1' }) }
+
+describe('planned-picks route', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('GET returns 403 if not a member', async () => {
+		vi.mocked(db.query.gamePlayer.findFirst).mockResolvedValue(undefined as never)
+		const res = await GET(makeReq(null, 'GET'), ctx)
+		expect(res.status).toBe(403)
+	})
+
+	it('POST rejects non-classic games', async () => {
+		vi.mocked(db.query.gamePlayer.findFirst).mockResolvedValue({ id: 'gp' } as never)
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({ gameMode: 'turbo' } as never)
+		vi.mocked(db.query.round.findFirst).mockResolvedValue({
+			status: 'upcoming',
+			number: 5,
+		} as never)
+		const res = await POST(makeReq({ roundId: 'r1', teamId: 't1', autoSubmit: false }), ctx)
+		expect(res.status).toBe(400)
+		expect(await res.json()).toEqual({ error: 'planner is classic-only' })
+	})
+
+	it('POST rejects starting rounds', async () => {
+		vi.mocked(db.query.gamePlayer.findFirst).mockResolvedValue({ id: 'gp' } as never)
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({ gameMode: 'classic' } as never)
+		vi.mocked(db.query.round.findFirst).mockResolvedValue({ status: 'open', number: 5 } as never)
+		const res = await POST(makeReq({ roundId: 'r1', teamId: 't1', autoSubmit: false }), ctx)
+		expect(res.status).toBe(400)
+	})
+
+	it('POST succeeds for valid plan', async () => {
+		vi.mocked(db.query.gamePlayer.findFirst).mockResolvedValue({ id: 'gp' } as never)
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({ gameMode: 'classic' } as never)
+		vi.mocked(db.query.round.findFirst).mockResolvedValue({
+			status: 'upcoming',
+			number: 5,
+		} as never)
+		const res = await POST(makeReq({ roundId: 'r1', teamId: 't1', autoSubmit: true }), ctx)
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({ plan: { id: 'plan-1' } })
+	})
+})

--- a/src/app/api/games/[id]/planned-picks/route.ts
+++ b/src/app/api/games/[id]/planned-picks/route.ts
@@ -1,0 +1,104 @@
+import { and, eq } from 'drizzle-orm'
+import { NextResponse } from 'next/server'
+import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import {
+	type PastPick,
+	type PlannedPick as PPick,
+	validatePlannedPick,
+} from '@/lib/game/planned-picks'
+import { round } from '@/lib/schema/competition'
+import { game, gamePlayer, pick, plannedPick } from '@/lib/schema/game'
+
+type Ctx = { params: Promise<{ id: string }> }
+
+export async function GET(_request: Request, ctx: Ctx): Promise<Response> {
+	const session = await requireSession()
+	const { id: gameId } = await ctx.params
+
+	const membership = await db.query.gamePlayer.findFirst({
+		where: and(eq(gamePlayer.gameId, gameId), eq(gamePlayer.userId, session.user.id)),
+	})
+	if (!membership) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+	const plans = await db.query.plannedPick.findMany({
+		where: eq(plannedPick.gamePlayerId, membership.id),
+	})
+	return NextResponse.json({ plans })
+}
+
+interface PostBody {
+	roundId: string
+	teamId: string
+	autoSubmit: boolean
+}
+
+export async function POST(request: Request, ctx: Ctx): Promise<Response> {
+	const session = await requireSession()
+	const { id: gameId } = await ctx.params
+	const body = (await request.json()) as PostBody
+
+	const [membership, g, r] = await Promise.all([
+		db.query.gamePlayer.findFirst({
+			where: and(eq(gamePlayer.gameId, gameId), eq(gamePlayer.userId, session.user.id)),
+		}),
+		db.query.game.findFirst({ where: eq(game.id, gameId) }),
+		db.query.round.findFirst({ where: eq(round.id, body.roundId) }),
+	])
+	if (!membership || !g || !r) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+	if (g.gameMode !== 'classic') {
+		return NextResponse.json({ error: 'planner is classic-only' }, { status: 400 })
+	}
+	if (r.status !== 'upcoming') {
+		return NextResponse.json({ error: 'cannot plan for a started round' }, { status: 400 })
+	}
+
+	// Load this player's past picks and existing plans with their round numbers
+	const [pastPickRows, planRows] = await Promise.all([
+		db.query.pick.findMany({
+			where: eq(pick.gamePlayerId, membership.id),
+			with: { round: true },
+		}),
+		db.query.plannedPick.findMany({
+			where: eq(plannedPick.gamePlayerId, membership.id),
+			with: { round: true },
+		}),
+	])
+	const pastPicks: PastPick[] = pastPickRows.map((p) => ({
+		roundNumber: p.round.number,
+		teamId: p.teamId,
+	}))
+	const plannedPicks: PPick[] = planRows.map((p) => ({
+		roundNumber: p.round.number,
+		teamId: p.teamId,
+	}))
+
+	const result = validatePlannedPick({
+		teamId: body.teamId,
+		roundNumber: r.number,
+		pastPicks,
+		plannedPicks,
+	})
+	if (!result.valid) {
+		return NextResponse.json(
+			{ error: result.reason, roundNumber: result.roundNumber },
+			{ status: 400 },
+		)
+	}
+
+	// Upsert: delete existing plan for this (player, round) and insert new
+	await db
+		.delete(plannedPick)
+		.where(and(eq(plannedPick.gamePlayerId, membership.id), eq(plannedPick.roundId, body.roundId)))
+	const [created] = await db
+		.insert(plannedPick)
+		.values({
+			gamePlayerId: membership.id,
+			roundId: body.roundId,
+			teamId: body.teamId,
+			autoSubmit: body.autoSubmit,
+		})
+		.returning()
+
+	return NextResponse.json({ plan: created })
+}

--- a/src/app/api/games/[id]/route.ts
+++ b/src/app/api/games/[id]/route.ts
@@ -34,7 +34,7 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
 		where: eq(payment.gameId, id),
 	})
 
-	const pot = calculatePot(gameData.entryFee, gameData.players.length)
+	const pot = calculatePot(payments)
 
 	return NextResponse.json({
 		...gameData,

--- a/src/app/api/picks/[gameId]/[roundId]/route.ts
+++ b/src/app/api/picks/[gameId]/[roundId]/route.ts
@@ -2,6 +2,7 @@ import { and, eq, inArray } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import { requireSession } from '@/lib/auth-helpers'
 import { db } from '@/lib/db'
+import { computeTierDifference } from '@/lib/game-logic/cup-tier'
 import { validateWcClassicPick, wcRoundStage } from '@/lib/game-logic/wc-classic'
 import { validateClassicPick, validateTurboPicks } from '@/lib/picks/validate'
 import { round } from '@/lib/schema/competition'
@@ -42,10 +43,10 @@ export async function POST(request: Request, { params }: { params: Params }) {
 		return NextResponse.json({ error: 'Not a member of this game' }, { status: 403 })
 	}
 
-	// Get round
+	// Get round (with team relations so cup-mode validation can inspect tiers)
 	const roundData = await db.query.round.findFirst({
 		where: eq(round.id, roundId),
-		with: { fixtures: true },
+		with: { fixtures: { with: { homeTeam: true, awayTeam: true } } },
 	})
 	if (!roundData) {
 		return NextResponse.json({ error: 'Round not found' }, { status: 404 })
@@ -158,6 +159,35 @@ export async function POST(request: Request, { params }: { params: Params }) {
 
 	if (!validation.valid) {
 		return NextResponse.json({ error: validation.reason }, { status: 400 })
+	}
+
+	// Cup mode: reject submissions that include any restricted pick (picking a team
+	// more than 1 tier below its opponent). The UI already hides these, but the API
+	// must enforce it defensively.
+	if (gameData.gameMode === 'cup') {
+		for (const entry of pickEntries as Array<{
+			fixtureId: string
+			predictedResult: string
+		}>) {
+			const fx = roundData.fixtures.find((f) => f.id === entry.fixtureId)
+			if (!fx) continue
+			if (entry.predictedResult !== 'home_win' && entry.predictedResult !== 'away_win') continue
+			const tierDiff = computeTierDifference(fx.homeTeam, fx.awayTeam, gameData.competition.type)
+			// A positive tierDiff means the home team is in a worse (higher-pot) tier.
+			// Picking the home side when tierDiff > 1 means picking a team > 1 tier below;
+			// picking the away side when tierDiff < -1 is the same case on the other side.
+			const tierFromPicked = entry.predictedResult === 'home_win' ? tierDiff : -tierDiff
+			if (tierFromPicked > 1) {
+				return NextResponse.json(
+					{
+						error: 'restricted',
+						fixtureId: entry.fixtureId,
+						predictedResult: entry.predictedResult,
+					},
+					{ status: 400 },
+				)
+			}
+		}
 	}
 
 	// Delete existing picks for this round, then insert new ones

--- a/src/components/game/game-card.tsx
+++ b/src/components/game/game-card.tsx
@@ -33,7 +33,7 @@ export function GameCard({ game }: GameCardProps) {
 					<span>
 						{game.playerCount} players · {game.aliveCount} alive
 					</span>
-					<span className="font-display font-semibold text-foreground">£{game.pot} pot</span>
+					<span className="font-display font-semibold text-foreground">£{game.pot.total} pot</span>
 				</div>
 
 				{!isCompleted && !isEliminated && (

--- a/src/components/game/game-detail-view.tsx
+++ b/src/components/game/game-detail-view.tsx
@@ -1,7 +1,12 @@
 'use client'
 
+import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { GameHeader } from '@/components/game/game-header'
+import { MyPaymentStrip } from '@/components/game/my-payment-strip'
+import { OtherPlayersPayments } from '@/components/game/other-players-payments'
+import type { PaymentStatus } from '@/components/game/payment-status-chip'
+import { type AdminPayment, PaymentsPanel } from '@/components/game/payments-panel'
 import { ShareDialog } from '@/components/game/share-dialog'
 import { CupStandings } from '@/components/standings/cup-standings'
 import { type GridPlayer, type GridRound, ProgressGrid } from '@/components/standings/progress-grid'
@@ -23,6 +28,11 @@ interface GameDetailViewProps {
 		aliveCount: number
 		status: string
 		inviteCode: string
+		creatorName: string
+		isAdmin: boolean
+		myPayment: { status: PaymentStatus; amount: string } | null
+		otherPayments: Array<{ userName: string; status: PaymentStatus; isRebuy: boolean }>
+		adminPayments: AdminPayment[] | undefined
 	}
 	pickSection: React.ReactNode
 	classicGrid?: {
@@ -47,6 +57,8 @@ export function GameDetailView({
 	cupStandings,
 }: GameDetailViewProps) {
 	const [shareOpen, setShareOpen] = useState(false)
+	const router = useRouter()
+	const refresh = () => router.refresh()
 	const inviteUrl =
 		typeof window !== 'undefined' ? `${window.location.origin}/join/${game.inviteCode}` : ''
 
@@ -66,6 +78,24 @@ export function GameDetailView({
 				inviteCode={game.inviteCode}
 				onShare={() => setShareOpen(true)}
 			/>
+
+			{game.myPayment && (
+				<div className="mb-4">
+					<MyPaymentStrip
+						gameId={game.id}
+						status={game.myPayment.status}
+						amount={game.myPayment.amount}
+						creatorName={game.creatorName}
+						onClaimed={refresh}
+					/>
+				</div>
+			)}
+
+			{game.otherPayments.length > 0 && (
+				<div className="mb-6">
+					<OtherPlayersPayments payments={game.otherPayments} />
+				</div>
+			)}
 
 			<div className="mb-6">{pickSection}</div>
 
@@ -90,6 +120,19 @@ export function GameDetailView({
 			)}
 
 			{cupStandings && <CupStandings data={cupStandings} onShare={() => setShareOpen(true)} />}
+
+			{game.isAdmin && game.adminPayments && game.adminPayments.length > 0 && (
+				<div className="mt-6">
+					<PaymentsPanel
+						gameId={game.id}
+						gameName={game.name}
+						inviteCode={game.inviteCode}
+						totals={game.pot}
+						payments={game.adminPayments}
+						onChange={refresh}
+					/>
+				</div>
+			)}
 
 			<ShareDialog
 				open={shareOpen}

--- a/src/components/game/game-detail-view.tsx
+++ b/src/components/game/game-detail-view.tsx
@@ -3,8 +3,10 @@
 import { useState } from 'react'
 import { GameHeader } from '@/components/game/game-header'
 import { ShareDialog } from '@/components/game/share-dialog'
+import { CupStandings } from '@/components/standings/cup-standings'
 import { type GridPlayer, type GridRound, ProgressGrid } from '@/components/standings/progress-grid'
 import { type TurboRoundSummary, TurboStandings } from '@/components/standings/turbo-standings'
+import type { CupLadderData } from '@/lib/game/cup-standings-queries'
 
 interface GameDetailViewProps {
 	game: {
@@ -31,6 +33,7 @@ interface GameDetailViewProps {
 		rounds: TurboRoundSummary[]
 		numberOfPicks: number
 	} | null
+	cupStandings?: CupLadderData | null
 }
 
 export function GameDetailView({
@@ -38,6 +41,7 @@ export function GameDetailView({
 	pickSection,
 	classicGrid,
 	turboStandings,
+	cupStandings,
 }: GameDetailViewProps) {
 	const [shareOpen, setShareOpen] = useState(false)
 	const inviteUrl =
@@ -79,6 +83,8 @@ export function GameDetailView({
 					onShare={() => setShareOpen(true)}
 				/>
 			)}
+
+			{cupStandings && <CupStandings data={cupStandings} onShare={() => setShareOpen(true)} />}
 
 			<ShareDialog
 				open={shareOpen}

--- a/src/components/game/game-detail-view.tsx
+++ b/src/components/game/game-detail-view.tsx
@@ -7,6 +7,7 @@ import { CupStandings } from '@/components/standings/cup-standings'
 import { type GridPlayer, type GridRound, ProgressGrid } from '@/components/standings/progress-grid'
 import { type TurboRoundSummary, TurboStandings } from '@/components/standings/turbo-standings'
 import type { CupLadderData } from '@/lib/game/cup-standings-queries'
+import type { PotBreakdown } from '@/lib/game-logic/prizes'
 
 interface GameDetailViewProps {
 	game: {
@@ -14,7 +15,9 @@ interface GameDetailViewProps {
 		name: string
 		gameMode: string
 		competition: string
-		pot: string
+		pot: PotBreakdown
+		target: string
+		unpaid: string
 		entryFee: string | null
 		playerCount: number
 		aliveCount: number
@@ -53,7 +56,9 @@ export function GameDetailView({
 				name={game.name}
 				mode={game.gameMode}
 				competition={game.competition}
-				pot={game.pot}
+				potBreakdown={game.pot}
+				target={game.target}
+				unpaid={game.unpaid}
 				entryFee={game.entryFee}
 				playerCount={game.playerCount}
 				aliveCount={game.aliveCount}
@@ -91,7 +96,7 @@ export function GameDetailView({
 				onOpenChange={setShareOpen}
 				gameId={game.id}
 				gameName={game.name}
-				pot={game.pot}
+				pot={game.pot.total}
 				inviteUrl={inviteUrl}
 				inviteCode={game.inviteCode}
 			/>

--- a/src/components/game/game-header.tsx
+++ b/src/components/game/game-header.tsx
@@ -2,12 +2,15 @@
 
 import { Share2, Users } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import type { PotBreakdown } from '@/lib/game-logic/prizes'
 
 interface GameHeaderProps {
 	name: string
 	mode: string
 	competition: string
-	pot: string
+	potBreakdown: PotBreakdown
+	target: string
+	unpaid: string
 	entryFee: string | null
 	playerCount: number
 	aliveCount: number
@@ -20,13 +23,18 @@ export function GameHeader({
 	name,
 	mode,
 	competition,
-	pot,
+	potBreakdown,
+	target,
+	unpaid,
 	entryFee,
 	playerCount,
 	aliveCount,
 	inviteCode,
 	onShare,
 }: GameHeaderProps) {
+	const hasPending = potBreakdown.pending !== '0.00'
+	const hasUnpaid = unpaid !== '0.00'
+
 	return (
 		<div className="mb-6 bg-card border border-border rounded-xl overflow-hidden">
 			<div className="p-5 flex flex-wrap items-start justify-between gap-4">
@@ -46,11 +54,18 @@ export function GameHeader({
 				<div className="flex items-center gap-3">
 					<div className="text-right">
 						<div className="text-[0.65rem] uppercase tracking-wider text-muted-foreground font-semibold">
-							Pot
+							Pot (confirmed)
 						</div>
-						<div className="font-display text-3xl md:text-4xl font-bold leading-none">£{pot}</div>
+						<div className="font-display text-3xl md:text-4xl font-bold leading-none">
+							£{potBreakdown.confirmed}
+						</div>
+						<div className="text-[0.7rem] text-muted-foreground mt-1">
+							{hasPending && <span>£{potBreakdown.pending} awaiting confirmation · </span>}
+							{hasUnpaid && <span>£{unpaid} unpaid · </span>}
+							<span>£{target} target</span>
+						</div>
 						{entryFee && (
-							<div className="text-[0.7rem] text-muted-foreground mt-1">£{entryFee} entry</div>
+							<div className="text-[0.65rem] text-muted-foreground mt-0.5">£{entryFee} entry</div>
 						)}
 					</div>
 				</div>

--- a/src/components/game/my-payment-strip.tsx
+++ b/src/components/game/my-payment-strip.tsx
@@ -2,11 +2,11 @@
 
 import { useState } from 'react'
 import { toast } from 'sonner'
-import { cn } from '@/lib/utils'
+import { type PaymentStatus, PaymentStatusChip } from './payment-status-chip'
 
 interface MyPaymentStripProps {
 	gameId: string
-	status: 'pending' | 'claimed' | 'paid' | 'refunded'
+	status: PaymentStatus
 	amount: string
 	creatorName: string
 	onClaimed?: () => void
@@ -41,7 +41,7 @@ export function MyPaymentStrip({
 		<div className="flex items-center justify-between rounded-lg border border-dashed border-border bg-muted/40 px-3.5 py-2.5">
 			<div className="flex items-center gap-3">
 				<span className="text-sm text-muted-foreground">Your entry fee</span>
-				<StatusChip status={status} />
+				<PaymentStatusChip status={status} />
 			</div>
 			<div className="flex items-center gap-2">
 				<span className="text-[11px] text-muted-foreground">
@@ -59,30 +59,5 @@ export function MyPaymentStrip({
 				)}
 			</div>
 		</div>
-	)
-}
-
-function StatusChip({ status }: { status: MyPaymentStripProps['status'] }) {
-	const styles = {
-		pending: 'bg-muted text-foreground/70',
-		claimed: 'bg-amber-100 text-amber-900',
-		paid: 'bg-emerald-100 text-emerald-900',
-		refunded: 'bg-muted text-foreground/70',
-	}[status]
-	const label = {
-		pending: 'UNPAID',
-		claimed: '⏱ AWAITING CONFIRMATION',
-		paid: '✓ PAID',
-		refunded: 'REFUNDED',
-	}[status]
-	return (
-		<span
-			className={cn(
-				'inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-bold',
-				styles,
-			)}
-		>
-			{label}
-		</span>
 	)
 }

--- a/src/components/game/my-payment-strip.tsx
+++ b/src/components/game/my-payment-strip.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { cn } from '@/lib/utils'
+
+interface MyPaymentStripProps {
+	gameId: string
+	status: 'pending' | 'claimed' | 'paid' | 'refunded'
+	amount: string
+	creatorName: string
+	onClaimed?: () => void
+}
+
+export function MyPaymentStrip({
+	gameId,
+	status,
+	amount,
+	creatorName,
+	onClaimed,
+}: MyPaymentStripProps) {
+	const [pending, setPending] = useState(false)
+
+	async function handleClaim() {
+		setPending(true)
+		try {
+			const res = await fetch(`/api/games/${gameId}/payments/claim`, {
+				method: 'POST',
+			})
+			if (!res.ok) throw new Error(String(res.status))
+			toast.success('Marked as paid — waiting for admin confirmation')
+			onClaimed?.()
+		} catch {
+			toast.error('Failed to mark as paid')
+		} finally {
+			setPending(false)
+		}
+	}
+
+	return (
+		<div className="flex items-center justify-between rounded-lg border border-dashed border-border bg-muted/40 px-3.5 py-2.5">
+			<div className="flex items-center gap-3">
+				<span className="text-sm text-muted-foreground">Your entry fee</span>
+				<StatusChip status={status} />
+			</div>
+			<div className="flex items-center gap-2">
+				<span className="text-[11px] text-muted-foreground">
+					£{amount} owed to {creatorName}
+				</span>
+				{status === 'pending' && (
+					<button
+						type="button"
+						className="rounded bg-foreground px-3 py-1.5 text-xs font-semibold text-background disabled:opacity-60"
+						disabled={pending}
+						onClick={handleClaim}
+					>
+						Mark as paid
+					</button>
+				)}
+			</div>
+		</div>
+	)
+}
+
+function StatusChip({ status }: { status: MyPaymentStripProps['status'] }) {
+	const styles = {
+		pending: 'bg-muted text-foreground/70',
+		claimed: 'bg-amber-100 text-amber-900',
+		paid: 'bg-emerald-100 text-emerald-900',
+		refunded: 'bg-muted text-foreground/70',
+	}[status]
+	const label = {
+		pending: 'UNPAID',
+		claimed: '⏱ AWAITING CONFIRMATION',
+		paid: '✓ PAID',
+		refunded: 'REFUNDED',
+	}[status]
+	return (
+		<span
+			className={cn(
+				'inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-bold',
+				styles,
+			)}
+		>
+			{label}
+		</span>
+	)
+}

--- a/src/components/game/other-players-payments.tsx
+++ b/src/components/game/other-players-payments.tsx
@@ -1,0 +1,29 @@
+import { type PaymentStatus, PaymentStatusChip } from './payment-status-chip'
+
+interface OtherPayment {
+	userName: string
+	status: PaymentStatus
+	isRebuy: boolean
+}
+
+export function OtherPlayersPayments({ payments }: { payments: OtherPayment[] }) {
+	return (
+		<div className="space-y-1">
+			<div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+				Other players
+			</div>
+			{payments.map((p) => (
+				<div
+					key={`${p.userName}-${p.isRebuy ? 'rebuy' : 'original'}`}
+					className="flex items-center justify-between rounded bg-muted/40 px-3 py-1.5 text-[12px]"
+				>
+					<span>
+						{p.userName}
+						{p.isRebuy ? ' (rebuy)' : ''}
+					</span>
+					<PaymentStatusChip status={p.status} />
+				</div>
+			))}
+		</div>
+	)
+}

--- a/src/components/game/payment-reminder.test.ts
+++ b/src/components/game/payment-reminder.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { buildReminderUrl } from './payment-reminder'
+
+describe('buildReminderUrl', () => {
+	it('encodes the reminder text into a wa.me URL', () => {
+		const url = buildReminderUrl({
+			gameName: 'The Lads LPS',
+			amount: '10.00',
+			creatorName: 'Dave',
+			inviteCode: 'ABC123',
+			origin: 'https://lps.example.com',
+		})
+		expect(url).toContain('https://wa.me/?text=')
+		const decoded = decodeURIComponent(url.split('text=')[1])
+		expect(decoded).toContain('£10.00')
+		expect(decoded).toContain('The Lads LPS')
+		expect(decoded).toContain('https://lps.example.com/join/ABC123')
+	})
+})

--- a/src/components/game/payment-reminder.tsx
+++ b/src/components/game/payment-reminder.tsx
@@ -1,0 +1,27 @@
+interface PaymentReminderProps {
+	gameName: string
+	amount: string
+	creatorName: string
+	inviteCode: string
+	origin?: string
+}
+
+export function buildReminderUrl(p: PaymentReminderProps): string {
+	const base = p.origin ?? (typeof window !== 'undefined' ? window.location.origin : '')
+	const inviteUrl = `${base}/join/${p.inviteCode}`
+	const text = `Hi! Reminder: you owe £${p.amount} for ${p.gameName}. When you've paid, hit "Mark as paid" in the app: ${inviteUrl}`
+	return `https://wa.me/?text=${encodeURIComponent(text)}`
+}
+
+export function PaymentReminderButton(p: PaymentReminderProps) {
+	return (
+		<a
+			href={buildReminderUrl(p)}
+			target="_blank"
+			rel="noreferrer"
+			className="inline-flex items-center gap-1 rounded bg-[#25d366] px-3 py-1.5 text-xs font-semibold text-white"
+		>
+			💬 Remind via WhatsApp
+		</a>
+	)
+}

--- a/src/components/game/payment-status-chip.tsx
+++ b/src/components/game/payment-status-chip.tsx
@@ -1,0 +1,37 @@
+import { cn } from '@/lib/utils'
+
+export type PaymentStatus = 'pending' | 'claimed' | 'paid' | 'refunded'
+
+const STYLES: Record<PaymentStatus, string> = {
+	pending: 'bg-muted text-foreground/70',
+	claimed: 'bg-amber-100 text-amber-900',
+	paid: 'bg-emerald-100 text-emerald-900',
+	refunded: 'bg-muted text-foreground/70',
+}
+
+const LABELS: Record<PaymentStatus, string> = {
+	pending: 'UNPAID',
+	claimed: '⏱ AWAITING CONFIRMATION',
+	paid: '✓ PAID',
+	refunded: 'REFUNDED',
+}
+
+export function PaymentStatusChip({
+	status,
+	className,
+}: {
+	status: PaymentStatus
+	className?: string
+}) {
+	return (
+		<span
+			className={cn(
+				'inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-bold',
+				STYLES[status],
+				className,
+			)}
+		>
+			{LABELS[status]}
+		</span>
+	)
+}

--- a/src/components/game/payments-panel.tsx
+++ b/src/components/game/payments-panel.tsx
@@ -1,0 +1,199 @@
+'use client'
+
+import { toast } from 'sonner'
+import { cn } from '@/lib/utils'
+import { PaymentReminderButton } from './payment-reminder'
+import { type PaymentStatus, PaymentStatusChip } from './payment-status-chip'
+
+export interface AdminPayment {
+	userId: string
+	userName: string
+	amount: string
+	status: PaymentStatus
+	isRebuy: boolean
+	claimedAt: Date | null
+	paidAt: Date | null
+}
+
+interface PaymentsPanelProps {
+	gameId: string
+	gameName: string
+	inviteCode: string
+	totals: { confirmed: string; pending: string; total: string }
+	payments: AdminPayment[]
+	onChange?: () => void
+}
+
+export function PaymentsPanel(props: PaymentsPanelProps) {
+	const claimed = props.payments.filter((p) => p.status === 'claimed')
+	const all = props.payments
+	const unpaidCount = all.filter((p) => p.status === 'pending').length
+
+	async function callAction(userId: string, action: 'confirm' | 'reject' | 'revert') {
+		const endpoint = action === 'confirm' ? 'confirm' : action === 'reject' ? 'reject' : 'override'
+		const body = action === 'revert' ? JSON.stringify({ status: 'pending' }) : undefined
+		const res = await fetch(`/api/games/${props.gameId}/payments/${userId}/${endpoint}`, {
+			method: 'POST',
+			headers: body ? { 'content-type': 'application/json' } : undefined,
+			body,
+		})
+		if (res.ok) {
+			toast.success(
+				action === 'confirm'
+					? 'Payment confirmed'
+					: action === 'reject'
+						? 'Payment rejected'
+						: 'Payment reverted',
+			)
+			props.onChange?.()
+		} else {
+			toast.error(`Failed to ${action}`)
+		}
+	}
+
+	return (
+		<section className="space-y-4 rounded-xl border border-border bg-card p-4 md:p-5">
+			<div className="flex items-start justify-between">
+				<div>
+					<h2 className="font-display text-lg font-semibold">Payments</h2>
+					<div className="text-[11px] text-muted-foreground">
+						{claimed.length} of {all.length} awaiting confirmation · {unpaidCount} unpaid
+					</div>
+				</div>
+				<div className="text-right">
+					<div className="text-[10px] uppercase text-muted-foreground">Received total</div>
+					<div className="font-display text-lg font-bold">£{props.totals.confirmed}</div>
+					{props.totals.pending !== '0.00' && (
+						<div className="text-[10px] text-amber-800">
+							+£{props.totals.pending} awaiting confirmation
+						</div>
+					)}
+				</div>
+			</div>
+
+			{claimed.length > 0 && (
+				<div>
+					<div className="mb-1.5 text-[10px] font-semibold uppercase text-muted-foreground">
+						Needs your attention ({claimed.length})
+					</div>
+					{claimed.map((p) => (
+						<Row
+							key={`${p.userId}-claimed`}
+							p={p}
+							highlight
+							actions={
+								<>
+									<button
+										type="button"
+										onClick={() => callAction(p.userId, 'confirm')}
+										className="rounded bg-foreground px-3 py-1.5 text-xs font-semibold text-background"
+									>
+										✓ Confirm
+									</button>
+									<button
+										type="button"
+										onClick={() => callAction(p.userId, 'reject')}
+										className="rounded border border-red-300 px-3 py-1.5 text-xs font-semibold text-red-700"
+									>
+										Reject
+									</button>
+								</>
+							}
+						/>
+					))}
+				</div>
+			)}
+
+			<div>
+				<div className="mb-1.5 text-[10px] font-semibold uppercase text-muted-foreground">
+					All payments
+				</div>
+				{all.map((p) => (
+					<Row
+						key={`${p.userId}-all-${p.isRebuy ? 'rebuy' : 'original'}`}
+						p={p}
+						actions={
+							p.status === 'paid' ? (
+								<button
+									type="button"
+									onClick={() => callAction(p.userId, 'revert')}
+									className="rounded border border-border px-3 py-1.5 text-xs font-semibold"
+								>
+									Revert
+								</button>
+							) : p.status === 'pending' ? (
+								<PaymentReminderButton
+									gameName={props.gameName}
+									amount={p.amount}
+									creatorName="you"
+									inviteCode={props.inviteCode}
+								/>
+							) : null
+						}
+					/>
+				))}
+			</div>
+		</section>
+	)
+}
+
+function Row({
+	p,
+	actions,
+	highlight,
+}: {
+	p: AdminPayment
+	actions: React.ReactNode
+	highlight?: boolean
+}) {
+	return (
+		<div
+			className={cn(
+				'mb-1 grid grid-cols-[28px_1fr_120px_60px_auto] items-center gap-2 rounded-lg border px-3 py-2',
+				highlight ? 'border-amber-300 bg-amber-50' : 'border-border bg-card',
+			)}
+		>
+			<Avatar name={p.userName} />
+			<div>
+				<div className="text-sm font-semibold">
+					{p.userName}
+					{p.isRebuy ? ' (rebuy)' : ''}
+				</div>
+				<div className="text-[10px] text-muted-foreground">{rowSubtitle(p)}</div>
+			</div>
+			<PaymentStatusChip status={p.status} />
+			<div className="text-sm font-semibold">£{p.amount}</div>
+			<div className="flex justify-end gap-1">{actions}</div>
+		</div>
+	)
+}
+
+function Avatar({ name }: { name: string }) {
+	const initials = name
+		.split(' ')
+		.slice(0, 2)
+		.map((s) => s.charAt(0).toUpperCase())
+		.join('')
+	return (
+		<span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-muted text-[11px] font-semibold text-foreground/80">
+			{initials || '?'}
+		</span>
+	)
+}
+
+function rowSubtitle(p: AdminPayment): string {
+	if (p.status === 'paid') {
+		return p.paidAt ? `Confirmed ${formatDate(p.paidAt)}` : 'Confirmed'
+	}
+	if (p.status === 'claimed') {
+		return p.claimedAt ? `Marked paid ${formatDate(p.claimedAt)}` : 'Marked paid'
+	}
+	if (p.status === 'refunded') {
+		return 'Refunded'
+	}
+	return 'Not yet paid'
+}
+
+function formatDate(d: Date): string {
+	return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
+}

--- a/src/components/picks/chain-ribbon.tsx
+++ b/src/components/picks/chain-ribbon.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+
+export type ChainSlotState =
+	| { kind: 'win'; teamShort: string; teamColour: string | null }
+	| { kind: 'loss'; teamShort: string; teamColour: string | null }
+	| { kind: 'draw'; teamShort: string; teamColour: string | null }
+	| { kind: 'current'; teamShort: string | null; teamColour: string | null }
+	| { kind: 'planned'; teamShort: string; teamColour: string | null }
+	| { kind: 'planned-locked'; teamShort: string; teamColour: string | null }
+	| { kind: 'empty' }
+	| { kind: 'tbc' }
+
+export interface ChainSlot {
+	roundId: string
+	roundNumber: number
+	state: ChainSlotState
+}
+
+interface ChainRibbonProps {
+	slots: ChainSlot[]
+	summary: { played: number; planned: number; availableTeams: number; totalTeams: number }
+}
+
+export function ChainRibbon({ slots, summary }: ChainRibbonProps) {
+	return (
+		<div className="rounded-xl border border-border bg-card px-3 py-2.5">
+			<div className="flex justify-between items-center mb-2">
+				<div>
+					<div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+						Your pick chain
+					</div>
+					<div className="text-xs text-muted-foreground">
+						{summary.played} played · {summary.planned} planned · {summary.availableTeams} of{' '}
+						{summary.totalTeams} teams available
+					</div>
+				</div>
+				<div className="flex gap-3 text-[10px] text-muted-foreground">
+					<Legend colour="bg-[var(--alive)]" label="Win" />
+					<Legend colour="bg-[var(--eliminated)]" label="Loss" />
+					<Legend colour="bg-[#7c3aed]" label="Planned" />
+				</div>
+			</div>
+			<div className="flex gap-1 overflow-x-auto py-1">
+				{slots.map((s) => (
+					<Slot key={s.roundId} slot={s} />
+				))}
+			</div>
+		</div>
+	)
+}
+
+function Legend({ colour, label }: { colour: string; label: string }) {
+	return (
+		<span className="flex items-center gap-1">
+			<span className={cn('h-2 w-2 rounded-full', colour)} />
+			{label}
+		</span>
+	)
+}
+
+function Slot({ slot }: { slot: ChainSlot }) {
+	const s = slot.state
+	const wrapperClass = cn(
+		'flex-none w-[54px] text-center px-1 py-1.5 rounded-md border bg-card',
+		s.kind === 'win' && 'bg-[var(--alive-bg)] border-[var(--alive)]',
+		s.kind === 'loss' && 'bg-[var(--eliminated-bg)] border-[var(--eliminated)]',
+		s.kind === 'draw' && 'bg-[var(--draw-bg)] border-[var(--draw)]',
+		s.kind === 'current' && 'border-2 border-[var(--alive)] shadow-[inset_0_0_0_1px_var(--alive)]',
+		s.kind === 'planned' && 'border-2 border-dashed border-[#7c3aed] bg-[#f5f3ff]',
+		s.kind === 'planned-locked' && 'border-2 border-[#7c3aed] bg-[#ede9fe]',
+		s.kind === 'empty' && 'border-dashed text-muted-foreground',
+		s.kind === 'tbc' && 'border-dashed opacity-55',
+	)
+	return (
+		<div className={wrapperClass}>
+			<div className="text-[9px] uppercase text-muted-foreground">GW{slot.roundNumber}</div>
+			{'teamShort' in s && s.teamShort ? (
+				<div
+					className="mx-auto mt-1 h-7 w-7 rounded-full text-white text-[9px] font-bold flex items-center justify-center"
+					style={{ backgroundColor: s.teamColour ?? '#888' }}
+				>
+					{s.teamShort}
+				</div>
+			) : (
+				<div className="mt-1 text-base opacity-50">?</div>
+			)}
+			{s.kind === 'planned-locked' && (
+				<div className="text-[7px] font-bold text-[#7c3aed] mt-0.5">AUTO</div>
+			)}
+		</div>
+	)
+}

--- a/src/components/picks/classic-pick.tsx
+++ b/src/components/picks/classic-pick.tsx
@@ -2,9 +2,12 @@
 
 import { ChevronDown, ChevronUp } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { ChainRibbon, type ChainSlot } from '@/components/picks/chain-ribbon'
+import { PlannerRound } from '@/components/picks/planner-round'
 import { TeamBadge } from '@/components/picks/team-badge'
 import { formatDeadline } from '@/lib/format'
+import type { ChainSummary, PlannerRoundInput } from '@/lib/game/classic-planner-view'
 import { FixtureRow, type FixtureTeamInfo } from './fixture-row'
 import { PickConfirmBar } from './pick-confirm-bar'
 
@@ -15,6 +18,12 @@ export interface ClassicPickFixture {
 	kickoff: string | null
 }
 
+export interface ClassicPickPlanHandlers {
+	onPlan: (roundId: string, teamId: string, autoSubmit: boolean) => Promise<void>
+	onRemove: (roundId: string) => Promise<void>
+	onToggleAuto: (roundId: string, autoSubmit: boolean) => Promise<void>
+}
+
 interface ClassicPickProps {
 	gameId: string
 	roundId: string
@@ -23,6 +32,9 @@ interface ClassicPickProps {
 	fixtures: ClassicPickFixture[]
 	usedTeamsByRound: Record<string, string>
 	existingPickTeamId: string | null
+	chain?: { slots: ChainSlot[]; summary: ChainSummary }
+	futureRounds?: PlannerRoundInput[]
+	planHandlers?: ClassicPickPlanHandlers
 }
 
 export function ClassicPick({
@@ -33,6 +45,9 @@ export function ClassicPick({
 	fixtures,
 	usedTeamsByRound,
 	existingPickTeamId,
+	chain,
+	futureRounds,
+	planHandlers,
 }: ClassicPickProps) {
 	const router = useRouter()
 	const [selectedTeamId, setSelectedTeamId] = useState<string | null>(existingPickTeamId)
@@ -91,9 +106,8 @@ export function ClassicPick({
 		: null
 	const lockedSide = lockedFixture && lockedFixture.home.id === existingPickTeamId ? 'H' : 'A'
 
-	// Collapsed mode: show a summary with toggle to expand
-	if (!expanded && existingPickTeamId && lockedTeam && lockedOpponent) {
-		return (
+	const currentRoundCard =
+		!expanded && existingPickTeamId && lockedTeam && lockedOpponent ? (
 			<div className="rounded-lg border border-[var(--alive)]/40 bg-[var(--alive-bg)] p-4">
 				<div className="flex items-center justify-between flex-wrap gap-3">
 					<div className="flex items-center gap-3">
@@ -126,73 +140,223 @@ export function ClassicPick({
 					</div>
 				</div>
 			</div>
+		) : (
+			<div className="space-y-2">
+				<div className="flex justify-between items-baseline mb-3">
+					<h2 className="font-display text-xl font-semibold">{roundName}</h2>
+					<div className="flex items-center gap-2">
+						{deadline && (
+							<span className="text-xs font-medium text-[var(--draw)] bg-[var(--draw-bg)] px-2 py-0.5 rounded-md">
+								⏱ {formatDeadline(deadline)}
+							</span>
+						)}
+						{existingPickTeamId && (
+							<button
+								type="button"
+								onClick={() => setExpanded(false)}
+								className="text-xs font-medium px-2 py-1 rounded-md border border-border hover:bg-muted flex items-center gap-1"
+							>
+								Collapse <ChevronUp className="h-3 w-3" />
+							</button>
+						)}
+					</div>
+				</div>
+
+				{fixtures.map((fixture) => {
+					const homeUsed = usedTeamsByRound[fixture.home.id]
+					const awayUsed = usedTeamsByRound[fixture.away.id]
+					let usedSide: 'home' | 'away' | 'both' | null = null
+					if (homeUsed && awayUsed) usedSide = 'both'
+					else if (homeUsed) usedSide = 'home'
+					else if (awayUsed) usedSide = 'away'
+
+					const selected =
+						fixture.home.id === selectedTeamId
+							? 'home'
+							: fixture.away.id === selectedTeamId
+								? 'away'
+								: null
+
+					return (
+						<FixtureRow
+							key={fixture.id}
+							home={fixture.home}
+							away={fixture.away}
+							kickoff={fixture.kickoff ?? undefined}
+							selectedSide={selected}
+							usedSide={usedSide}
+							usedLabel={usedSide === 'both' ? `Both used` : undefined}
+							onPickHome={() => handlePick(fixture, 'home')}
+							onPickAway={() => handlePick(fixture, 'away')}
+						/>
+					)
+				})}
+
+				{error && <p className="text-sm text-[var(--eliminated)] px-2">{error}</p>}
+
+				{selectedTeam && selectedFixture && (
+					<PickConfirmBar
+						message={`Picking ${selectedTeam.name} vs ${
+							selectedSide === 'home' ? selectedFixture.away.name : selectedFixture.home.name
+						} (${selectedSide === 'home' ? 'H' : 'A'})`}
+						actionLabel={existingPickTeamId === selectedTeamId ? 'Already locked' : 'Lock in pick'}
+						onConfirm={handleSubmit}
+						disabled={existingPickTeamId === selectedTeamId}
+						loading={loading}
+					/>
+				)}
+			</div>
 		)
+
+	// Default handlers perform the standard REST calls against the planned-picks
+	// endpoints. Callers can override via `planHandlers` for tests/storybook.
+	const resolvedHandlers: ClassicPickPlanHandlers = planHandlers ?? {
+		onPlan: async (rid, tid, auto) => {
+			const res = await fetch(`/api/games/${gameId}/planned-picks`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ roundId: rid, teamId: tid, autoSubmit: auto }),
+			})
+			if (!res.ok) {
+				const body = await res.json().catch(() => ({ error: 'Failed to save plan' }))
+				throw new Error(body.error ?? 'Failed to save plan')
+			}
+			router.refresh()
+		},
+		onRemove: async (rid) => {
+			const res = await fetch(`/api/games/${gameId}/planned-picks/${rid}`, { method: 'DELETE' })
+			if (!res.ok) {
+				const body = await res.json().catch(() => ({ error: 'Failed to clear plan' }))
+				throw new Error(body.error ?? 'Failed to clear plan')
+			}
+			router.refresh()
+		},
+		onToggleAuto: async (rid, auto) => {
+			// To toggle auto-submit we re-post the existing plan (upsert) with the new flag.
+			// The server-side POST handler does a delete+insert so this is idempotent.
+			const existing = futureRounds?.find((r) => r.roundId === rid)
+			if (!existing?.plannedTeamId) return
+			const res = await fetch(`/api/games/${gameId}/planned-picks`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					roundId: rid,
+					teamId: existing.plannedTeamId,
+					autoSubmit: auto,
+				}),
+			})
+			if (!res.ok) {
+				const body = await res.json().catch(() => ({ error: 'Failed to toggle auto-submit' }))
+				throw new Error(body.error ?? 'Failed to toggle auto-submit')
+			}
+			router.refresh()
+		},
 	}
 
 	return (
-		<div className="space-y-2">
-			<div className="flex justify-between items-baseline mb-3">
-				<h2 className="font-display text-xl font-semibold">{roundName}</h2>
-				<div className="flex items-center gap-2">
-					{deadline && (
-						<span className="text-xs font-medium text-[var(--draw)] bg-[var(--draw-bg)] px-2 py-0.5 rounded-md">
-							⏱ {formatDeadline(deadline)}
-						</span>
-					)}
-					{existingPickTeamId && (
-						<button
-							type="button"
-							onClick={() => setExpanded(false)}
-							className="text-xs font-medium px-2 py-1 rounded-md border border-border hover:bg-muted flex items-center gap-1"
-						>
-							Collapse <ChevronUp className="h-3 w-3" />
-						</button>
-					)}
+		<div className="space-y-4">
+			{chain && <ChainRibbon slots={chain.slots} summary={chain.summary} />}
+			<div>{currentRoundCard}</div>
+			{futureRounds && futureRounds.length > 0 && (
+				<PlannerSection gameId={gameId} rounds={futureRounds} handlers={resolvedHandlers} />
+			)}
+		</div>
+	)
+}
+
+/**
+ * Collapsible wrapper around the planner rounds. Open/closed state is
+ * persisted in localStorage, scoped by gameId so each game remembers its
+ * own preference.
+ */
+function PlannerSection({
+	gameId,
+	rounds,
+	handlers,
+}: {
+	gameId: string
+	rounds: PlannerRoundInput[]
+	handlers: ClassicPickPlanHandlers
+}) {
+	const storageKey = `lps.planner-open.${gameId}`
+	// Default closed — the planner is an optional power-user feature.
+	const [open, setOpen] = useState(false)
+	const [error, setError] = useState<string | null>(null)
+
+	// Hydrate the open/closed preference from localStorage after mount to avoid
+	// SSR/client markup mismatches.
+	useEffect(() => {
+		try {
+			const saved = window.localStorage.getItem(storageKey)
+			if (saved === 'open') setOpen(true)
+		} catch {
+			// ignore — localStorage access can throw in some browsers
+		}
+	}, [storageKey])
+
+	function toggle() {
+		const next = !open
+		setOpen(next)
+		try {
+			window.localStorage.setItem(storageKey, next ? 'open' : 'closed')
+		} catch {
+			// ignore
+		}
+	}
+
+	async function guard<T>(fn: () => Promise<T>): Promise<void> {
+		setError(null)
+		try {
+			await fn()
+		} catch (e) {
+			setError(e instanceof Error ? e.message : 'Something went wrong')
+		}
+	}
+
+	const plannedCount = rounds.filter((r) => r.plannedTeamId).length
+
+	return (
+		<div className="rounded-xl border border-border bg-card">
+			<button
+				type="button"
+				onClick={toggle}
+				aria-expanded={open}
+				className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-muted/40 rounded-xl"
+			>
+				<div>
+					<div className="font-semibold text-sm">Plan ahead</div>
+					<div className="text-xs text-muted-foreground">
+						{rounds.length} upcoming {rounds.length === 1 ? 'gameweek' : 'gameweeks'} ·{' '}
+						{plannedCount} planned
+					</div>
 				</div>
-			</div>
-
-			{fixtures.map((fixture) => {
-				const homeUsed = usedTeamsByRound[fixture.home.id]
-				const awayUsed = usedTeamsByRound[fixture.away.id]
-				let usedSide: 'home' | 'away' | 'both' | null = null
-				if (homeUsed && awayUsed) usedSide = 'both'
-				else if (homeUsed) usedSide = 'home'
-				else if (awayUsed) usedSide = 'away'
-
-				const selected =
-					fixture.home.id === selectedTeamId
-						? 'home'
-						: fixture.away.id === selectedTeamId
-							? 'away'
-							: null
-
-				return (
-					<FixtureRow
-						key={fixture.id}
-						home={fixture.home}
-						away={fixture.away}
-						kickoff={fixture.kickoff ?? undefined}
-						selectedSide={selected}
-						usedSide={usedSide}
-						usedLabel={usedSide === 'both' ? `Both used` : undefined}
-						onPickHome={() => handlePick(fixture, 'home')}
-						onPickAway={() => handlePick(fixture, 'away')}
-					/>
-				)
-			})}
-
-			{error && <p className="text-sm text-[var(--eliminated)] px-2">{error}</p>}
-
-			{selectedTeam && selectedFixture && (
-				<PickConfirmBar
-					message={`Picking ${selectedTeam.name} vs ${
-						selectedSide === 'home' ? selectedFixture.away.name : selectedFixture.home.name
-					} (${selectedSide === 'home' ? 'H' : 'A'})`}
-					actionLabel={existingPickTeamId === selectedTeamId ? 'Already locked' : 'Lock in pick'}
-					onConfirm={handleSubmit}
-					disabled={existingPickTeamId === selectedTeamId}
-					loading={loading}
-				/>
+				{open ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+			</button>
+			{open && (
+				<div className="border-t border-border p-3 space-y-3">
+					{error && (
+						<p className="text-sm text-[var(--eliminated)] px-1" role="alert">
+							{error}
+						</p>
+					)}
+					{rounds.map((r) => (
+						<PlannerRound
+							key={r.roundId}
+							roundId={r.roundId}
+							roundNumber={r.roundNumber}
+							roundName={r.roundName}
+							deadline={r.deadline}
+							fixturesTbc={r.fixturesTbc}
+							fixtures={r.fixtures}
+							usedTeams={r.usedTeams}
+							plannedTeamId={r.plannedTeamId}
+							plannedAutoSubmit={r.plannedAutoSubmit}
+							onPlan={(rid, tid, auto) => guard(() => handlers.onPlan(rid, tid, auto))}
+							onRemove={(rid) => guard(() => handlers.onRemove(rid))}
+							onToggleAuto={(rid, auto) => guard(() => handlers.onToggleAuto(rid, auto))}
+						/>
+					))}
+				</div>
 			)}
 		</div>
 	)

--- a/src/components/picks/cup-pick-form.tsx
+++ b/src/components/picks/cup-pick-form.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { CupPick, type CupPickFixture, type CupPickSlot } from './cup-pick'
+
+interface CupPickFormProps {
+	gameId: string
+	roundId: string
+	fixtures: CupPickFixture[]
+	numberOfPicks: number
+	livesRemaining: number
+	maxLives: number
+	initialSlots: CupPickSlot[]
+	deadline: Date | null
+	readonly?: boolean
+}
+
+export function CupPickForm({
+	gameId,
+	roundId,
+	fixtures,
+	numberOfPicks,
+	livesRemaining,
+	maxLives,
+	initialSlots,
+	deadline,
+	readonly,
+}: CupPickFormProps) {
+	const router = useRouter()
+
+	async function handleSubmit(slots: CupPickSlot[]) {
+		const res = await fetch(`/api/picks/${gameId}/${roundId}`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				picks: slots.map((s) => ({
+					fixtureId: s.fixtureId,
+					confidenceRank: s.confidenceRank,
+					predictedResult: s.pickedSide === 'home' ? 'home_win' : 'away_win',
+				})),
+			}),
+		})
+		if (!res.ok) {
+			const body = await res.json().catch(() => ({ error: 'Failed to submit picks' }))
+			// CupPick shows the thrown message in its error state. Task 8 will extend the
+			// pick API to surface a typed cup error and this can become richer.
+			throw new Error(body.error ?? 'Failed to submit picks')
+		}
+		router.refresh()
+	}
+
+	return (
+		<CupPick
+			fixtures={fixtures}
+			numberOfPicks={numberOfPicks}
+			livesRemaining={livesRemaining}
+			maxLives={maxLives}
+			initialSlots={initialSlots}
+			onSubmit={handleSubmit}
+			deadline={deadline}
+			readonly={readonly}
+		/>
+	)
+}

--- a/src/components/picks/cup-pick.tsx
+++ b/src/components/picks/cup-pick.tsx
@@ -1,0 +1,448 @@
+'use client'
+
+import { ChevronDown, ChevronUp, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { cn } from '@/lib/utils'
+import { FixtureRow, type SideState } from './fixture-row'
+import { HeartIcon } from './heart-icon'
+import { LivesSummary } from './lives-summary'
+import { PlusNBadge } from './plus-n-badge'
+import { TeamBadge } from './team-badge'
+import { TierPips } from './tier-pips'
+
+export interface CupPickFixture {
+	id: string
+	homeTeamId: string
+	awayTeamId: string
+	homeShort: string
+	homeName: string
+	homeColor: string | null
+	homeBadgeUrl: string | null
+	awayShort: string
+	awayName: string
+	awayColor: string | null
+	awayBadgeUrl: string | null
+	kickoff: Date | null
+	/** From home perspective: positive = home is higher tier, negative = away is higher tier. */
+	tierDifference: number
+}
+
+export interface CupPickSlot {
+	confidenceRank: number
+	fixtureId: string
+	pickedSide: 'home' | 'away'
+}
+
+interface CupPickProps {
+	fixtures: CupPickFixture[]
+	/** 6 for WC, up to 10 for domestic cup. */
+	numberOfPicks: number
+	livesRemaining: number
+	maxLives: number
+	initialSlots: CupPickSlot[]
+	onSubmit: (slots: CupPickSlot[]) => Promise<void>
+	deadline?: Date | null
+	readonly?: boolean
+}
+
+function tierForDisplay(fixture: CupPickFixture): { value: number; plusN: number; heart: boolean } {
+	const abs = Math.abs(fixture.tierDifference)
+	return { value: abs, plusN: abs, heart: abs >= 2 }
+}
+
+function sideRestricted(
+	fixture: CupPickFixture,
+	side: 'home' | 'away',
+): { kind: 'restricted'; reason: string } | undefined {
+	// Cup rule: can't pick a side more than 1 tier higher than the opponent.
+	const tierFromPicked = side === 'home' ? fixture.tierDifference : -fixture.tierDifference
+	if (tierFromPicked > 1) {
+		return {
+			kind: 'restricted',
+			reason: `Restricted — opponent is ${tierFromPicked} tiers lower`,
+		}
+	}
+	return undefined
+}
+
+/** Sum of abs(tierDifference) for slots where the picked side is the underdog. */
+function computeProjectedGain(slots: CupPickSlot[], fixtures: CupPickFixture[]): number {
+	let total = 0
+	for (const slot of slots) {
+		const f = fixtures.find((x) => x.id === slot.fixtureId)
+		if (!f) continue
+		const abs = Math.abs(f.tierDifference)
+		if (abs === 0) continue
+		// Underdog is away when home is higher (tierDifference > 0), home when away is higher.
+		const underdogSide: 'home' | 'away' = f.tierDifference > 0 ? 'away' : 'home'
+		if (slot.pickedSide === underdogSide) {
+			total += abs
+		}
+	}
+	return total
+}
+
+function formatKickoff(kickoff: Date | null): string | undefined {
+	if (!kickoff) return undefined
+	try {
+		return kickoff.toLocaleString(undefined, {
+			weekday: 'short',
+			day: 'numeric',
+			month: 'short',
+			hour: '2-digit',
+			minute: '2-digit',
+		})
+	} catch {
+		return undefined
+	}
+}
+
+function formatDeadlineLabel(deadline: Date | null | undefined): string {
+	if (!deadline) return 'Deadline not set'
+	try {
+		return `Deadline ${deadline.toLocaleString(undefined, {
+			weekday: 'short',
+			day: 'numeric',
+			month: 'short',
+			hour: '2-digit',
+			minute: '2-digit',
+		})}`
+	} catch {
+		return 'Deadline not set'
+	}
+}
+
+export function CupPick({
+	fixtures,
+	numberOfPicks,
+	livesRemaining,
+	maxLives,
+	initialSlots,
+	onSubmit,
+	deadline,
+	readonly,
+}: CupPickProps) {
+	// Normalise initial slots into rank order (1..N) — defensive against callers passing gaps.
+	const normalisedInitial = useMemo<CupPickSlot[]>(
+		() =>
+			initialSlots
+				.slice()
+				.sort((a, b) => a.confidenceRank - b.confidenceRank)
+				.map((slot, i) => ({ ...slot, confidenceRank: i + 1 })),
+		[initialSlots],
+	)
+
+	const [slots, setSlots] = useState<CupPickSlot[]>(normalisedInitial)
+	const [loading, setLoading] = useState(false)
+	const [error, setError] = useState<string | null>(null)
+
+	// Min picks to submit — default 60% of N, rounded up. Tunable later.
+	const minPicks = Math.ceil(numberOfPicks * 0.6)
+
+	function handlePickTeam(fixtureId: string, side: 'home' | 'away') {
+		if (readonly) return
+		const existing = slots.find((s) => s.fixtureId === fixtureId)
+		if (existing) {
+			// Fixture can only appear once — ignore. (Removal happens from the ranked column.)
+			return
+		}
+		if (slots.length >= numberOfPicks) return
+		setSlots([
+			...slots,
+			{
+				confidenceRank: slots.length + 1,
+				fixtureId,
+				pickedSide: side,
+			},
+		])
+	}
+
+	function handleRemoveSlot(confidenceRank: number) {
+		if (readonly) return
+		setSlots(
+			slots
+				.filter((s) => s.confidenceRank !== confidenceRank)
+				.sort((a, b) => a.confidenceRank - b.confidenceRank)
+				.map((s, i) => ({ ...s, confidenceRank: i + 1 })),
+		)
+	}
+
+	function handleReorder(fromRank: number, toRank: number) {
+		if (readonly) return
+		if (fromRank === toRank) return
+		const from = slots.find((s) => s.confidenceRank === fromRank)
+		const to = slots.find((s) => s.confidenceRank === toRank)
+		if (!from || !to) return
+		setSlots(
+			slots
+				.map((s) => {
+					if (s.confidenceRank === fromRank) return { ...s, confidenceRank: toRank }
+					if (s.confidenceRank === toRank) return { ...s, confidenceRank: fromRank }
+					return s
+				})
+				.sort((a, b) => a.confidenceRank - b.confidenceRank),
+		)
+	}
+
+	async function handleSubmit() {
+		if (readonly) return
+		if (slots.length < minPicks) return
+		setLoading(true)
+		setError(null)
+		try {
+			await onSubmit(slots)
+		} catch (e) {
+			// Task 8 updates the pick API to surface a typed cup error; for now just show message.
+			const message = e instanceof Error ? e.message : 'Failed to submit picks'
+			setError(message)
+		} finally {
+			setLoading(false)
+		}
+	}
+
+	const projectedGain = computeProjectedGain(slots, fixtures)
+	const deadlineLabel = formatDeadlineLabel(deadline ?? null)
+
+	return (
+		<div className="space-y-3">
+			<LivesSummary
+				livesRemaining={livesRemaining}
+				maxLives={maxLives}
+				projectedGain={projectedGain}
+			/>
+			<div className="rounded-lg bg-foreground text-background px-3 py-2 text-xs">
+				{deadlineLabel} · rank {numberOfPicks} picks
+			</div>
+			<div className="grid gap-3 md:grid-cols-[1fr_320px]">
+				<div>
+					<div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+						Available fixtures
+					</div>
+					<div className="space-y-3">
+						{fixtures.map((f) => {
+							const tier = tierForDisplay(f)
+							const slot = slots.find((s) => s.fixtureId === f.id)
+
+							const homeState: SideState | undefined =
+								slot?.pickedSide === 'home' ? { kind: 'current' } : sideRestricted(f, 'home')
+							const awayState: SideState | undefined =
+								slot?.pickedSide === 'away' ? { kind: 'current' } : sideRestricted(f, 'away')
+
+							return (
+								<FixtureRow
+									key={f.id}
+									home={{
+										id: f.homeTeamId,
+										name: f.homeName,
+										shortName: f.homeShort,
+										badgeUrl: f.homeBadgeUrl,
+									}}
+									away={{
+										id: f.awayTeamId,
+										name: f.awayName,
+										shortName: f.awayShort,
+										badgeUrl: f.awayBadgeUrl,
+									}}
+									kickoff={formatKickoff(f.kickoff)}
+									selectedSide={slot?.pickedSide ?? null}
+									tierValue={tier.value}
+									tierMax={3}
+									plusN={tier.plusN}
+									showHeart={tier.heart}
+									homeState={homeState}
+									awayState={awayState}
+									onPickHome={() => handlePickTeam(f.id, 'home')}
+									onPickAway={() => handlePickTeam(f.id, 'away')}
+								/>
+							)
+						})}
+					</div>
+				</div>
+				<div>
+					<div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+						Your picks, ranked
+					</div>
+					<div className="space-y-1.5">
+						{Array.from({ length: numberOfPicks }, (_, i) => i + 1).map((rank) => {
+							const slot = slots.find((s) => s.confidenceRank === rank)
+							if (!slot) return <EmptySlot key={rank} rank={rank} />
+							return (
+								<CupRankedRow
+									key={rank}
+									slot={slot}
+									fixtures={fixtures}
+									isFirst={rank === 1}
+									isLast={rank === slots.length}
+									onMoveUp={() => handleReorder(rank, rank - 1)}
+									onMoveDown={() => handleReorder(rank, rank + 1)}
+									onRemove={() => handleRemoveSlot(rank)}
+								/>
+							)
+						})}
+					</div>
+					<button
+						type="button"
+						className={cn(
+							'mt-3 w-full rounded bg-foreground text-background py-3 font-semibold',
+							'disabled:opacity-50 disabled:cursor-not-allowed',
+						)}
+						disabled={readonly || slots.length < minPicks || loading}
+						onClick={handleSubmit}
+					>
+						{loading ? 'Submitting...' : `Submit ${slots.length} of ${numberOfPicks} picks`}
+					</button>
+					{slots.length > 0 && slots.length < minPicks && (
+						<p className="mt-2 text-xs text-muted-foreground">
+							Rank at least {minPicks} picks before submitting.
+						</p>
+					)}
+					{error && (
+						<p className="mt-2 text-xs text-[var(--eliminated)]" role="alert">
+							{error}
+						</p>
+					)}
+				</div>
+			</div>
+		</div>
+	)
+}
+
+interface EmptySlotProps {
+	rank: number
+}
+
+function EmptySlot({ rank }: EmptySlotProps) {
+	return (
+		<div
+			className={cn(
+				'flex items-center gap-3 rounded-lg border border-dashed border-border bg-card/40 px-3 py-2.5',
+				'text-xs text-muted-foreground',
+			)}
+		>
+			<div
+				className={cn(
+					'w-8 h-8 rounded-md flex items-center justify-center text-sm font-bold shrink-0',
+					'bg-muted text-muted-foreground',
+				)}
+			>
+				{rank}
+			</div>
+			<span>Pick a fixture to fill slot #{rank}</span>
+		</div>
+	)
+}
+
+interface CupRankedRowProps {
+	slot: CupPickSlot
+	fixtures: CupPickFixture[]
+	isFirst: boolean
+	isLast: boolean
+	onMoveUp: () => void
+	onMoveDown: () => void
+	onRemove: () => void
+}
+
+function CupRankedRow({
+	slot,
+	fixtures,
+	isFirst,
+	isLast,
+	onMoveUp,
+	onMoveDown,
+	onRemove,
+}: CupRankedRowProps) {
+	const fixture = fixtures.find((f) => f.id === slot.fixtureId)
+	if (!fixture) {
+		return (
+			<div className="flex items-center gap-3 rounded-lg border border-border bg-card px-3 py-2.5 text-xs text-muted-foreground">
+				<div className="w-8 h-8 rounded-md flex items-center justify-center text-sm font-bold text-background bg-foreground shrink-0">
+					{slot.confidenceRank}
+				</div>
+				<span>Fixture unavailable</span>
+				<button
+					type="button"
+					onClick={onRemove}
+					className="ml-auto text-muted-foreground hover:text-[var(--eliminated)] p-1"
+					aria-label="Remove"
+				>
+					<X className="h-4 w-4" />
+				</button>
+			</div>
+		)
+	}
+
+	const pickedTeam =
+		slot.pickedSide === 'home'
+			? { short: fixture.homeShort, name: fixture.homeName, badge: fixture.homeBadgeUrl }
+			: { short: fixture.awayShort, name: fixture.awayName, badge: fixture.awayBadgeUrl }
+	const opponent =
+		slot.pickedSide === 'home'
+			? { short: fixture.awayShort, name: fixture.awayName }
+			: { short: fixture.homeShort, name: fixture.homeName }
+
+	const abs = Math.abs(fixture.tierDifference)
+	// Underdog if the picked side is the lower tier.
+	const underdogSide: 'home' | 'away' | null =
+		fixture.tierDifference === 0 ? null : fixture.tierDifference > 0 ? 'away' : 'home'
+	const isUnderdog = underdogSide != null && slot.pickedSide === underdogSide
+	const outcomeHint = isUnderdog
+		? `Win → +${abs} ${abs === 1 ? 'life' : 'lives'}`
+		: abs > 0
+			? 'Win → no life gained'
+			: 'Win → no life gained'
+
+	return (
+		<div className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2.5">
+			<div
+				className={cn(
+					'w-8 h-8 rounded-md flex items-center justify-center text-sm font-bold text-background shrink-0',
+					slot.confidenceRank <= 3 ? 'bg-[var(--alive)]' : 'bg-foreground',
+				)}
+			>
+				{slot.confidenceRank}
+			</div>
+			<div className="flex items-center gap-2 min-w-0 flex-1">
+				<TeamBadge shortName={pickedTeam.short} badgeUrl={pickedTeam.badge} size="md" />
+				<div className="min-w-0 flex-1">
+					<div className="text-sm font-semibold truncate">
+						{pickedTeam.name} to beat {opponent.name}
+					</div>
+					<div className="mt-1 flex items-center gap-1.5 text-[11px] text-muted-foreground">
+						{isUnderdog && <HeartIcon size={12} />}
+						{abs > 0 && <TierPips value={abs as 0 | 1 | 2 | 3 | 4 | 5} max={3} />}
+						{abs > 0 && <PlusNBadge value={abs} />}
+						<span className="ml-auto truncate">{outcomeHint}</span>
+					</div>
+				</div>
+			</div>
+			<div className="flex flex-col gap-0.5 shrink-0">
+				<button
+					type="button"
+					onClick={onMoveUp}
+					disabled={isFirst}
+					className="border border-border rounded p-1 disabled:opacity-30 hover:bg-muted"
+					aria-label="Move up"
+				>
+					<ChevronUp className="h-3.5 w-3.5" />
+				</button>
+				<button
+					type="button"
+					onClick={onMoveDown}
+					disabled={isLast}
+					className="border border-border rounded p-1 disabled:opacity-30 hover:bg-muted"
+					aria-label="Move down"
+				>
+					<ChevronDown className="h-3.5 w-3.5" />
+				</button>
+			</div>
+			<button
+				type="button"
+				onClick={onRemove}
+				className="text-muted-foreground hover:text-[var(--eliminated)] p-1 shrink-0"
+				aria-label="Remove"
+			>
+				<X className="h-4 w-4" />
+			</button>
+		</div>
+	)
+}

--- a/src/components/picks/fixture-row.tsx
+++ b/src/components/picks/fixture-row.tsx
@@ -1,8 +1,12 @@
 'use client'
 
+import type React from 'react'
 import { cn } from '@/lib/utils'
 import { FormDots, type FormResult } from './form-dots'
+import { HeartIcon } from './heart-icon'
+import { PlusNBadge } from './plus-n-badge'
 import { TeamBadge } from './team-badge'
+import { TierPips } from './tier-pips'
 
 export interface FixtureTeamInfo {
 	id: string
@@ -12,6 +16,14 @@ export interface FixtureTeamInfo {
 	form?: FormResult[]
 	leaguePosition?: number | null
 }
+
+export type SideState =
+	| { kind: 'current' }
+	| { kind: 'tentative' }
+	| { kind: 'auto-locked' }
+	| { kind: 'restricted'; reason?: string }
+	| { kind: 'used'; label: string }
+	| { kind: 'planned-elsewhere'; label: string }
 
 export interface FixtureRowProps {
 	home: FixtureTeamInfo
@@ -24,6 +36,14 @@ export interface FixtureRowProps {
 	onPickAway?: () => void
 	disabledSide?: 'home' | 'away' | 'both' | null
 	disabledReason?: string
+	// Tier strip (per-fixture annotations)
+	tierValue?: number
+	tierMax?: 3 | 5
+	plusN?: number
+	showHeart?: boolean
+	// Per-side state
+	homeState?: SideState
+	awayState?: SideState
 }
 
 export function FixtureRow({
@@ -37,49 +57,69 @@ export function FixtureRow({
 	onPickAway,
 	disabledSide,
 	disabledReason,
+	tierValue,
+	tierMax,
+	plusN,
+	showHeart,
+	homeState,
+	awayState,
 }: FixtureRowProps) {
 	const isFullyUsed = usedSide === 'both'
+	const showTierStrip = tierValue != null || plusN != null || showHeart
 
 	return (
-		<div
-			className={cn(
-				'rounded-lg border border-border bg-card flex items-stretch transition-all overflow-hidden',
-				isFullyUsed && 'opacity-30 pointer-events-none',
+		<div className={cn(isFullyUsed && 'opacity-30 pointer-events-none')}>
+			{showTierStrip && (
+				<div className="flex items-center gap-2 mb-2 text-[11px] text-muted-foreground">
+					{showHeart && <HeartIcon size={13} />}
+					{tierValue != null && (
+						<TierPips value={tierValue as 0 | 1 | 2 | 3 | 4 | 5} max={tierMax} />
+					)}
+					{plusN != null && <PlusNBadge value={plusN} />}
+					{kickoff && <span className="ml-auto">{kickoff}</span>}
+				</div>
 			)}
-		>
-			<TeamPickButton
-				team={home}
-				side="home"
-				selected={selectedSide === 'home'}
-				used={usedSide === 'home'}
-				disabled={disabledSide === 'home' || disabledSide === 'both'}
-				disabledReason={disabledReason}
-				onClick={onPickHome}
-			/>
-			<div className="flex flex-col items-center justify-center px-3 shrink-0 min-w-[64px] bg-muted/30 border-l border-r border-border">
-				<span className="text-xs text-muted-foreground font-semibold uppercase tracking-wide">
-					vs
-				</span>
-				{kickoff && (
-					<span className="text-[0.7rem] text-muted-foreground mt-1 text-center leading-tight">
-						{kickoff}
+			<div
+				className={cn(
+					'rounded-lg border border-border bg-card flex items-stretch transition-all overflow-hidden',
+				)}
+			>
+				<TeamPickButton
+					team={home}
+					side="home"
+					selected={selectedSide === 'home'}
+					used={usedSide === 'home'}
+					disabled={disabledSide === 'home' || disabledSide === 'both'}
+					disabledReason={disabledReason}
+					state={homeState}
+					onClick={onPickHome}
+				/>
+				<div className="flex flex-col items-center justify-center px-3 shrink-0 min-w-[64px] bg-muted/30 border-l border-r border-border">
+					<span className="text-xs text-muted-foreground font-semibold uppercase tracking-wide">
+						vs
+					</span>
+					{kickoff && !showTierStrip && (
+						<span className="text-[0.7rem] text-muted-foreground mt-1 text-center leading-tight">
+							{kickoff}
+						</span>
+					)}
+				</div>
+				<TeamPickButton
+					team={away}
+					side="away"
+					selected={selectedSide === 'away'}
+					used={usedSide === 'away'}
+					disabled={disabledSide === 'away' || disabledSide === 'both'}
+					disabledReason={disabledReason}
+					state={awayState}
+					onClick={onPickAway}
+				/>
+				{usedLabel && (
+					<span className="text-[0.7rem] text-muted-foreground px-2 self-center shrink-0">
+						{usedLabel}
 					</span>
 				)}
 			</div>
-			<TeamPickButton
-				team={away}
-				side="away"
-				selected={selectedSide === 'away'}
-				used={usedSide === 'away'}
-				disabled={disabledSide === 'away' || disabledSide === 'both'}
-				disabledReason={disabledReason}
-				onClick={onPickAway}
-			/>
-			{usedLabel && (
-				<span className="text-[0.7rem] text-muted-foreground px-2 self-center shrink-0">
-					{usedLabel}
-				</span>
-			)}
 		</div>
 	)
 }
@@ -91,12 +131,25 @@ interface TeamPickButtonProps {
 	used: boolean
 	disabled: boolean
 	disabledReason?: string
+	state?: SideState
 	onClick?: () => void
 }
 
-function TeamPickButton({ team, side, selected, used, disabled, onClick }: TeamPickButtonProps) {
-	const clickable = !!onClick && !disabled && !used
+function TeamPickButton({
+	team,
+	side,
+	selected,
+	used,
+	disabled,
+	state,
+	onClick,
+}: TeamPickButtonProps) {
+	const stateBlocksClick =
+		state?.kind === 'restricted' || state?.kind === 'used' || state?.kind === 'planned-elsewhere'
+	const clickable = !!onClick && !disabled && !used && !stateBlocksClick
 	const isHome = side === 'home'
+	const stateCls = sideClass(state)
+	const chip = sideChip(state)
 
 	/*
 	 * Layout goal: symmetric, badge nearest the centre "vs" divider.
@@ -115,6 +168,7 @@ function TeamPickButton({ team, side, selected, used, disabled, onClick }: TeamP
 				selected && 'bg-[var(--alive-bg)] ring-2 ring-[var(--alive)] ring-inset',
 				used && 'opacity-30 line-through',
 				disabled && !used && 'opacity-50 cursor-not-allowed',
+				stateCls,
 			)}
 		>
 			<TeamBadge shortName={team.shortName} badgeUrl={team.badgeUrl} size="lg" />
@@ -130,9 +184,62 @@ function TeamPickButton({ team, side, selected, used, disabled, onClick }: TeamP
 					)}
 					{team.form && team.form.length > 0 && <FormDots results={team.form} size="md" />}
 				</div>
+				{chip && <div className={cn('flex', isHome ? 'justify-end' : 'justify-start')}>{chip}</div>}
 			</div>
 		</button>
 	)
+}
+
+function sideClass(state?: SideState): string {
+	if (!state) return ''
+	switch (state.kind) {
+		case 'current':
+			return 'border-[var(--alive)] bg-[var(--alive-bg)]'
+		case 'tentative':
+			return 'border-2 border-dashed border-[#7c3aed] bg-[#f5f3ff]'
+		case 'auto-locked':
+			return 'border-2 border-[#7c3aed] bg-[#ede9fe]'
+		case 'restricted':
+			return 'opacity-40 cursor-not-allowed'
+		case 'used':
+		case 'planned-elsewhere':
+			return 'opacity-40 cursor-not-allowed line-through'
+	}
+}
+
+function sideChip(state?: SideState): React.ReactNode {
+	if (!state) return null
+	switch (state.kind) {
+		case 'current':
+			return (
+				<span className="text-[9px] bg-[var(--alive-bg)] text-[var(--alive)] px-1.5 py-0.5 rounded font-bold">
+					CURRENT
+				</span>
+			)
+		case 'tentative':
+			return (
+				<span className="text-[9px] bg-[#ddd6fe] text-[#5b21b6] px-1.5 py-0.5 rounded font-bold">
+					TENTATIVE
+				</span>
+			)
+		case 'auto-locked':
+			return (
+				<span className="text-[9px] bg-[#7c3aed] text-white px-1.5 py-0.5 rounded font-bold">
+					🔒 AUTO
+				</span>
+			)
+		case 'restricted':
+			return (
+				<span className="text-[9px] text-muted-foreground">{state.reason ?? 'Restricted'}</span>
+			)
+		case 'used':
+		case 'planned-elsewhere':
+			return (
+				<span className="text-[9px] bg-muted text-foreground/70 px-1.5 py-0.5 rounded font-bold">
+					{state.label}
+				</span>
+			)
+	}
 }
 
 function ordinal(n: number): string {

--- a/src/components/picks/heart-icon.tsx
+++ b/src/components/picks/heart-icon.tsx
@@ -1,0 +1,18 @@
+import { Heart } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface HeartIconProps {
+	className?: string
+	size?: number
+}
+
+export function HeartIcon({ className, size = 14 }: HeartIconProps) {
+	return (
+		<Heart
+			className={cn('fill-[#dc2626] text-[#dc2626] shrink-0', className)}
+			size={size}
+			aria-label="life-earning fixture"
+			role="img"
+		/>
+	)
+}

--- a/src/components/picks/lives-summary.tsx
+++ b/src/components/picks/lives-summary.tsx
@@ -1,0 +1,58 @@
+import { cn } from '@/lib/utils'
+
+interface LivesSummaryProps {
+	livesRemaining: number
+	maxLives: number
+	projectedGain: number
+	className?: string
+}
+
+export function LivesSummary({
+	livesRemaining,
+	maxLives,
+	projectedGain,
+	className,
+}: LivesSummaryProps) {
+	const total = livesRemaining + projectedGain
+	return (
+		<div
+			className={cn(
+				'flex items-center justify-between rounded-xl border border-border bg-card px-4 py-3',
+				className,
+			)}
+		>
+			<div>
+				<div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+					Lives
+				</div>
+				<div className="flex items-center gap-1 mt-1">
+					{Array.from({ length: maxLives }, (_, i) => (
+						<span
+							// biome-ignore lint/suspicious/noArrayIndexKey: stable index
+							key={i}
+							className={cn(
+								'inline-block h-3.5 w-3.5 rounded-full',
+								i < livesRemaining
+									? 'bg-[#dc2626]'
+									: 'bg-transparent ring-1 ring-inset ring-border',
+							)}
+						/>
+					))}
+					<span className="ml-2 text-xs text-muted-foreground">
+						{livesRemaining} of {maxLives}
+					</span>
+				</div>
+			</div>
+			{projectedGain > 0 && (
+				<div className="text-right">
+					<div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+						If all correct
+					</div>
+					<div className="text-sm font-bold text-[var(--alive)]">
+						+{projectedGain} → {total} lives
+					</div>
+				</div>
+			)}
+		</div>
+	)
+}

--- a/src/components/picks/planner-round.tsx
+++ b/src/components/picks/planner-round.tsx
@@ -1,0 +1,176 @@
+'use client'
+
+import { useState } from 'react'
+import { cn } from '@/lib/utils'
+import { FixtureRow } from './fixture-row'
+
+export interface PlannerFixture {
+	id: string
+	homeTeam: {
+		id: string
+		short: string
+		name: string
+		colour: string | null
+		badgeUrl: string | null
+	}
+	awayTeam: {
+		id: string
+		short: string
+		name: string
+		colour: string | null
+		badgeUrl: string | null
+	}
+	kickoff: Date | null
+}
+
+export interface UsedInfo {
+	teamId: string
+	label: string // e.g. "USED GW3" or "PLANNED GW27"
+	kind: 'used' | 'planned-elsewhere'
+}
+
+interface PlannerRoundProps {
+	roundId: string
+	roundNumber: number
+	roundName: string
+	deadline: Date | null
+	fixturesTbc: boolean
+	fixtures: PlannerFixture[]
+	usedTeams: UsedInfo[]
+	plannedTeamId: string | null
+	plannedAutoSubmit: boolean
+	onPlan: (roundId: string, teamId: string, autoSubmit: boolean) => Promise<void>
+	onRemove: (roundId: string) => Promise<void>
+	onToggleAuto: (roundId: string, autoSubmit: boolean) => Promise<void>
+}
+
+export function PlannerRound(props: PlannerRoundProps) {
+	const [pending, setPending] = useState(false)
+	if (props.fixturesTbc) {
+		return (
+			<div className="rounded-xl border border-border bg-muted/30 px-3 py-3 opacity-55">
+				<div className="flex justify-between items-center">
+					<div className="font-semibold text-sm">GW{props.roundNumber} · Fixtures TBC</div>
+					<span className="text-[11px] text-muted-foreground">
+						Planner unlocks when fixtures are published
+					</span>
+				</div>
+			</div>
+		)
+	}
+	return (
+		<div className="rounded-xl border border-border bg-card px-3 py-3">
+			<div className="flex justify-between items-center mb-2">
+				<div>
+					<div className="font-semibold text-sm">
+						GW{props.roundNumber} · {props.roundName}
+					</div>
+					{props.deadline && (
+						<div className="text-[11px] text-muted-foreground">
+							Deadline {formatDeadline(props.deadline)}
+						</div>
+					)}
+				</div>
+				<label
+					className={cn(
+						'flex items-center gap-2 text-[11px] text-muted-foreground cursor-pointer',
+						pending && 'opacity-50',
+					)}
+				>
+					<span>Auto-submit</span>
+					<input
+						type="checkbox"
+						className="sr-only peer"
+						checked={props.plannedAutoSubmit}
+						disabled={pending || !props.plannedTeamId}
+						onChange={async (e) => {
+							setPending(true)
+							try {
+								await props.onToggleAuto(props.roundId, e.target.checked)
+							} finally {
+								setPending(false)
+							}
+						}}
+					/>
+					<span className="relative w-7 h-4 bg-muted rounded-full peer-checked:bg-[#7c3aed]">
+						<span className="absolute top-[2px] left-[2px] w-3 h-3 bg-white rounded-full transition-all peer-checked:left-[14px]" />
+					</span>
+				</label>
+			</div>
+			{props.fixtures.map((f) => {
+				const homeUsed = props.usedTeams.find((u) => u.teamId === f.homeTeam.id)
+				const awayUsed = props.usedTeams.find((u) => u.teamId === f.awayTeam.id)
+				const homeIsPlan = f.homeTeam.id === props.plannedTeamId
+				const awayIsPlan = f.awayTeam.id === props.plannedTeamId
+				const planKind: 'auto-locked' | 'tentative' = props.plannedAutoSubmit
+					? 'auto-locked'
+					: 'tentative'
+				return (
+					<FixtureRow
+						key={f.id}
+						home={{
+							id: f.homeTeam.id,
+							shortName: f.homeTeam.short,
+							name: f.homeTeam.name,
+							badgeUrl: f.homeTeam.badgeUrl,
+						}}
+						away={{
+							id: f.awayTeam.id,
+							shortName: f.awayTeam.short,
+							name: f.awayTeam.name,
+							badgeUrl: f.awayTeam.badgeUrl,
+						}}
+						kickoff={f.kickoff ? formatKickoff(f.kickoff) : undefined}
+						homeState={
+							homeIsPlan
+								? { kind: planKind }
+								: homeUsed
+									? { kind: homeUsed.kind, label: homeUsed.label }
+									: undefined
+						}
+						awayState={
+							awayIsPlan
+								? { kind: planKind }
+								: awayUsed
+									? { kind: awayUsed.kind, label: awayUsed.label }
+									: undefined
+						}
+						onPickHome={
+							homeUsed
+								? undefined
+								: () => props.onPlan(props.roundId, f.homeTeam.id, props.plannedAutoSubmit)
+						}
+						onPickAway={
+							awayUsed
+								? undefined
+								: () => props.onPlan(props.roundId, f.awayTeam.id, props.plannedAutoSubmit)
+						}
+					/>
+				)
+			})}
+			{props.plannedTeamId && (
+				<button
+					type="button"
+					className="mt-2 text-[11px] text-muted-foreground underline"
+					onClick={() => props.onRemove(props.roundId)}
+				>
+					Clear plan
+				</button>
+			)}
+		</div>
+	)
+}
+
+function formatDeadline(d: Date): string {
+	return d.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' })
+}
+
+function formatKickoff(d: Date): string {
+	return d.toLocaleString('en-GB', {
+		weekday: 'short',
+		day: 'numeric',
+		month: 'short',
+		hour: '2-digit',
+		minute: '2-digit',
+	})
+}

--- a/src/components/picks/plus-n-badge.tsx
+++ b/src/components/picks/plus-n-badge.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@/lib/utils'
+
+interface PlusNBadgeProps {
+	value: number
+	className?: string
+}
+
+export function PlusNBadge({ value, className }: PlusNBadgeProps) {
+	const strong = value >= 2
+	return (
+		<span
+			className={cn(
+				'inline-flex items-center rounded px-1.5 py-[1px] text-[10px] font-bold leading-none',
+				strong ? 'bg-amber-100 text-amber-900' : 'bg-muted text-foreground/70',
+				className,
+			)}
+		>
+			+{value}
+		</span>
+	)
+}

--- a/src/components/picks/tier-pips.tsx
+++ b/src/components/picks/tier-pips.tsx
@@ -1,0 +1,28 @@
+import { cn } from '@/lib/utils'
+
+interface TierPipsProps {
+	value: 0 | 1 | 2 | 3 | 4 | 5
+	max?: 3 | 5
+	className?: string
+}
+
+export function TierPips({ value, max = 3, className }: TierPipsProps) {
+	return (
+		<span
+			className={cn('inline-flex items-center gap-[2px]', className)}
+			aria-label={`${value} of ${max} tier`}
+			role="img"
+		>
+			{Array.from({ length: max }, (_, i) => (
+				<span
+					// biome-ignore lint/suspicious/noArrayIndexKey: stable index
+					key={i}
+					className={cn(
+						'inline-block h-2 w-2 rounded-full',
+						i < value ? 'bg-foreground' : 'bg-transparent ring-1 ring-inset ring-border',
+					)}
+				/>
+			))}
+		</span>
+	)
+}

--- a/src/components/standings/cup-grid.tsx
+++ b/src/components/standings/cup-grid.tsx
@@ -1,0 +1,239 @@
+'use client'
+
+import type { CupStandingsData } from '@/lib/game/cup-standings-queries'
+import { cn } from '@/lib/utils'
+
+interface CupGridProps {
+	data: CupStandingsData
+}
+
+export function CupGrid({ data }: CupGridProps) {
+	const alive = data.players
+		.filter((p) => p.status !== 'eliminated')
+		.sort((a, b) => b.streak - a.streak || b.goals - a.goals)
+	const out = data.players
+		.filter((p) => p.status === 'eliminated')
+		.sort((a, b) => (a.eliminatedRoundNumber ?? 0) - (b.eliminatedRoundNumber ?? 0))
+
+	return (
+		<div className="rounded-xl border border-border bg-card overflow-hidden">
+			<div className="p-4 md:p-5 border-b border-border">
+				<h2 className="font-display text-2xl font-semibold">Cup Standings</h2>
+				<p className="text-sm text-muted-foreground mt-1">
+					GW{data.roundNumber} ·{' '}
+					{data.roundStatus === 'open'
+						? 'Picks hidden until deadline'
+						: data.roundStatus === 'active'
+							? 'Round in play'
+							: 'Round complete'}
+				</p>
+			</div>
+
+			<div className="overflow-x-auto p-4 md:p-5">
+				<HeaderRow numberOfPicks={data.numberOfPicks} />
+				{alive.map((player, idx) => (
+					<PlayerRow
+						key={player.id}
+						player={player}
+						numberOfPicks={data.numberOfPicks}
+						maxLives={data.maxLives}
+						position={idx + 1}
+					/>
+				))}
+				{out.length > 0 && (
+					<div className="mt-3 pt-3 border-t-2 border-dashed border-border">
+						<p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2 px-1">
+							Eliminated
+						</p>
+						{out.map((player, idx) => (
+							<PlayerRow
+								key={player.id}
+								player={player}
+								numberOfPicks={data.numberOfPicks}
+								maxLives={data.maxLives}
+								position={alive.length + idx + 1}
+								isOut
+							/>
+						))}
+					</div>
+				)}
+			</div>
+		</div>
+	)
+}
+
+function HeaderRow({ numberOfPicks }: { numberOfPicks: number }) {
+	return (
+		<div
+			className="grid grid-cols-[24px_140px_80px_48px_48px_repeat(var(--picks),62px)] gap-1.5 px-1 py-1.5 items-center text-[10px] font-semibold uppercase tracking-wider text-muted-foreground"
+			style={{ ['--picks' as string]: numberOfPicks }}
+		>
+			<div>#</div>
+			<div>Player</div>
+			<div>Lives</div>
+			<div className="text-center">Strk</div>
+			<div className="text-center">Gls</div>
+			{Array.from({ length: numberOfPicks }, (_, i) => (
+				<div
+					// biome-ignore lint/suspicious/noArrayIndexKey: rank columns are stable
+					key={i}
+					className="text-center"
+				>
+					#{i + 1}
+				</div>
+			))}
+		</div>
+	)
+}
+
+function PlayerRow({
+	player,
+	numberOfPicks,
+	maxLives,
+	position,
+	isOut,
+}: {
+	player: CupStandingsData['players'][number]
+	numberOfPicks: number
+	maxLives: number
+	position: number
+	isOut?: boolean
+}) {
+	return (
+		<div
+			className={cn(
+				'grid grid-cols-[24px_140px_80px_48px_48px_repeat(var(--picks),62px)] gap-1.5 px-1 py-1.5 items-center border-t border-border',
+				isOut && 'opacity-55',
+			)}
+			style={{ ['--picks' as string]: numberOfPicks }}
+		>
+			<div className="font-display font-bold text-muted-foreground">{position}</div>
+			<div className="flex items-center gap-2 min-w-0">
+				<Avatar name={player.name} />
+				<span className="text-sm font-semibold truncate">{player.name}</span>
+				{!player.hasSubmitted && <Badge tone="warn">NO PICKS</Badge>}
+				{isOut && <Badge tone="danger">OUT GW{player.eliminatedRoundNumber ?? '?'}</Badge>}
+			</div>
+			<LivesCell remaining={player.livesRemaining} max={maxLives} />
+			<div className="text-center font-bold">{player.streak || '—'}</div>
+			<div className="text-center">{player.goals || '—'}</div>
+			{Array.from({ length: numberOfPicks }, (_, i) => {
+				const rank = i + 1
+				const pick = player.picks.find((p) => p.confidenceRank === rank)
+				return <GridCell key={rank} pick={pick} />
+			})}
+		</div>
+	)
+}
+
+function LivesCell({ remaining, max }: { remaining: number; max: number }) {
+	return (
+		<div className="flex items-center gap-0.5">
+			{Array.from({ length: max }, (_, i) => (
+				<span
+					// biome-ignore lint/suspicious/noArrayIndexKey: stable index
+					key={i}
+					className={cn(
+						'inline-block h-2.5 w-2.5 rounded-full',
+						i < remaining ? 'bg-[#dc2626]' : 'ring-1 ring-inset ring-border',
+					)}
+				/>
+			))}
+			<span
+				className={cn(
+					'ml-1 text-[10px]',
+					remaining === 0 ? 'text-red-600 font-bold' : 'text-muted-foreground',
+				)}
+			>
+				{remaining}/{max}
+				{remaining === 0 ? ' ⚠' : ''}
+			</span>
+		</div>
+	)
+}
+
+function GridCell({ pick }: { pick?: CupStandingsData['players'][number]['picks'][number] }) {
+	if (!pick) {
+		return <div className="h-9 w-14 rounded border border-dashed border-border bg-muted/40" />
+	}
+	if (pick.result === 'hidden') {
+		return (
+			<div className="h-9 w-14 rounded border border-dashed border-border bg-muted/40 flex items-center justify-center text-xs text-muted-foreground">
+				🔒
+			</div>
+		)
+	}
+	if (pick.result === 'restricted') {
+		return (
+			<div className="h-9 w-14 rounded border border-dashed border-border bg-muted/40 flex items-center justify-center text-xs text-muted-foreground">
+				—
+			</div>
+		)
+	}
+	const bg =
+		pick.result === 'win'
+			? 'bg-[var(--alive)]'
+			: pick.result === 'saved_by_life'
+				? 'bg-amber-500'
+				: pick.result === 'loss'
+					? 'bg-[var(--eliminated)]'
+					: 'bg-muted'
+	const fg = pick.result === 'pending' ? 'text-foreground/70' : 'text-white'
+	const label = pick.pickedSide === 'home' ? pick.homeShort : pick.awayShort
+	return (
+		<div
+			className={cn(
+				'relative h-9 w-14 rounded flex flex-col items-center justify-center text-[10px] font-bold',
+				bg,
+				fg,
+			)}
+		>
+			<span>{label}</span>
+			<span className="text-[8px] opacity-90">
+				{pick.tierDifference <= -1 ? `+${Math.abs(pick.tierDifference)}` : ''}
+			</span>
+			{pick.livesGained > 0 && (
+				<span className="absolute -top-1.5 -right-1.5 bg-emerald-700 text-white text-[8px] px-1 rounded-full font-bold">
+					+{pick.livesGained}
+				</span>
+			)}
+			{pick.livesSpent > 0 && (
+				<span className="absolute -top-1.5 -right-1.5 bg-amber-800 text-white text-[8px] px-1 rounded-full font-bold">
+					-{pick.livesSpent}
+				</span>
+			)}
+		</div>
+	)
+}
+
+function Avatar({ name }: { name: string }) {
+	const initials = name
+		.split(/\s+/)
+		.map((part) => part[0])
+		.filter(Boolean)
+		.slice(0, 2)
+		.join('')
+		.toUpperCase()
+	return (
+		<span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-muted text-[10px] font-bold text-foreground/80 shrink-0">
+			{initials || '?'}
+		</span>
+	)
+}
+
+function Badge({ tone, children }: { tone: 'warn' | 'danger'; children: React.ReactNode }) {
+	const cls =
+		tone === 'danger'
+			? 'bg-[var(--eliminated-bg)] text-[var(--eliminated)]'
+			: 'bg-[var(--draw-bg)] text-[var(--draw)]'
+	return (
+		<span
+			className={cn(
+				'inline-flex items-center rounded px-1.5 py-0.5 text-[0.6rem] font-semibold leading-none',
+				cls,
+			)}
+		>
+			{children}
+		</span>
+	)
+}

--- a/src/components/standings/cup-ladder.tsx
+++ b/src/components/standings/cup-ladder.tsx
@@ -1,0 +1,298 @@
+'use client'
+
+import { AlertTriangle, CheckCircle2, Flame, Target, Zap } from 'lucide-react'
+import { HeartIcon } from '@/components/picks/heart-icon'
+import { PlusNBadge } from '@/components/picks/plus-n-badge'
+import { TeamBadge } from '@/components/picks/team-badge'
+import { TierPips } from '@/components/picks/tier-pips'
+import type {
+	CupLadderBacker,
+	CupLadderData,
+	CupLadderFixture,
+	CupStandingsPlayer,
+} from '@/lib/game/cup-standings-queries'
+import { cn } from '@/lib/utils'
+
+interface CupLadderProps {
+	data: CupLadderData
+}
+
+export function CupLadder({ data }: CupLadderProps) {
+	const played = data.fixtures.filter((f) => f.actualOutcome != null)
+	const unplayed = data.fixtures.filter((f) => f.actualOutcome == null)
+	const top3 = [...data.players]
+		.filter((p) => p.status !== 'eliminated')
+		.sort((a, b) => b.streak - a.streak || b.goals - a.goals)
+		.slice(0, 3)
+
+	return (
+		<div className="space-y-6">
+			<Podium players={top3} maxLives={data.maxLives} />
+			{unplayed.length > 0 && (
+				<section>
+					<h3 className="flex items-center gap-2 font-display text-lg font-semibold mb-3">
+						<Zap className="h-4 w-4 text-[var(--accent)]" />
+						Still to play
+					</h3>
+					<div className="space-y-2">
+						{unplayed.map((f) => (
+							<CupFixtureCard key={f.id} fixture={f} />
+						))}
+					</div>
+				</section>
+			)}
+			{played.length > 0 && (
+				<section>
+					<h3 className="flex items-center gap-2 font-display text-lg font-semibold mb-3">
+						<CheckCircle2 className="h-4 w-4 text-[var(--alive)]" />
+						Played
+					</h3>
+					<div className="space-y-2">
+						{played.map((f) => (
+							<CupFixtureCard key={f.id} fixture={f} />
+						))}
+					</div>
+				</section>
+			)}
+		</div>
+	)
+}
+
+function Podium({ players, maxLives }: { players: CupStandingsPlayer[]; maxLives: number }) {
+	if (players.length === 0) return null
+	return (
+		<div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+			{players.map((p, i) => {
+				const medal = i === 0 ? '🏆' : i === 1 ? '🥈' : '🥉'
+				const borderTone =
+					i === 0 ? 'border-[var(--alive)]/60 bg-[var(--alive-bg)]' : 'border-border bg-card'
+				const lowLives = p.livesRemaining <= 1
+				return (
+					<div
+						key={p.id}
+						className={cn(
+							'rounded-lg border-2 p-4 flex items-center justify-between gap-3',
+							borderTone,
+						)}
+					>
+						<div className="flex items-center gap-3 min-w-0">
+							<div className="text-2xl">{medal}</div>
+							<div className="min-w-0">
+								<div className="text-xs uppercase tracking-wider text-muted-foreground font-semibold">
+									{i === 0 ? 'Leader' : `#${i + 1}`}
+								</div>
+								<div className="font-display text-xl font-semibold truncate">{p.name}</div>
+							</div>
+						</div>
+						<div className="flex flex-col items-end shrink-0 gap-1">
+							<div className="flex items-center gap-1 text-lg font-display font-bold">
+								<Flame className="h-4 w-4 text-[var(--draw)]" />
+								{p.streak}
+							</div>
+							<div
+								className={cn(
+									'flex items-center gap-1 text-xs',
+									lowLives ? 'text-[var(--eliminated)] font-bold' : 'text-muted-foreground',
+								)}
+								title={`${p.livesRemaining} of ${maxLives} lives`}
+							>
+								<HeartIcon size={12} />
+								{p.livesRemaining}/{maxLives}
+							</div>
+							<div className="flex items-center gap-1 text-xs text-muted-foreground">
+								<Target className="h-3 w-3" />
+								{p.goals}
+							</div>
+						</div>
+					</div>
+				)
+			})}
+		</div>
+	)
+}
+
+function CupFixtureCard({ fixture }: { fixture: CupLadderFixture }) {
+	const isPlayed = fixture.actualOutcome != null
+	const score =
+		fixture.homeScore != null && fixture.awayScore != null
+			? `${fixture.homeScore}–${fixture.awayScore}`
+			: null
+
+	return (
+		<div
+			className={cn(
+				'rounded-lg border bg-card overflow-hidden',
+				fixture.crucial && 'border-[var(--draw)] shadow-[0_0_0_1px_var(--draw)]',
+			)}
+		>
+			{fixture.crucial && (
+				<div className="bg-[var(--draw-bg)] text-[var(--draw)] text-xs font-semibold px-3 py-1 flex items-center gap-1.5">
+					<AlertTriangle className="h-3.5 w-3.5" />
+					Crucial fixture
+				</div>
+			)}
+
+			{/* Fixture header */}
+			<div className="flex items-stretch">
+				<div className="flex items-center gap-3 px-4 py-3 flex-1 min-w-0 flex-row-reverse">
+					<TeamBadge
+						shortName={fixture.homeTeam.shortName}
+						badgeUrl={fixture.homeTeam.badgeUrl}
+						size="lg"
+					/>
+					<div className="flex flex-col items-end min-w-0">
+						<span className="font-semibold text-base truncate w-full text-right">
+							{fixture.homeTeam.name}
+						</span>
+						<span className="text-xs text-muted-foreground">Home</span>
+					</div>
+				</div>
+				<div className="flex flex-col items-center justify-center px-3 shrink-0 min-w-[96px] bg-muted/30 border-l border-r border-border">
+					{score ? (
+						<>
+							<span className="font-display font-bold text-lg leading-none">{score}</span>
+							<span className="text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground mt-1">
+								{outcomeLabel(fixture.actualOutcome as 'home_win' | 'draw' | 'away_win')}
+							</span>
+						</>
+					) : (
+						<>
+							<span className="text-xs text-muted-foreground font-semibold uppercase tracking-wide">
+								vs
+							</span>
+							{fixture.kickoff && (
+								<span className="text-[0.7rem] text-muted-foreground mt-1 text-center leading-tight">
+									{fixture.kickoff.toLocaleDateString('en-GB', { weekday: 'short' })}{' '}
+									{fixture.kickoff.toLocaleTimeString('en-GB', {
+										hour: '2-digit',
+										minute: '2-digit',
+									})}
+								</span>
+							)}
+						</>
+					)}
+					<div className="mt-1.5 flex items-center gap-1">
+						<TierPips value={Math.min(fixture.plusN, 3) as 0 | 1 | 2 | 3} max={3} />
+						{fixture.plusN >= 1 && <PlusNBadge value={fixture.plusN} />}
+						{fixture.heart && <HeartIcon size={12} />}
+					</div>
+				</div>
+				<div className="flex items-center gap-3 px-4 py-3 flex-1 min-w-0">
+					<TeamBadge
+						shortName={fixture.awayTeam.shortName}
+						badgeUrl={fixture.awayTeam.badgeUrl}
+						size="lg"
+					/>
+					<div className="flex flex-col items-start min-w-0">
+						<span className="font-semibold text-base truncate w-full">{fixture.awayTeam.name}</span>
+						<span className="text-xs text-muted-foreground">Away</span>
+					</div>
+				</div>
+			</div>
+
+			{/* Backers */}
+			<div className="border-t border-border bg-muted/10 px-4 py-3 grid grid-cols-1 md:grid-cols-2 gap-2 text-sm">
+				<BackerGroup
+					label={`Backing ${fixture.homeTeam.shortName}`}
+					backers={fixture.homeBackers}
+					isCorrectOutcome={fixture.actualOutcome === 'home_win'}
+					isPlayed={isPlayed}
+					side="home"
+				/>
+				<BackerGroup
+					label={`Backing ${fixture.awayTeam.shortName}`}
+					backers={fixture.awayBackers}
+					isCorrectOutcome={fixture.actualOutcome === 'away_win'}
+					isPlayed={isPlayed}
+					side="away"
+				/>
+			</div>
+		</div>
+	)
+}
+
+function BackerGroup({
+	label,
+	backers,
+	isCorrectOutcome,
+	isPlayed,
+	side,
+}: {
+	label: string
+	backers: CupLadderBacker[]
+	isCorrectOutcome: boolean
+	isPlayed: boolean
+	side: 'home' | 'away'
+}) {
+	const headerColour = side === 'home' ? 'text-[var(--accent)]' : 'text-[var(--eliminated)]'
+	const borderTone =
+		isPlayed && isCorrectOutcome
+			? 'border-[var(--alive)] bg-[var(--alive-bg)]'
+			: 'border-border bg-card'
+
+	return (
+		<div className={cn('rounded border p-2', borderTone)}>
+			<div className={cn('text-[0.65rem] font-bold uppercase tracking-wide mb-1.5', headerColour)}>
+				{label}
+				{backers.length > 0 && (
+					<span className="ml-1 text-muted-foreground font-medium">({backers.length})</span>
+				)}
+			</div>
+			{backers.length === 0 ? (
+				<div className="text-[0.7rem] text-muted-foreground italic">No one picked this</div>
+			) : (
+				<div className="flex flex-wrap gap-1">
+					{backers.map((b) => (
+						<BackerChip key={`${b.playerId}-${b.confidenceRank}`} backer={b} />
+					))}
+				</div>
+			)}
+		</div>
+	)
+}
+
+function BackerChip({ backer }: { backer: CupLadderBacker }) {
+	if (backer.result === 'hidden') {
+		return (
+			<span className="text-[0.65rem] font-medium px-1.5 py-0.5 rounded bg-muted/40 text-muted-foreground border border-dashed border-border">
+				🔒
+			</span>
+		)
+	}
+
+	const bg =
+		backer.result === 'win'
+			? 'bg-[var(--alive)] text-white'
+			: backer.result === 'saved_by_life'
+				? 'bg-amber-500 text-white'
+				: backer.result === 'loss'
+					? 'bg-[var(--eliminated-bg)] text-[var(--eliminated)] line-through'
+					: 'bg-muted text-foreground'
+
+	return (
+		<span
+			className={cn(
+				'relative inline-flex items-center gap-1 text-[0.65rem] font-semibold px-1.5 py-0.5 rounded',
+				bg,
+			)}
+			title={`Ranked #${backer.confidenceRank}`}
+		>
+			<span>{backer.playerName}</span>
+			<span className="opacity-75">#{backer.confidenceRank}</span>
+			{backer.livesGained > 0 && (
+				<span className="ml-0.5 bg-emerald-700 text-white text-[8px] px-1 rounded-full font-bold">
+					+{backer.livesGained}
+				</span>
+			)}
+			{backer.livesSpent > 0 && (
+				<span className="ml-0.5 bg-amber-800 text-white text-[8px] px-1 rounded-full font-bold">
+					-{backer.livesSpent}
+				</span>
+			)}
+		</span>
+	)
+}
+
+function outcomeLabel(o: 'home_win' | 'draw' | 'away_win'): string {
+	return o === 'home_win' ? 'HOME' : o === 'away_win' ? 'AWAY' : 'DRAW'
+}

--- a/src/components/standings/cup-standings.tsx
+++ b/src/components/standings/cup-standings.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { Clock, LayoutGrid, ListTree } from 'lucide-react'
+import { useState } from 'react'
+import type { CupLadderData } from '@/lib/game/cup-standings-queries'
+import { cn } from '@/lib/utils'
+import { CupGrid } from './cup-grid'
+import { CupLadder } from './cup-ladder'
+import { CupTimeline } from './cup-timeline'
+
+type ViewMode = 'ladder' | 'grid' | 'timeline'
+
+interface CupStandingsProps {
+	data: CupLadderData
+	onShare?: () => void
+}
+
+export function CupStandings({ data, onShare }: CupStandingsProps) {
+	const [view, setView] = useState<ViewMode>('ladder')
+	return (
+		<div className="rounded-xl border border-border bg-card overflow-hidden">
+			<div className="p-4 md:p-5 flex flex-wrap items-start justify-between gap-3 border-b border-border">
+				<div>
+					<h2 className="font-display text-2xl font-semibold">Standings</h2>
+					<p className="text-sm text-muted-foreground mt-1">
+						{data.roundStatus === 'completed'
+							? 'Round complete.'
+							: data.roundStatus === 'open'
+								? 'Round open — picks hidden until the deadline passes.'
+								: 'Round in play.'}
+					</p>
+				</div>
+				<div className="flex items-center gap-2">
+					<div className="flex gap-1 border border-border rounded-md p-0.5">
+						{(['ladder', 'timeline', 'grid'] as const).map((m) => (
+							<button
+								key={m}
+								type="button"
+								onClick={() => setView(m)}
+								className={cn(
+									'text-xs font-semibold px-2.5 py-1 rounded flex items-center gap-1',
+									view === m
+										? 'bg-foreground text-background'
+										: 'text-muted-foreground hover:text-foreground',
+								)}
+							>
+								{m === 'ladder' && <ListTree className="h-3 w-3" />}
+								{m === 'timeline' && <Clock className="h-3 w-3" />}
+								{m === 'grid' && <LayoutGrid className="h-3 w-3" />}
+								{m[0].toUpperCase() + m.slice(1)}
+							</button>
+						))}
+					</div>
+					{onShare && (
+						<button
+							type="button"
+							onClick={onShare}
+							className="text-xs font-semibold px-3 py-1 rounded border border-border"
+						>
+							Share
+						</button>
+					)}
+				</div>
+			</div>
+			<div className="p-4 md:p-5">
+				{view === 'ladder' && <CupLadder data={data} />}
+				{view === 'grid' && <CupGrid data={data} />}
+				{view === 'timeline' && <CupTimeline data={data} />}
+			</div>
+		</div>
+	)
+}

--- a/src/components/standings/cup-timeline.tsx
+++ b/src/components/standings/cup-timeline.tsx
@@ -1,0 +1,263 @@
+'use client'
+
+import { XCircle } from 'lucide-react'
+import type { CupLadderData, CupLadderFixture } from '@/lib/game/cup-standings-queries'
+import { cn } from '@/lib/utils'
+
+interface CupTimelineProps {
+	data: CupLadderData
+}
+
+// A "kickoff slot" is a unique kickoff time across the round's fixtures.
+interface KickoffSlot {
+	key: string
+	label: string // e.g. "Sat 15:00"
+	fullLabel: string // e.g. "Sat 17 Jan, 15:00"
+	time: number // epoch ms
+	fixtures: CupLadderFixture[]
+}
+
+interface PlayerTimeline {
+	playerId: string
+	playerName: string
+	livesRemaining: number
+	status: 'alive' | 'eliminated' | 'winner'
+	picks: Array<{
+		fixtureId: string
+		confidenceRank: number
+		result: 'win' | 'saved_by_life' | 'loss' | 'pending' | 'hidden' | 'restricted'
+		livesGained: number
+		livesSpent: number
+		pickedTeamId: string
+		pickedSide: 'home' | 'away'
+	}>
+}
+
+export function CupTimeline({ data }: CupTimelineProps) {
+	// Build kickoff slots
+	const slotMap = new Map<string, KickoffSlot>()
+	for (const f of data.fixtures) {
+		if (!f.kickoff) continue
+		const d = new Date(f.kickoff)
+		// Group by rounded hour to handle minor differences
+		const key = `${d.toDateString()}T${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}`
+		let slot = slotMap.get(key)
+		if (!slot) {
+			slot = {
+				key,
+				label: `${d.toLocaleDateString('en-GB', { weekday: 'short' })} ${d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })}`,
+				fullLabel: `${d.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' })}, ${d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })}`,
+				time: d.getTime(),
+				fixtures: [],
+			}
+			slotMap.set(key, slot)
+		}
+		slot.fixtures.push(f)
+	}
+
+	const slots = Array.from(slotMap.values()).sort((a, b) => a.time - b.time)
+
+	if (slots.length === 0) {
+		return (
+			<div className="p-6 text-center text-sm text-muted-foreground">
+				Kickoff times not available for this round.
+			</div>
+		)
+	}
+
+	// Build a fixture → slot index lookup
+	const fixtureSlot = new Map<string, number>()
+	slots.forEach((slot, i) => {
+		for (const f of slot.fixtures) fixtureSlot.set(f.id, i)
+	})
+
+	// Pull all picks for all players and index by player
+	const playerPicksByRank = new Map<
+		string,
+		Map<
+			number,
+			Array<{
+				fixtureId: string
+				confidenceRank: number
+				result: 'win' | 'saved_by_life' | 'loss' | 'pending' | 'hidden' | 'restricted'
+				livesGained: number
+				livesSpent: number
+				pickedTeamId: string
+				pickedSide: 'home' | 'away'
+			}>
+		>
+	>()
+
+	for (const player of data.players) {
+		const picksMap = new Map<
+			number,
+			Array<{
+				fixtureId: string
+				confidenceRank: number
+				result: 'win' | 'saved_by_life' | 'loss' | 'pending' | 'hidden' | 'restricted'
+				livesGained: number
+				livesSpent: number
+				pickedTeamId: string
+				pickedSide: 'home' | 'away'
+			}>
+		>()
+
+		for (const pick of player.picks) {
+			const list = picksMap.get(pick.confidenceRank) ?? []
+			list.push({
+				fixtureId: pick.fixtureId,
+				confidenceRank: pick.confidenceRank,
+				result: pick.result,
+				livesGained: pick.livesGained,
+				livesSpent: pick.livesSpent,
+				pickedTeamId: pick.pickedTeamId,
+				pickedSide: pick.pickedSide,
+			})
+			picksMap.set(pick.confidenceRank, list)
+		}
+		playerPicksByRank.set(player.id, picksMap)
+	}
+
+	// Build timelines for each player
+	const timelines: PlayerTimeline[] = data.players.map((player) => ({
+		playerId: player.id,
+		playerName: player.name,
+		livesRemaining: player.livesRemaining,
+		status: player.status,
+		picks: player.picks,
+	}))
+
+	// Sort: survivors first (by lives remaining desc, streak desc, goals desc), then eliminated
+	timelines.sort((a, b) => {
+		const aAlive = a.status !== 'eliminated'
+		const bAlive = b.status !== 'eliminated'
+		if (aAlive && !bAlive) return -1
+		if (!aAlive && bAlive) return 1
+		if (aAlive && bAlive) {
+			return b.livesRemaining - a.livesRemaining
+		}
+		return 0
+	})
+
+	const slotWidth = `minmax(120px, 1fr)`
+
+	return (
+		<div className="space-y-5">
+			{/* Slot header row */}
+			<div
+				className="grid gap-2"
+				style={{ gridTemplateColumns: `180px repeat(${slots.length}, ${slotWidth})` }}
+			>
+				<div />
+				{slots.map((slot) => (
+					<div key={slot.key} className="rounded-md border border-border bg-card p-2.5 text-xs">
+						<div className="font-semibold uppercase tracking-wide text-[0.65rem] text-muted-foreground">
+							{slot.label}
+						</div>
+						<div className="mt-1 text-foreground font-medium">
+							{slot.fixtures.length} {slot.fixtures.length === 1 ? 'fixture' : 'fixtures'}
+						</div>
+					</div>
+				))}
+			</div>
+
+			{/* Player rows */}
+			<div className="space-y-2">
+				{timelines.map((t) => (
+					<div
+						key={t.playerId}
+						className="grid gap-2 items-stretch"
+						style={{
+							gridTemplateColumns: `180px repeat(${slots.length}, ${slotWidth})`,
+						}}
+					>
+						<div className="flex items-center gap-2 px-2">
+							<div className="flex items-center gap-1.5 min-w-0 flex-1">
+								{t.status === 'winner' ? (
+									<span className="text-lg shrink-0">🏆</span>
+								) : t.status === 'eliminated' ? (
+									<XCircle className="h-4 w-4 text-[var(--eliminated)] shrink-0" />
+								) : (
+									<span className="text-lg shrink-0">✓</span>
+								)}
+								<span
+									className={cn(
+										'font-semibold text-sm truncate',
+										t.status === 'eliminated' && 'text-muted-foreground',
+									)}
+								>
+									<span className="flex items-center gap-2">
+										{t.playerName}
+										{t.livesRemaining === 0 && <span className="h-2 w-2 rounded-full bg-red-600" />}
+									</span>
+								</span>
+							</div>
+						</div>
+
+						{slots.map((slot) => {
+							// Find the player's picks that resolve in this slot
+							const picksInSlot = t.picks.filter((p) => {
+								const slotIdx = fixtureSlot.get(p.fixtureId)
+								return slotIdx === slots.indexOf(slot)
+							})
+
+							if (picksInSlot.length === 0) {
+								return (
+									<div
+										key={slot.key}
+										className="rounded-md border border-border flex items-center gap-1 px-2 py-1.5 text-[0.65rem] bg-muted/10"
+									>
+										<span className="text-muted-foreground text-[0.6rem] italic">—</span>
+									</div>
+								)
+							}
+
+							// For cup mode, we typically show one pick per slot per player
+							// Render cells with life-change bars
+							return (
+								<div key={slot.key} className="flex flex-col gap-1">
+									{picksInSlot.map((pick) => {
+										const cellBgColour =
+											pick.result === 'win'
+												? 'bg-[var(--alive)] text-white'
+												: pick.result === 'saved_by_life'
+													? 'bg-amber-600 text-white'
+													: pick.result === 'loss'
+														? 'bg-[var(--eliminated)] text-white'
+														: 'bg-muted text-foreground'
+
+										const fixture = data.fixtures.find((f) => f.id === pick.fixtureId)
+										if (!fixture) return null
+
+										const label =
+											pick.pickedSide === 'home'
+												? fixture.homeTeam.shortName
+												: fixture.awayTeam.shortName
+
+										return (
+											<div
+												key={`${pick.fixtureId}-${pick.confidenceRank}`}
+												className={cn(
+													'relative h-8 w-14 rounded-sm flex items-center justify-center text-[10px] font-semibold',
+													cellBgColour,
+												)}
+											>
+												{label}
+												{pick.livesGained > 0 && (
+													<span className="absolute right-0 top-0 bottom-0 w-1 bg-emerald-700 rounded-r-sm" />
+												)}
+												{pick.livesSpent > 0 && (
+													<span className="absolute right-0 top-0 bottom-0 w-1 bg-amber-700 rounded-r-sm" />
+												)}
+											</div>
+										)
+									})}
+								</div>
+							)
+						})}
+					</div>
+				))}
+			</div>
+		</div>
+	)
+}

--- a/src/lib/data/qstash.test.ts
+++ b/src/lib/data/qstash.test.ts
@@ -8,7 +8,7 @@ vi.mock('@upstash/qstash', () => ({
 	}),
 }))
 
-import { enqueueDeadlineReminder, enqueueProcessRound } from './qstash'
+import { enqueueAutoSubmit, enqueueDeadlineReminder, enqueueProcessRound } from './qstash'
 
 describe('qstash helpers', () => {
 	beforeEach(() => {
@@ -37,6 +37,19 @@ describe('qstash helpers', () => {
 			gameId: 'game-1',
 			roundId: 'round-1',
 			window: '24h',
+		})
+		expect(call.notBefore).toBe(Math.floor(notBefore.getTime() / 1000))
+	})
+
+	it('enqueues an auto-submit at the given timestamp', async () => {
+		const notBefore = new Date('2026-06-11T12:00:00Z')
+		await enqueueAutoSubmit('gp-1', 'r-1', 't-1', notBefore)
+		const call = publishJSONMock.mock.calls[0][0]
+		expect(call.body).toEqual({
+			type: 'auto_submit',
+			gamePlayerId: 'gp-1',
+			roundId: 'r-1',
+			teamId: 't-1',
 		})
 		expect(call.notBefore).toBe(Math.floor(notBefore.getTime() / 1000))
 	})

--- a/src/lib/data/qstash.ts
+++ b/src/lib/data/qstash.ts
@@ -3,6 +3,7 @@ import { Client } from '@upstash/qstash'
 export type QStashJob =
 	| { type: 'process_round'; gameId: string; roundId: string }
 	| { type: 'deadline_reminder'; gameId: string; roundId: string; window: '24h' | '2h' }
+	| { type: 'auto_submit'; gamePlayerId: string; roundId: string; teamId: string }
 
 function handlerUrl(): string {
 	const base = process.env.VERCEL_URL ?? ''
@@ -34,6 +35,19 @@ export async function enqueueDeadlineReminder(
 	await client().publishJSON({
 		url: handlerUrl(),
 		body: { type: 'deadline_reminder', gameId, roundId, window } satisfies QStashJob,
+		notBefore: Math.floor(notBefore.getTime() / 1000),
+	})
+}
+
+export async function enqueueAutoSubmit(
+	gamePlayerId: string,
+	roundId: string,
+	teamId: string,
+	notBefore: Date,
+): Promise<void> {
+	await client().publishJSON({
+		url: handlerUrl(),
+		body: { type: 'auto_submit', gamePlayerId, roundId, teamId } satisfies QStashJob,
 		notBefore: Math.floor(notBefore.getTime() / 1000),
 	})
 }

--- a/src/lib/game-logic/cup-tier.test.ts
+++ b/src/lib/game-logic/cup-tier.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { computeTierDifference } from './cup-tier'
+
+describe('computeTierDifference', () => {
+	const pot1 = { externalIds: { fifa_pot: 1 } }
+	const pot4 = { externalIds: { fifa_pot: 4 } }
+	const pot2 = { externalIds: { fifa_pot: 2 } }
+	const noPot = { externalIds: {} }
+
+	it('returns homePot - awayPot for group_knockout', () => {
+		expect(computeTierDifference(pot1, pot4, 'group_knockout')).toBe(-3)
+		expect(computeTierDifference(pot4, pot1, 'group_knockout')).toBe(3)
+		expect(computeTierDifference(pot1, pot2, 'group_knockout')).toBe(-1)
+	})
+
+	it('returns 0 when a pot is missing', () => {
+		expect(computeTierDifference(pot1, noPot, 'group_knockout')).toBe(0)
+	})
+
+	it('returns 0 for non-cup competition types', () => {
+		expect(computeTierDifference(pot1, pot4, 'league')).toBe(0)
+		expect(computeTierDifference(pot1, pot4, 'knockout')).toBe(0)
+	})
+})

--- a/src/lib/game-logic/cup-tier.ts
+++ b/src/lib/game-logic/cup-tier.ts
@@ -1,0 +1,15 @@
+type TeamWithExternalIds = {
+	externalIds: Record<string, string | number> | null | undefined
+}
+
+export function computeTierDifference(
+	home: TeamWithExternalIds,
+	away: TeamWithExternalIds,
+	competitionType: 'league' | 'knockout' | 'group_knockout',
+): number {
+	if (competitionType !== 'group_knockout') return 0
+	const homePot = Number(home.externalIds?.fifa_pot)
+	const awayPot = Number(away.externalIds?.fifa_pot)
+	if (!Number.isFinite(homePot) || !Number.isFinite(awayPot)) return 0
+	return homePot - awayPot
+}

--- a/src/lib/game-logic/prizes.test.ts
+++ b/src/lib/game-logic/prizes.test.ts
@@ -2,14 +2,45 @@ import { describe, expect, it } from 'vitest'
 import { calculatePayouts, calculatePot } from './prizes'
 
 describe('calculatePot', () => {
-	it('multiplies entry fee by player count', () => {
-		expect(calculatePot('10.00', 12)).toBe('120.00')
+	it('returns all zeros on empty input', () => {
+		expect(calculatePot([])).toEqual({ confirmed: '0.00', pending: '0.00', total: '0.00' })
 	})
-	it('returns 0 when no entry fee', () => {
-		expect(calculatePot(null, 12)).toBe('0.00')
+
+	it('sums paid rows into confirmed', () => {
+		expect(
+			calculatePot([
+				{ amount: '10.00', status: 'paid' },
+				{ amount: '10.00', status: 'paid' },
+			]),
+		).toEqual({ confirmed: '20.00', pending: '0.00', total: '20.00' })
 	})
-	it('handles decimal entry fees', () => {
-		expect(calculatePot('7.50', 8)).toBe('60.00')
+
+	it('separates claimed into pending', () => {
+		expect(
+			calculatePot([
+				{ amount: '10.00', status: 'paid' },
+				{ amount: '10.00', status: 'claimed' },
+			]),
+		).toEqual({ confirmed: '10.00', pending: '10.00', total: '20.00' })
+	})
+
+	it('ignores pending and refunded', () => {
+		expect(
+			calculatePot([
+				{ amount: '10.00', status: 'paid' },
+				{ amount: '10.00', status: 'pending' },
+				{ amount: '10.00', status: 'refunded' },
+			]),
+		).toEqual({ confirmed: '10.00', pending: '0.00', total: '10.00' })
+	})
+
+	it('handles multiple payments per player (rebuy pre-wiring)', () => {
+		expect(
+			calculatePot([
+				{ amount: '10.00', status: 'paid' },
+				{ amount: '10.00', status: 'paid' }, // rebuy
+			]),
+		).toEqual({ confirmed: '20.00', pending: '0.00', total: '20.00' })
 	})
 })
 

--- a/src/lib/game-logic/prizes.ts
+++ b/src/lib/game-logic/prizes.ts
@@ -1,6 +1,26 @@
-export function calculatePot(entryFee: string | null, playerCount: number): string {
-	if (!entryFee) return '0.00'
-	return (Number.parseFloat(entryFee) * playerCount).toFixed(2)
+export interface PaymentLike {
+	amount: string
+	status: string
+}
+
+export interface PotBreakdown {
+	confirmed: string
+	pending: string
+	total: string
+}
+
+export function calculatePot(payments: PaymentLike[]): PotBreakdown {
+	let paid = 0
+	let claimed = 0
+	for (const p of payments) {
+		if (p.status === 'paid') paid += Number.parseFloat(p.amount)
+		else if (p.status === 'claimed') claimed += Number.parseFloat(p.amount)
+	}
+	return {
+		confirmed: paid.toFixed(2),
+		pending: claimed.toFixed(2),
+		total: (paid + claimed).toFixed(2),
+	}
 }
 
 export interface PayoutEntry {

--- a/src/lib/game/auto-submit.ts
+++ b/src/lib/game/auto-submit.ts
@@ -1,0 +1,42 @@
+import { and, eq } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { fixture } from '@/lib/schema/competition'
+import { gamePlayer, pick, plannedPick } from '@/lib/schema/game'
+
+export async function submitPlannedPick(
+	gamePlayerId: string,
+	roundId: string,
+	teamId: string,
+): Promise<{ submitted: boolean; reason?: string }> {
+	// Verify plan still exists (player might have removed it)
+	const plan = await db.query.plannedPick.findFirst({
+		where: and(eq(plannedPick.gamePlayerId, gamePlayerId), eq(plannedPick.roundId, roundId)),
+	})
+	if (!plan || plan.teamId !== teamId) return { submitted: false, reason: 'plan-removed' }
+
+	const gp = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gamePlayerId) })
+	if (!gp || gp.status !== 'alive') return { submitted: false, reason: 'player-not-alive' }
+
+	// Verify no pick already submitted for this round
+	const existingPick = await db.query.pick.findFirst({
+		where: and(eq(pick.gamePlayerId, gamePlayerId), eq(pick.roundId, roundId)),
+	})
+	if (existingPick) return { submitted: false, reason: 'already-picked' }
+
+	// Find the fixture where this team plays in this round
+	const fixturesInRound = await db.query.fixture.findMany({ where: eq(fixture.roundId, roundId) })
+	const fx = fixturesInRound.find((f) => f.homeTeamId === teamId || f.awayTeamId === teamId)
+	if (!fx) return { submitted: false, reason: 'team-not-in-round' }
+
+	// Write the pick with auto_submitted = true, then clear the plan
+	await db.insert(pick).values({
+		gameId: gp.gameId,
+		gamePlayerId,
+		roundId,
+		teamId,
+		fixtureId: fx.id,
+		autoSubmitted: true,
+	})
+	await db.delete(plannedPick).where(eq(plannedPick.id, plan.id))
+	return { submitted: true }
+}

--- a/src/lib/game/bootstrap-competitions.test.ts
+++ b/src/lib/game/bootstrap-competitions.test.ts
@@ -7,12 +7,14 @@ const {
 	dbQueryRoundFindFirst,
 	dbQueryRoundFindMany,
 	dbQueryFixtureFindFirst,
+	dbQueryPlannedPickFindMany,
 	dbInsertFn,
 	dbUpdateFn,
 	fplFetchTeams,
 	fplFetchRounds,
 	fdFetchTeams,
 	fdFetchRounds,
+	enqueueAutoSubmitMock,
 } = vi.hoisted(() => ({
 	dbQueryCompetitionFindFirst: vi.fn(),
 	dbQueryTeamFindFirst: vi.fn(),
@@ -20,6 +22,7 @@ const {
 	dbQueryRoundFindFirst: vi.fn(),
 	dbQueryRoundFindMany: vi.fn().mockResolvedValue([]),
 	dbQueryFixtureFindFirst: vi.fn(),
+	dbQueryPlannedPickFindMany: vi.fn().mockResolvedValue([]),
 	dbInsertFn: vi.fn(() => ({
 		values: vi.fn(() => ({
 			returning: vi.fn().mockResolvedValue([{ id: 'new', externalId: 'WC' }]),
@@ -32,6 +35,7 @@ const {
 	fplFetchRounds: vi.fn().mockResolvedValue([]),
 	fdFetchTeams: vi.fn().mockResolvedValue([]),
 	fdFetchRounds: vi.fn().mockResolvedValue([]),
+	enqueueAutoSubmitMock: vi.fn().mockResolvedValue(undefined),
 }))
 
 vi.mock('@/lib/db', () => ({
@@ -41,11 +45,14 @@ vi.mock('@/lib/db', () => ({
 			team: { findFirst: dbQueryTeamFindFirst, findMany: dbQueryTeamFindMany },
 			round: { findFirst: dbQueryRoundFindFirst, findMany: dbQueryRoundFindMany },
 			fixture: { findFirst: dbQueryFixtureFindFirst },
+			plannedPick: { findMany: dbQueryPlannedPickFindMany },
 		},
 		insert: dbInsertFn,
 		update: dbUpdateFn,
 	},
 }))
+
+vi.mock('@/lib/data/qstash', () => ({ enqueueAutoSubmit: enqueueAutoSubmitMock }))
 
 vi.mock('@/lib/data/fpl', () => ({
 	// biome-ignore lint/complexity/useArrowFunction: vi.fn().mockImplementation needs a constructable function for `new FplAdapter()`
@@ -62,13 +69,14 @@ vi.mock('@/lib/data/football-data', () => ({
 	resolveFootballDataCode: vi.fn(() => 'PL'),
 }))
 
-import { bootstrapCompetitions } from './bootstrap-competitions'
+import { bootstrapCompetitions, syncCompetition } from './bootstrap-competitions'
 
 describe('bootstrapCompetitions', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
 		dbQueryTeamFindMany.mockResolvedValue([])
 		dbQueryRoundFindMany.mockResolvedValue([])
+		dbQueryPlannedPickFindMany.mockResolvedValue([])
 	})
 
 	it('creates PL and WC competitions when they do not exist', async () => {
@@ -87,5 +95,110 @@ describe('bootstrapCompetitions', () => {
 		await bootstrapCompetitions({ footballDataApiKey: 'fd-key' })
 		// No assertion that insert was NOT called — adapters may still insert teams/rounds.
 		// This test just ensures the function runs without error when comps already exist.
+	})
+})
+
+describe('syncCompetition auto-submit enqueue', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		dbQueryTeamFindMany.mockResolvedValue([])
+		dbQueryRoundFindMany.mockResolvedValue([])
+		dbQueryPlannedPickFindMany.mockResolvedValue([])
+	})
+
+	it('enqueues auto-submits when a round transitions from upcoming to open', async () => {
+		const deadline = new Date(Date.now() + 24 * 3600 * 1000) // 24h away → within 48h window → open
+		fplFetchTeams.mockResolvedValue([])
+		fplFetchRounds.mockResolvedValue([
+			{
+				number: 1,
+				name: 'Round 1',
+				deadline,
+				finished: false,
+				fixtures: [],
+			},
+		])
+		dbQueryRoundFindFirst.mockResolvedValue({
+			id: 'round-1',
+			status: 'upcoming',
+		})
+		dbQueryPlannedPickFindMany.mockResolvedValue([
+			{ id: 'pp-1', gamePlayerId: 'gp-1', roundId: 'round-1', teamId: 't-1', autoSubmit: true },
+			{ id: 'pp-2', gamePlayerId: 'gp-2', roundId: 'round-1', teamId: 't-2', autoSubmit: false },
+		])
+
+		await syncCompetition(
+			{
+				id: 'comp-1',
+				dataSource: 'fpl',
+				externalId: null,
+				season: '2025/26',
+			} as never,
+			{ footballDataApiKey: 'fd-key' },
+		)
+
+		expect(enqueueAutoSubmitMock).toHaveBeenCalledTimes(1)
+		expect(enqueueAutoSubmitMock).toHaveBeenCalledWith(
+			'gp-1',
+			'round-1',
+			't-1',
+			new Date(deadline.getTime() - 60_000),
+		)
+	})
+
+	it('does not re-enqueue when the round was already open', async () => {
+		const deadline = new Date(Date.now() + 24 * 3600 * 1000)
+		fplFetchTeams.mockResolvedValue([])
+		fplFetchRounds.mockResolvedValue([
+			{
+				number: 1,
+				name: 'Round 1',
+				deadline,
+				finished: false,
+				fixtures: [],
+			},
+		])
+		dbQueryRoundFindFirst.mockResolvedValue({
+			id: 'round-1',
+			status: 'open',
+		})
+		dbQueryPlannedPickFindMany.mockResolvedValue([
+			{ id: 'pp-1', gamePlayerId: 'gp-1', roundId: 'round-1', teamId: 't-1', autoSubmit: true },
+		])
+
+		await syncCompetition(
+			{ id: 'comp-1', dataSource: 'fpl', externalId: null, season: '2025/26' } as never,
+			{ footballDataApiKey: 'fd-key' },
+		)
+
+		expect(enqueueAutoSubmitMock).not.toHaveBeenCalled()
+	})
+
+	it('does not enqueue when the round remains upcoming (deadline still far away)', async () => {
+		const deadline = new Date(Date.now() + 10 * 24 * 3600 * 1000) // 10 days away
+		fplFetchTeams.mockResolvedValue([])
+		fplFetchRounds.mockResolvedValue([
+			{
+				number: 1,
+				name: 'Round 1',
+				deadline,
+				finished: false,
+				fixtures: [],
+			},
+		])
+		dbQueryRoundFindFirst.mockResolvedValue({
+			id: 'round-1',
+			status: 'upcoming',
+		})
+		dbQueryPlannedPickFindMany.mockResolvedValue([
+			{ id: 'pp-1', gamePlayerId: 'gp-1', roundId: 'round-1', teamId: 't-1', autoSubmit: true },
+		])
+
+		await syncCompetition(
+			{ id: 'comp-1', dataSource: 'fpl', externalId: null, season: '2025/26' } as never,
+			{ footballDataApiKey: 'fd-key' },
+		)
+
+		expect(enqueueAutoSubmitMock).not.toHaveBeenCalled()
 	})
 })

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -1,14 +1,19 @@
 import { and, eq, inArray } from 'drizzle-orm'
 import { FootballDataAdapter } from '@/lib/data/football-data'
 import { FplAdapter } from '@/lib/data/fpl'
+import { enqueueAutoSubmit } from '@/lib/data/qstash'
 import type { CompetitionAdapter } from '@/lib/data/types'
 import { WC_2026_POTS } from '@/lib/data/wc-pots'
 import { db } from '@/lib/db'
 import { competition, fixture, round, team } from '@/lib/schema/competition'
+import { plannedPick } from '@/lib/schema/game'
 
 export interface BootstrapOptions {
 	footballDataApiKey?: string
 }
+
+const OPEN_WINDOW_MS = 48 * 3600 * 1000
+const AUTO_SUBMIT_LEAD_MS = 60_000
 
 type CompetitionRow = typeof competition.$inferSelect
 
@@ -90,7 +95,14 @@ export async function syncCompetition(
 		const existingRound = await db.query.round.findFirst({
 			where: and(eq(round.competitionId, comp.id), eq(round.number, ar.number)),
 		})
+		const newStatus: 'upcoming' | 'open' | 'active' | 'completed' = ar.finished
+			? 'completed'
+			: ar.deadline && ar.deadline.getTime() - Date.now() < OPEN_WINDOW_MS
+				? 'open'
+				: (existingRound?.status ?? 'upcoming')
 		let roundId: string
+		const transitioningToOpen =
+			!!existingRound && existingRound.status !== 'open' && newStatus === 'open'
 		if (existingRound) {
 			roundId = existingRound.id
 			await db
@@ -98,7 +110,7 @@ export async function syncCompetition(
 				.set({
 					name: ar.name,
 					deadline: ar.deadline,
-					status: ar.finished ? 'completed' : existingRound.status,
+					status: newStatus,
 				})
 				.where(eq(round.id, existingRound.id))
 		} else {
@@ -109,10 +121,21 @@ export async function syncCompetition(
 					number: ar.number,
 					name: ar.name,
 					deadline: ar.deadline,
-					status: ar.finished ? 'completed' : 'upcoming',
+					status: newStatus,
 				})
 				.returning()
 			roundId = created.id
+		}
+
+		if (transitioningToOpen && ar.deadline) {
+			const plans = await db.query.plannedPick.findMany({
+				where: eq(plannedPick.roundId, roundId),
+			})
+			const autoPlans = plans.filter((p) => p.autoSubmit)
+			const notBefore = new Date(ar.deadline.getTime() - AUTO_SUBMIT_LEAD_MS)
+			for (const p of autoPlans) {
+				await enqueueAutoSubmit(p.gamePlayerId, p.roundId, p.teamId, notBefore)
+			}
 		}
 
 		for (const af of ar.fixtures) {

--- a/src/lib/game/classic-planner-view.ts
+++ b/src/lib/game/classic-planner-view.ts
@@ -1,0 +1,271 @@
+import type { ChainSlot } from '@/components/picks/chain-ribbon'
+import type { PlannerFixture, UsedInfo } from '@/components/picks/planner-round'
+
+/**
+ * Pure view-builders for the classic-pick chain ribbon + planner section.
+ *
+ * These functions take already-loaded database rows and assemble the exact
+ * props the client components need. Keeping the mapping out of the page
+ * component lets us unit-test it without hitting the DB.
+ */
+
+export interface ChainSummary {
+	played: number
+	planned: number
+	availableTeams: number
+	totalTeams: number
+}
+
+export interface PlannerRoundInput {
+	roundId: string
+	roundNumber: number
+	roundName: string
+	deadline: Date | null
+	fixturesTbc: boolean
+	fixtures: PlannerFixture[]
+	usedTeams: UsedInfo[]
+	plannedTeamId: string | null
+	plannedAutoSubmit: boolean
+}
+
+export interface ChainRoundRow {
+	id: string
+	number: number
+	name: string | null
+	status: 'upcoming' | 'open' | 'active' | 'completed'
+}
+
+export interface ChainPastPickRow {
+	roundId: string
+	teamId: string
+	result: 'pending' | 'win' | 'loss' | 'draw' | 'saved_by_life'
+	teamShortName: string
+	teamColour: string | null
+}
+
+export interface ChainPlannedPickRow {
+	roundId: string
+	teamId: string
+	autoSubmit: boolean
+	teamShortName: string
+	teamColour: string | null
+}
+
+export interface ChainCurrentPickInfo {
+	roundId: string
+	teamShortName: string | null
+	teamColour: string | null
+}
+
+export interface BuildChainSlotsInput {
+	rounds: ChainRoundRow[]
+	pastPicks: ChainPastPickRow[] // completed rounds only (result != pending)
+	currentPick: ChainCurrentPickInfo | null
+	plannedPicks: ChainPlannedPickRow[]
+	currentRoundId: string | null
+	upcomingRoundsFixturesTbc: Set<string>
+	totalTeams: number
+}
+
+export function buildChainSlots(input: BuildChainSlotsInput): {
+	slots: ChainSlot[]
+	summary: ChainSummary
+} {
+	const pastById = new Map(input.pastPicks.map((p) => [p.roundId, p]))
+	const planById = new Map(input.plannedPicks.map((p) => [p.roundId, p]))
+
+	const slots: ChainSlot[] = input.rounds.map((r) => {
+		if (r.id === input.currentRoundId) {
+			const plan = planById.get(r.id)
+			if (plan) {
+				return {
+					roundId: r.id,
+					roundNumber: r.number,
+					state: plan.autoSubmit
+						? {
+								kind: 'planned-locked',
+								teamShort: plan.teamShortName,
+								teamColour: plan.teamColour,
+							}
+						: {
+								kind: 'planned',
+								teamShort: plan.teamShortName,
+								teamColour: plan.teamColour,
+							},
+				}
+			}
+			return {
+				roundId: r.id,
+				roundNumber: r.number,
+				state: {
+					kind: 'current',
+					teamShort: input.currentPick?.teamShortName ?? null,
+					teamColour: input.currentPick?.teamColour ?? null,
+				},
+			}
+		}
+
+		// Completed round — render based on result
+		const past = pastById.get(r.id)
+		if (past) {
+			if (past.result === 'win' || past.result === 'saved_by_life') {
+				return {
+					roundId: r.id,
+					roundNumber: r.number,
+					state: { kind: 'win', teamShort: past.teamShortName, teamColour: past.teamColour },
+				}
+			}
+			if (past.result === 'draw') {
+				return {
+					roundId: r.id,
+					roundNumber: r.number,
+					state: { kind: 'draw', teamShort: past.teamShortName, teamColour: past.teamColour },
+				}
+			}
+			if (past.result === 'loss') {
+				return {
+					roundId: r.id,
+					roundNumber: r.number,
+					state: { kind: 'loss', teamShort: past.teamShortName, teamColour: past.teamColour },
+				}
+			}
+		}
+
+		// Upcoming round — planned or empty or tbc
+		const plan = planById.get(r.id)
+		if (plan) {
+			return {
+				roundId: r.id,
+				roundNumber: r.number,
+				state: plan.autoSubmit
+					? {
+							kind: 'planned-locked',
+							teamShort: plan.teamShortName,
+							teamColour: plan.teamColour,
+						}
+					: {
+							kind: 'planned',
+							teamShort: plan.teamShortName,
+							teamColour: plan.teamColour,
+						},
+			}
+		}
+
+		if (input.upcomingRoundsFixturesTbc.has(r.id)) {
+			return { roundId: r.id, roundNumber: r.number, state: { kind: 'tbc' } }
+		}
+
+		return { roundId: r.id, roundNumber: r.number, state: { kind: 'empty' } }
+	})
+
+	const played = input.pastPicks.length
+	const planned = input.plannedPicks.length
+	const usedCount = new Set<string>([
+		...input.pastPicks.map((p) => p.teamId),
+		...input.plannedPicks.map((p) => p.teamId),
+	]).size
+	const availableTeams = Math.max(0, input.totalTeams - usedCount)
+
+	return {
+		slots,
+		summary: { played, planned, availableTeams, totalTeams: input.totalTeams },
+	}
+}
+
+export interface FutureRoundRow {
+	id: string
+	number: number
+	name: string | null
+	deadline: Date | null
+	fixtures: Array<{
+		id: string
+		kickoff: Date | null
+		homeTeam: {
+			id: string
+			name: string
+			shortName: string
+			badgeUrl: string | null
+			primaryColor: string | null
+		}
+		awayTeam: {
+			id: string
+			name: string
+			shortName: string
+			badgeUrl: string | null
+			primaryColor: string | null
+		}
+	}>
+}
+
+export interface BuildPlannerRoundsInput {
+	futureRounds: FutureRoundRow[]
+	pastPicks: Array<{ roundNumber: number; teamId: string }>
+	plannedPicks: Array<{ roundNumber: number; teamId: string; autoSubmit: boolean; roundId: string }>
+}
+
+/**
+ * Build the PlannerRound inputs for every upcoming round.
+ * Applies cascading "used" labels — a pick in an earlier planned gameweek
+ * locks that team out of later gameweeks automatically.
+ */
+export function buildPlannerRounds(input: BuildPlannerRoundsInput): PlannerRoundInput[] {
+	const sortedFutures = [...input.futureRounds].sort((a, b) => a.number - b.number)
+
+	return sortedFutures.map((r) => {
+		const fixturesTbc = r.fixtures.length === 0
+		const plan = input.plannedPicks.find((p) => p.roundId === r.id)
+		const plannedTeamId = plan?.teamId ?? null
+		const plannedAutoSubmit = plan?.autoSubmit ?? false
+
+		// A team is "used" for this round if:
+		//   - it was picked in a past (completed) round, OR
+		//   - it is planned for any OTHER round (planned in this round is handled by plannedTeamId).
+		const usedTeams: UsedInfo[] = []
+		for (const pp of input.pastPicks) {
+			usedTeams.push({
+				teamId: pp.teamId,
+				label: `USED GW${pp.roundNumber}`,
+				kind: 'used',
+			})
+		}
+		for (const plp of input.plannedPicks) {
+			if (plp.roundId === r.id) continue
+			usedTeams.push({
+				teamId: plp.teamId,
+				label: `PLANNED GW${plp.roundNumber}`,
+				kind: 'planned-elsewhere',
+			})
+		}
+
+		const fixtures: PlannerFixture[] = r.fixtures.map((f) => ({
+			id: f.id,
+			kickoff: f.kickoff,
+			homeTeam: {
+				id: f.homeTeam.id,
+				name: f.homeTeam.name,
+				short: f.homeTeam.shortName,
+				colour: f.homeTeam.primaryColor,
+				badgeUrl: f.homeTeam.badgeUrl,
+			},
+			awayTeam: {
+				id: f.awayTeam.id,
+				name: f.awayTeam.name,
+				short: f.awayTeam.shortName,
+				colour: f.awayTeam.primaryColor,
+				badgeUrl: f.awayTeam.badgeUrl,
+			},
+		}))
+
+		return {
+			roundId: r.id,
+			roundNumber: r.number,
+			roundName: r.name ?? `GW${r.number}`,
+			deadline: r.deadline,
+			fixturesTbc,
+			fixtures,
+			usedTeams,
+			plannedTeamId,
+			plannedAutoSubmit,
+		}
+	})
+}

--- a/src/lib/game/cup-standings-queries.test.ts
+++ b/src/lib/game/cup-standings-queries.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+	findFirstMock: vi.fn(),
+	findManyMock: vi.fn(),
+	selectMock: vi.fn(),
+}))
+
+vi.mock('@/lib/db', () => ({
+	db: {
+		query: {
+			game: { findFirst: mocks.findFirstMock },
+			pick: { findMany: mocks.findManyMock },
+		},
+		select: mocks.selectMock,
+	},
+}))
+
+const { findFirstMock } = mocks
+
+import {
+	type CupStandingsPick,
+	computeLivesGained,
+	computeLivesSpent,
+	computeStreak,
+	getCupStandingsData,
+	mapPickResult,
+} from './cup-standings-queries'
+
+describe('getCupStandingsData', () => {
+	it('returns null when game is missing', async () => {
+		findFirstMock.mockResolvedValue(undefined)
+		expect(await getCupStandingsData('g1', 'u1')).toBeNull()
+	})
+
+	it('returns null when there is no current round', async () => {
+		findFirstMock.mockResolvedValue({
+			id: 'g',
+			currentRound: null,
+			players: [],
+			competition: { type: 'group_knockout' },
+			modeConfig: {},
+		})
+		expect(await getCupStandingsData('g1', 'u1')).toBeNull()
+	})
+})
+
+describe('mapPickResult', () => {
+	it('maps draw and win to win', () => {
+		expect(mapPickResult('win')).toBe('win')
+		expect(mapPickResult('draw')).toBe('win')
+	})
+
+	it('maps saved_by_life through', () => {
+		expect(mapPickResult('saved_by_life')).toBe('saved_by_life')
+	})
+
+	it('maps loss through', () => {
+		expect(mapPickResult('loss')).toBe('loss')
+	})
+
+	it('returns pending for anything else', () => {
+		expect(mapPickResult('pending')).toBe('pending')
+		expect(mapPickResult('unknown')).toBe('pending')
+	})
+})
+
+describe('computeLivesGained', () => {
+	it('returns 0 when pick did not win', () => {
+		expect(computeLivesGained({ result: 'loss' }, -3)).toBe(0)
+		expect(computeLivesGained({ result: 'pending' }, -3)).toBe(0)
+		expect(computeLivesGained({ result: 'saved_by_life' }, -3)).toBe(0)
+	})
+
+	it('returns 0 for a win on a neutral or favourite pick', () => {
+		expect(computeLivesGained({ result: 'win' }, 0)).toBe(0)
+		expect(computeLivesGained({ result: 'win' }, -1)).toBe(0)
+		expect(computeLivesGained({ result: 'win' }, 2)).toBe(0)
+	})
+
+	it('returns |tier| lives for an upset win where tier <= -2', () => {
+		expect(computeLivesGained({ result: 'win' }, -2)).toBe(2)
+		expect(computeLivesGained({ result: 'win' }, -3)).toBe(3)
+	})
+})
+
+describe('computeLivesSpent', () => {
+	it('returns 1 when saved_by_life, otherwise 0', () => {
+		expect(computeLivesSpent({ result: 'saved_by_life' })).toBe(1)
+		expect(computeLivesSpent({ result: 'win' })).toBe(0)
+		expect(computeLivesSpent({ result: 'loss' })).toBe(0)
+		expect(computeLivesSpent({ result: 'pending' })).toBe(0)
+	})
+})
+
+describe('computeStreak', () => {
+	const makePick = (rank: number, result: CupStandingsPick['result']): CupStandingsPick => ({
+		gamePlayerId: 'gp',
+		confidenceRank: rank,
+		fixtureId: 'f',
+		homeShort: 'H',
+		awayShort: 'A',
+		pickedTeamId: 't',
+		pickedSide: 'home',
+		tierDifference: 0,
+		result,
+		livesGained: 0,
+		livesSpent: 0,
+		goalsCounted: 0,
+	})
+
+	it('returns 0 when first pick lost', () => {
+		expect(computeStreak([makePick(1, 'loss'), makePick(2, 'win')])).toBe(0)
+	})
+
+	it('counts consecutive wins from lowest rank up', () => {
+		expect(computeStreak([makePick(2, 'win'), makePick(1, 'win'), makePick(3, 'loss')])).toBe(2)
+	})
+
+	it('counts saved_by_life as continuing the streak', () => {
+		expect(
+			computeStreak([makePick(1, 'win'), makePick(2, 'saved_by_life'), makePick(3, 'loss')]),
+		).toBe(2)
+	})
+
+	it('breaks on pending', () => {
+		expect(computeStreak([makePick(1, 'win'), makePick(2, 'pending')])).toBe(1)
+	})
+})

--- a/src/lib/game/cup-standings-queries.test.ts
+++ b/src/lib/game/cup-standings-queries.test.ts
@@ -19,11 +19,14 @@ vi.mock('@/lib/db', () => ({
 const { findFirstMock } = mocks
 
 import {
+	type CupLadderBacker,
 	type CupStandingsPick,
+	type CupStandingsPlayer,
 	computeLivesGained,
 	computeLivesSpent,
 	computeStreak,
 	getCupStandingsData,
+	isCrucial,
 	mapPickResult,
 } from './cup-standings-queries'
 
@@ -125,5 +128,81 @@ describe('computeStreak', () => {
 
 	it('breaks on pending', () => {
 		expect(computeStreak([makePick(1, 'win'), makePick(2, 'pending')])).toBe(1)
+	})
+})
+
+describe('isCrucial', () => {
+	const makeBacker = (
+		playerId: string,
+		confidenceRank = 1,
+		result: CupLadderBacker['result'] = 'pending',
+	): CupLadderBacker => ({
+		playerId,
+		playerName: playerId,
+		confidenceRank,
+		result,
+		livesGained: 0,
+		livesSpent: 0,
+	})
+
+	const makePlayer = (id: string, livesRemaining: number): CupStandingsPlayer => ({
+		id,
+		userId: `user-${id}`,
+		name: id,
+		status: 'alive',
+		livesRemaining,
+		streak: 0,
+		goals: 0,
+		hasSubmitted: true,
+		eliminatedRoundNumber: null,
+		picks: [],
+	})
+
+	it('is not crucial once the fixture has played', () => {
+		expect(
+			isCrucial(
+				{ actualOutcome: 'home_win' },
+				{ homeBackers: [makeBacker('p1')], awayBackers: [makeBacker('p2')] },
+				[makePlayer('p1', 2), makePlayer('p2', 2)],
+			),
+		).toBe(false)
+	})
+
+	it('is crucial when backers split across both sides', () => {
+		expect(
+			isCrucial(
+				{ actualOutcome: null },
+				{ homeBackers: [makeBacker('p1')], awayBackers: [makeBacker('p2')] },
+				[makePlayer('p1', 2), makePlayer('p2', 2)],
+			),
+		).toBe(true)
+	})
+
+	it('is crucial when a no-lives player has staked a pick on it', () => {
+		expect(
+			isCrucial(
+				{ actualOutcome: null },
+				{ homeBackers: [makeBacker('p1'), makeBacker('p2')], awayBackers: [] },
+				[makePlayer('p1', 0), makePlayer('p2', 2)],
+			),
+		).toBe(true)
+	})
+
+	it('is not crucial when everyone is on the same side and has lives', () => {
+		expect(
+			isCrucial(
+				{ actualOutcome: null },
+				{ homeBackers: [makeBacker('p1'), makeBacker('p2')], awayBackers: [] },
+				[makePlayer('p1', 2), makePlayer('p2', 2)],
+			),
+		).toBe(false)
+	})
+
+	it('is not crucial when the fixture has no backers at all', () => {
+		expect(
+			isCrucial({ actualOutcome: null }, { homeBackers: [], awayBackers: [] }, [
+				makePlayer('p1', 0),
+			]),
+		).toBe(false)
 	})
 })

--- a/src/lib/game/cup-standings-queries.ts
+++ b/src/lib/game/cup-standings-queries.ts
@@ -1,0 +1,182 @@
+import { and, eq, inArray } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { computeTierDifference } from '@/lib/game-logic/cup-tier'
+import { pick } from '@/lib/schema/game'
+
+export interface CupStandingsPick {
+	gamePlayerId: string
+	confidenceRank: number
+	fixtureId: string
+	homeShort: string
+	awayShort: string
+	pickedTeamId: string
+	pickedSide: 'home' | 'away'
+	tierDifference: number // from picked side
+	result: 'win' | 'saved_by_life' | 'loss' | 'pending' | 'hidden' | 'restricted'
+	livesGained: number
+	livesSpent: number
+	goalsCounted: number
+}
+
+export interface CupStandingsPlayer {
+	id: string
+	userId: string
+	name: string
+	status: 'alive' | 'eliminated' | 'winner'
+	livesRemaining: number
+	streak: number
+	goals: number
+	hasSubmitted: boolean
+	eliminatedRoundNumber: number | null
+	picks: CupStandingsPick[]
+}
+
+export interface CupStandingsData {
+	gameId: string
+	roundId: string
+	roundNumber: number
+	roundStatus: 'open' | 'active' | 'completed'
+	maxLives: number
+	numberOfPicks: number
+	players: CupStandingsPlayer[]
+}
+
+export async function getCupStandingsData(
+	gameId: string,
+	viewerUserId: string,
+): Promise<CupStandingsData | null> {
+	const g = await db.query.game.findFirst({
+		where: (t, { eq: eqOp }) => eqOp(t.id, gameId),
+		with: {
+			competition: true,
+			currentRound: {
+				with: { fixtures: { with: { homeTeam: true, awayTeam: true } } },
+			},
+			players: true,
+		},
+	})
+	if (!g?.currentRound) return null
+
+	const allPicks = await db.query.pick.findMany({
+		where: and(eq(pick.gameId, gameId), eq(pick.roundId, g.currentRound.id)),
+	})
+
+	// User-name lookup — mirror the pattern in getTurboStandingsData.
+	const { user } = await import('@/lib/schema/auth')
+	const userRows =
+		g.players.length > 0
+			? await db
+					.select({ id: user.id, name: user.name })
+					.from(user)
+					.where(
+						inArray(
+							user.id,
+							g.players.map((p) => p.userId),
+						),
+					)
+			: []
+	const userNames = new Map(userRows.map((u) => [u.id, u.name]))
+
+	const hideOpenPicks = g.currentRound.status === 'open'
+
+	const players: CupStandingsPlayer[] = g.players.map((p) => {
+		const isViewer = p.userId === viewerUserId
+		const myPicks = allPicks.filter((pk) => pk.gamePlayerId === p.id)
+		const picks: CupStandingsPick[] = myPicks.map((pk) => {
+			const fx = g.currentRound?.fixtures.find((f) => f.id === pk.fixtureId)
+			if (!fx) {
+				// Shouldn't happen — pick referencing a fixture not in the round — but
+				// be defensive rather than throwing at the query layer.
+				return {
+					gamePlayerId: p.id,
+					confidenceRank: pk.confidenceRank ?? 0,
+					fixtureId: pk.fixtureId ?? '',
+					homeShort: '?',
+					awayShort: '?',
+					pickedTeamId: pk.teamId,
+					pickedSide: 'home' as const,
+					tierDifference: 0,
+					result: 'pending' as const,
+					livesGained: 0,
+					livesSpent: 0,
+					goalsCounted: pk.goalsScored ?? 0,
+				}
+			}
+			const pickedSide: 'home' | 'away' = pk.teamId === fx.homeTeamId ? 'home' : 'away'
+			const tierFromHome = computeTierDifference(fx.homeTeam, fx.awayTeam, g.competition.type)
+			const tierFromPicked = pickedSide === 'home' ? tierFromHome : -tierFromHome
+			const hidden = hideOpenPicks && !isViewer
+			const mapped = mapPickResult(pk.result)
+			return {
+				gamePlayerId: p.id,
+				confidenceRank: pk.confidenceRank ?? 0,
+				fixtureId: fx.id,
+				homeShort: fx.homeTeam.shortName,
+				awayShort: fx.awayTeam.shortName,
+				pickedTeamId: pk.teamId,
+				pickedSide,
+				tierDifference: tierFromPicked,
+				result: hidden ? 'hidden' : mapped,
+				livesGained: hidden ? 0 : computeLivesGained(pk, tierFromPicked),
+				livesSpent: hidden ? 0 : computeLivesSpent(pk),
+				goalsCounted: pk.goalsScored ?? 0,
+			}
+		})
+		const streak = computeStreak(picks)
+		return {
+			id: p.id,
+			userId: p.userId,
+			name: userNames.get(p.userId) ?? 'Player',
+			status: p.status,
+			livesRemaining: p.livesRemaining,
+			streak,
+			goals: picks.reduce((sum, pk) => sum + pk.goalsCounted, 0),
+			hasSubmitted: myPicks.length > 0,
+			eliminatedRoundNumber: null,
+			picks,
+		}
+	})
+
+	return {
+		gameId: g.id,
+		roundId: g.currentRound.id,
+		roundNumber: g.currentRound.number,
+		roundStatus: g.currentRound.status as 'open' | 'active' | 'completed',
+		maxLives: (g.modeConfig as { startingLives?: number } | null)?.startingLives ?? 3,
+		numberOfPicks: (g.modeConfig as { numberOfPicks?: number } | null)?.numberOfPicks ?? 6,
+		players,
+	}
+}
+
+export function mapPickResult(r: string): 'win' | 'saved_by_life' | 'loss' | 'pending' {
+	switch (r) {
+		case 'win':
+		case 'draw':
+			return 'win'
+		case 'saved_by_life':
+			return 'saved_by_life'
+		case 'loss':
+			return 'loss'
+		default:
+			return 'pending'
+	}
+}
+
+export function computeLivesGained(pk: { result: string }, tierFromPicked: number): number {
+	if (pk.result !== 'win') return 0
+	if (tierFromPicked <= -2) return Math.abs(tierFromPicked)
+	return 0
+}
+
+export function computeLivesSpent(pk: { result: string }): number {
+	return pk.result === 'saved_by_life' ? 1 : 0
+}
+
+export function computeStreak(picks: CupStandingsPick[]): number {
+	let streak = 0
+	for (const p of [...picks].sort((a, b) => a.confidenceRank - b.confidenceRank)) {
+		if (p.result === 'win' || p.result === 'saved_by_life') streak++
+		else break
+	}
+	return streak
+}

--- a/src/lib/game/cup-standings-queries.ts
+++ b/src/lib/game/cup-standings-queries.ts
@@ -1,5 +1,6 @@
 import { and, eq, inArray } from 'drizzle-orm'
 import { db } from '@/lib/db'
+import { determineFixtureOutcome } from '@/lib/game-logic/common'
 import { computeTierDifference } from '@/lib/game-logic/cup-tier'
 import { pick } from '@/lib/schema/game'
 
@@ -39,6 +40,35 @@ export interface CupStandingsData {
 	maxLives: number
 	numberOfPicks: number
 	players: CupStandingsPlayer[]
+}
+
+export interface CupLadderBacker {
+	playerId: string
+	playerName: string
+	confidenceRank: number
+	result: 'win' | 'saved_by_life' | 'loss' | 'pending' | 'hidden' | 'upset-pending' | 'last-life'
+	livesGained: number
+	livesSpent: number
+}
+
+export interface CupLadderFixture {
+	id: string
+	homeTeam: { shortName: string; name: string; badgeUrl: string | null; color: string | null }
+	awayTeam: { shortName: string; name: string; badgeUrl: string | null; color: string | null }
+	kickoff: Date | null
+	homeScore: number | null
+	awayScore: number | null
+	tierDifference: number
+	plusN: number
+	heart: boolean
+	actualOutcome: 'home_win' | 'draw' | 'away_win' | null
+	homeBackers: CupLadderBacker[]
+	awayBackers: CupLadderBacker[]
+	crucial: boolean
+}
+
+export interface CupLadderData extends CupStandingsData {
+	fixtures: CupLadderFixture[]
 }
 
 export async function getCupStandingsData(
@@ -179,4 +209,111 @@ export function computeStreak(picks: CupStandingsPick[]): number {
 		else break
 	}
 	return streak
+}
+
+/**
+ * A fixture is "crucial" for the cup ladder when it hasn't played yet AND
+ * either splits the backing table (at least one player on each side) OR has
+ * at least one no-lives-remaining player's pick on it.
+ */
+export function isCrucial(
+	fixture: { actualOutcome: 'home_win' | 'draw' | 'away_win' | null },
+	backers: { homeBackers: CupLadderBacker[]; awayBackers: CupLadderBacker[] },
+	players: CupStandingsPlayer[],
+): boolean {
+	if (fixture.actualOutcome != null) return false
+	const homeCount = backers.homeBackers.length
+	const awayCount = backers.awayBackers.length
+	if (homeCount >= 1 && awayCount >= 1) return true
+	const allBackers = [...backers.homeBackers, ...backers.awayBackers]
+	for (const b of allBackers) {
+		const player = players.find((p) => p.id === b.playerId)
+		if (player && player.livesRemaining === 0) return true
+	}
+	return false
+}
+
+export async function getCupLadderData(
+	gameId: string,
+	viewerUserId: string,
+): Promise<CupLadderData | null> {
+	const base = await getCupStandingsData(gameId, viewerUserId)
+	if (!base) return null
+
+	// Re-fetch the round fixtures so we have team details + scores.
+	const g = await db.query.game.findFirst({
+		where: (t, { eq: eqOp }) => eqOp(t.id, gameId),
+		with: {
+			competition: true,
+			currentRound: {
+				with: { fixtures: { with: { homeTeam: true, awayTeam: true } } },
+			},
+		},
+	})
+	if (!g?.currentRound) return null
+
+	const fixturesRaw = g.currentRound.fixtures
+
+	const fixtures: CupLadderFixture[] = fixturesRaw.map((fx) => {
+		const tierFromHome = computeTierDifference(fx.homeTeam, fx.awayTeam, g.competition.type)
+		const plusN = Math.abs(tierFromHome)
+		const heart = plusN >= 2
+
+		const actualOutcome: 'home_win' | 'draw' | 'away_win' | null =
+			fx.homeScore != null && fx.awayScore != null
+				? determineFixtureOutcome(fx.homeScore, fx.awayScore)
+				: null
+
+		const homeBackers: CupLadderBacker[] = []
+		const awayBackers: CupLadderBacker[] = []
+
+		for (const player of base.players) {
+			for (const pk of player.picks) {
+				if (pk.fixtureId !== fx.id) continue
+				const backer: CupLadderBacker = {
+					playerId: player.id,
+					playerName: player.name,
+					confidenceRank: pk.confidenceRank,
+					result: pk.result === 'restricted' ? 'pending' : pk.result,
+					livesGained: pk.livesGained,
+					livesSpent: pk.livesSpent,
+				}
+				if (pk.pickedSide === 'home') homeBackers.push(backer)
+				else awayBackers.push(backer)
+			}
+		}
+
+		const crucial = isCrucial({ actualOutcome }, { homeBackers, awayBackers }, base.players)
+
+		return {
+			id: fx.id,
+			homeTeam: {
+				shortName: fx.homeTeam.shortName,
+				name: fx.homeTeam.name,
+				badgeUrl: fx.homeTeam.badgeUrl ?? null,
+				color: fx.homeTeam.primaryColor ?? null,
+			},
+			awayTeam: {
+				shortName: fx.awayTeam.shortName,
+				name: fx.awayTeam.name,
+				badgeUrl: fx.awayTeam.badgeUrl ?? null,
+				color: fx.awayTeam.primaryColor ?? null,
+			},
+			kickoff: fx.kickoff ?? null,
+			homeScore: fx.homeScore ?? null,
+			awayScore: fx.awayScore ?? null,
+			tierDifference: tierFromHome,
+			plusN,
+			heart,
+			actualOutcome,
+			homeBackers,
+			awayBackers,
+			crucial,
+		}
+	})
+
+	return {
+		...base,
+		fixtures,
+	}
 }

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -95,6 +95,7 @@ export async function getGameDetail(gameId: string, userId: string) {
 		id: gameData.id,
 		name: gameData.name,
 		gameMode: gameData.gameMode,
+		modeConfig: gameData.modeConfig,
 		status: gameData.status,
 		competition: gameData.competition,
 		currentRound: gameData.currentRound,

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -3,9 +3,17 @@ import type { ClassicPickFixture } from '@/components/picks/classic-pick'
 import type { FormResult } from '@/components/picks/form-dots'
 import type { GridCell, GridPlayer, GridRound } from '@/components/standings/progress-grid'
 import { db } from '@/lib/db'
+import {
+	buildChainSlots,
+	buildPlannerRounds,
+	type ChainPastPickRow,
+	type ChainPlannedPickRow,
+	type ChainRoundRow,
+	type FutureRoundRow,
+} from '@/lib/game/classic-planner-view'
 import { calculatePot } from '@/lib/game-logic/prizes'
-import { fixture, round } from '@/lib/schema/competition'
-import { game, pick } from '@/lib/schema/game'
+import { fixture, round, team } from '@/lib/schema/competition'
+import { game, pick, plannedPick } from '@/lib/schema/game'
 
 export async function getGameDetail(gameId: string, userId: string) {
 	const gameData = await db.query.game.findFirst({
@@ -650,4 +658,164 @@ export async function getLivePayload(gameId: string, viewerUserId: string) {
 		viewerUserId,
 		updatedAt: new Date().toISOString(),
 	}
+}
+
+/**
+ * Load everything needed to render the classic-pick chain ribbon and the
+ * planner section: all rounds in the competition, the player's own past and
+ * planned picks (with team metadata), and every upcoming round's fixtures.
+ */
+export async function getClassicPlannerData(
+	gameId: string,
+	gamePlayerId: string,
+	currentRoundId: string | null,
+) {
+	const gameData = await db.query.game.findFirst({
+		where: eq(game.id, gameId),
+		with: {
+			competition: {
+				with: {
+					rounds: {
+						orderBy: (r, { asc }) => asc(r.number),
+						with: { fixtures: { with: { homeTeam: true, awayTeam: true } } },
+					},
+				},
+			},
+		},
+	})
+	if (!gameData) return null
+
+	// Pull the player's picks (all rounds) and plans in parallel.
+	const [playerPicks, playerPlans] = await Promise.all([
+		db.query.pick.findMany({
+			where: and(eq(pick.gameId, gameId), eq(pick.gamePlayerId, gamePlayerId)),
+			with: { round: true, team: true },
+		}),
+		db.query.plannedPick.findMany({
+			where: eq(plannedPick.gamePlayerId, gamePlayerId),
+			with: { round: true, team: true },
+		}),
+	])
+
+	const rounds: ChainRoundRow[] = gameData.competition.rounds.map((r) => ({
+		id: r.id,
+		number: r.number,
+		name: r.name,
+		status: r.status,
+	}))
+
+	// Past picks are every pick for a round that isn't the current round (i.e.
+	// something already in the past — draws/losses/wins/saves). We include the
+	// current-round pick separately so the ribbon can render it as 'current'.
+	const pastPicks: ChainPastPickRow[] = playerPicks
+		.filter((p) => p.roundId !== currentRoundId)
+		.map((p) => ({
+			roundId: p.roundId,
+			teamId: p.teamId,
+			result: p.result,
+			teamShortName: p.team.shortName,
+			teamColour: p.team.primaryColor,
+		}))
+
+	const currentPickRow = currentRoundId
+		? playerPicks.find((p) => p.roundId === currentRoundId)
+		: undefined
+	const currentPick = currentPickRow
+		? {
+				roundId: currentPickRow.roundId,
+				teamShortName: currentPickRow.team.shortName,
+				teamColour: currentPickRow.team.primaryColor,
+			}
+		: null
+
+	const plannedPicksChain: ChainPlannedPickRow[] = playerPlans.map((p) => ({
+		roundId: p.roundId,
+		teamId: p.teamId,
+		autoSubmit: p.autoSubmit,
+		teamShortName: p.team.shortName,
+		teamColour: p.team.primaryColor,
+	}))
+
+	const upcomingRoundsFixturesTbc = new Set<string>()
+	for (const r of gameData.competition.rounds) {
+		if (r.status === 'upcoming' && r.fixtures.length === 0) {
+			upcomingRoundsFixturesTbc.add(r.id)
+		}
+	}
+
+	// Count distinct teams in the competition. We derive this from the team
+	// table joined on this competition's fixtures — any team appearing in a
+	// fixture counts as "in the competition".
+	const teamRows = await db
+		.selectDistinct({ id: team.id })
+		.from(team)
+		.innerJoin(fixture, or(eq(fixture.homeTeamId, team.id), eq(fixture.awayTeamId, team.id)))
+		.innerJoin(round, eq(round.id, fixture.roundId))
+		.where(eq(round.competitionId, gameData.competition.id))
+	const totalTeams = teamRows.length
+
+	const chain = buildChainSlots({
+		rounds,
+		pastPicks,
+		currentPick,
+		plannedPicks: plannedPicksChain,
+		currentRoundId,
+		upcomingRoundsFixturesTbc,
+		totalTeams,
+	})
+
+	// Build future-round inputs: every upcoming round, whether its fixtures
+	// are published or not. The PlannerRound component handles the TBC case.
+	const futureRoundRows: FutureRoundRow[] = gameData.competition.rounds
+		.filter((r) => r.status === 'upcoming')
+		.map((r) => ({
+			id: r.id,
+			number: r.number,
+			name: r.name,
+			deadline: r.deadline,
+			fixtures: r.fixtures.map((f) => ({
+				id: f.id,
+				kickoff: f.kickoff,
+				homeTeam: {
+					id: f.homeTeam.id,
+					name: f.homeTeam.name,
+					shortName: f.homeTeam.shortName,
+					badgeUrl: f.homeTeam.badgeUrl,
+					primaryColor: f.homeTeam.primaryColor,
+				},
+				awayTeam: {
+					id: f.awayTeam.id,
+					name: f.awayTeam.name,
+					shortName: f.awayTeam.shortName,
+					badgeUrl: f.awayTeam.badgeUrl,
+					primaryColor: f.awayTeam.primaryColor,
+				},
+			})),
+		}))
+
+	// Past picks & plans keyed by round number (for the "USED GW3" labels).
+	const pastPicksForPlanner = playerPicks
+		.filter((p) => p.roundId !== currentRoundId && p.round)
+		.map((p) => ({ roundNumber: p.round.number, teamId: p.teamId }))
+	// Treat the current-round pick as "used" in future planner views too.
+	if (currentPickRow?.round) {
+		pastPicksForPlanner.push({
+			roundNumber: currentPickRow.round.number,
+			teamId: currentPickRow.teamId,
+		})
+	}
+	const plannedPicksForPlanner = playerPlans.map((p) => ({
+		roundId: p.roundId,
+		roundNumber: p.round.number,
+		teamId: p.teamId,
+		autoSubmit: p.autoSubmit,
+	}))
+
+	const futureRounds = buildPlannerRounds({
+		futureRounds: futureRoundRows,
+		pastPicks: pastPicksForPlanner,
+		plannedPicks: plannedPicksForPlanner,
+	})
+
+	return { chain, futureRounds }
 }

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -14,6 +14,7 @@ import {
 import { calculatePot } from '@/lib/game-logic/prizes'
 import { fixture, round, team } from '@/lib/schema/competition'
 import { game, pick, plannedPick } from '@/lib/schema/game'
+import { payment } from '@/lib/schema/payment'
 
 export async function getGameDetail(gameId: string, userId: string) {
 	const gameData = await db.query.game.findFirst({
@@ -32,7 +33,10 @@ export async function getGameDetail(gameId: string, userId: string) {
 	const isAdmin = gameData.createdBy === userId
 	const isMember = !!myMembership
 
-	const pot = calculatePot(gameData.entryFee, gameData.players.length)
+	const payments = await db.query.payment.findMany({
+		where: eq(payment.gameId, gameId),
+	})
+	const pot = calculatePot(payments)
 
 	return {
 		id: gameData.id,
@@ -605,7 +609,10 @@ export async function getProgressGridData(
 
 	const aliveCount = players.filter((p) => p.status === 'alive').length
 	const eliminatedCount = players.filter((p) => p.status === 'eliminated').length
-	const pot = calculatePot(gameData.entryFee, gameData.players.length)
+	const payments = await db.query.payment.findMany({
+		where: eq(payment.gameId, gameId),
+	})
+	const pot = calculatePot(payments).total
 
 	return { rounds, players, aliveCount, eliminatedCount, pot }
 }

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -38,6 +38,59 @@ export async function getGameDetail(gameId: string, userId: string) {
 	})
 	const pot = calculatePot(payments)
 
+	// Resolve user names for every player + the admin so payment UI can show names.
+	const { user } = await import('@/lib/schema/auth')
+	const relevantUserIds = Array.from(
+		new Set([gameData.createdBy, ...gameData.players.map((p) => p.userId)]),
+	)
+	const userRows =
+		relevantUserIds.length > 0
+			? await db
+					.select({ id: user.id, name: user.name })
+					.from(user)
+					.where(inArray(user.id, relevantUserIds))
+			: []
+	const userNames = new Map(userRows.map((u) => [u.id, u.name]))
+	const creatorName = userNames.get(gameData.createdBy) ?? 'the admin'
+
+	// Group payments by userId so we can mark duplicates (rebuys) for UI.
+	const paymentsByUser = new Map<string, typeof payments>()
+	for (const p of payments) {
+		const list = paymentsByUser.get(p.userId) ?? []
+		list.push(p)
+		paymentsByUser.set(p.userId, list)
+	}
+
+	// Viewer's primary (earliest) payment row — the one the claim endpoint targets.
+	const myPaymentRows = [...(paymentsByUser.get(userId) ?? [])].sort(
+		(a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+	)
+	const myPayment = myPaymentRows[0]
+		? {
+				status: myPaymentRows[0].status as 'pending' | 'claimed' | 'paid' | 'refunded',
+				amount: myPaymentRows[0].amount,
+			}
+		: null
+
+	// Full list of payments (one row per payment record) with user name + isRebuy
+	// flag. Viewer's own payments are excluded from otherPayments.
+	const allPayments = Array.from(paymentsByUser.entries()).flatMap(([uid, rows]) => {
+		const sorted = [...rows].sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+		return sorted.map((row, idx) => ({
+			userId: uid,
+			userName: userNames.get(uid) ?? 'Player',
+			amount: row.amount,
+			status: row.status as 'pending' | 'claimed' | 'paid' | 'refunded',
+			isRebuy: idx > 0,
+			claimedAt: row.claimedAt,
+			paidAt: row.paidAt,
+		}))
+	})
+	const otherPayments = allPayments
+		.filter((p) => p.userId !== userId)
+		.map((p) => ({ userName: p.userName, status: p.status, isRebuy: p.isRebuy }))
+	const adminPayments = isAdmin ? allPayments : undefined
+
 	return {
 		id: gameData.id,
 		name: gameData.name,
@@ -53,6 +106,10 @@ export async function getGameDetail(gameId: string, userId: string) {
 		myMembership,
 		isAdmin,
 		isMember,
+		creatorName,
+		myPayment,
+		otherPayments,
+		adminPayments,
 	}
 }
 

--- a/src/lib/game/planned-picks.test.ts
+++ b/src/lib/game/planned-picks.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { computeUsedTeamIds, validatePlannedPick } from './planned-picks'
+
+describe('computeUsedTeamIds', () => {
+	it('returns teams used in completed past rounds', () => {
+		const used = computeUsedTeamIds({
+			pastPicks: [
+				{ roundNumber: 1, teamId: 't-ars' },
+				{ roundNumber: 2, teamId: 't-liv' },
+			],
+			plannedPicks: [],
+			excludeRoundNumber: 5,
+		})
+		expect([...used]).toEqual(['t-ars', 't-liv'])
+	})
+
+	it('includes planned picks from other rounds', () => {
+		const used = computeUsedTeamIds({
+			pastPicks: [{ roundNumber: 1, teamId: 't-ars' }],
+			plannedPicks: [
+				{ roundNumber: 4, teamId: 't-che' },
+				{ roundNumber: 5, teamId: 't-mci' },
+			],
+			excludeRoundNumber: 5,
+		})
+		expect([...used]).toEqual(['t-ars', 't-che'])
+	})
+
+	it('excludes the target round so the user can change their own plan', () => {
+		const used = computeUsedTeamIds({
+			pastPicks: [],
+			plannedPicks: [{ roundNumber: 5, teamId: 't-ars' }],
+			excludeRoundNumber: 5,
+		})
+		expect([...used]).toEqual([])
+	})
+})
+
+describe('validatePlannedPick', () => {
+	it('allows a pick of an unused team', () => {
+		expect(
+			validatePlannedPick({
+				teamId: 't-che',
+				roundNumber: 5,
+				pastPicks: [{ roundNumber: 1, teamId: 't-ars' }],
+				plannedPicks: [{ roundNumber: 4, teamId: 't-liv' }],
+			}),
+		).toEqual({ valid: true })
+	})
+
+	it('rejects when team was used in a past round', () => {
+		expect(
+			validatePlannedPick({
+				teamId: 't-ars',
+				roundNumber: 5,
+				pastPicks: [{ roundNumber: 1, teamId: 't-ars' }],
+				plannedPicks: [],
+			}),
+		).toEqual({ valid: false, reason: 'team-already-used', roundNumber: 1 })
+	})
+
+	it('rejects when team is already planned for another round', () => {
+		expect(
+			validatePlannedPick({
+				teamId: 't-che',
+				roundNumber: 5,
+				pastPicks: [],
+				plannedPicks: [{ roundNumber: 3, teamId: 't-che' }],
+			}),
+		).toEqual({ valid: false, reason: 'team-already-planned', roundNumber: 3 })
+	})
+
+	it('allows replacing the target round’s own plan', () => {
+		expect(
+			validatePlannedPick({
+				teamId: 't-che',
+				roundNumber: 5,
+				pastPicks: [],
+				plannedPicks: [{ roundNumber: 5, teamId: 't-che' }],
+			}),
+		).toEqual({ valid: true })
+	})
+})

--- a/src/lib/game/planned-picks.ts
+++ b/src/lib/game/planned-picks.ts
@@ -1,0 +1,44 @@
+export interface PastPick {
+	roundNumber: number
+	teamId: string
+}
+
+export interface PlannedPick {
+	roundNumber: number
+	teamId: string
+}
+
+export function computeUsedTeamIds(input: {
+	pastPicks: PastPick[]
+	plannedPicks: PlannedPick[]
+	excludeRoundNumber: number
+}): Set<string> {
+	const used = new Set<string>()
+	for (const p of input.pastPicks) used.add(p.teamId)
+	for (const p of input.plannedPicks) {
+		if (p.roundNumber === input.excludeRoundNumber) continue
+		used.add(p.teamId)
+	}
+	return used
+}
+
+export type ValidationResult =
+	| { valid: true }
+	| { valid: false; reason: 'team-already-used' | 'team-already-planned'; roundNumber: number }
+
+export function validatePlannedPick(input: {
+	teamId: string
+	roundNumber: number
+	pastPicks: PastPick[]
+	plannedPicks: PlannedPick[]
+}): ValidationResult {
+	const pastHit = input.pastPicks.find((p) => p.teamId === input.teamId)
+	if (pastHit)
+		return { valid: false, reason: 'team-already-used', roundNumber: pastHit.roundNumber }
+	const planHit = input.plannedPicks.find(
+		(p) => p.teamId === input.teamId && p.roundNumber !== input.roundNumber,
+	)
+	if (planHit)
+		return { valid: false, reason: 'team-already-planned', roundNumber: planHit.roundNumber }
+	return { valid: true }
+}

--- a/src/lib/game/process-round.ts
+++ b/src/lib/game/process-round.ts
@@ -2,6 +2,7 @@ import { and, eq } from 'drizzle-orm'
 import { db } from '@/lib/db'
 import { processClassicRound } from '@/lib/game-logic/classic'
 import { evaluateCupPicks } from '@/lib/game-logic/cup'
+import { computeTierDifference } from '@/lib/game-logic/cup-tier'
 import { calculateTurboStandings, evaluateTurboPicks } from '@/lib/game-logic/turbo'
 import {
 	computeWcClassicAutoElims,
@@ -24,7 +25,11 @@ export async function processGameRound(
 
 	const roundData = await db.query.round.findFirst({
 		where: eq(round.id, roundId),
-		with: { fixtures: true },
+		with: {
+			fixtures: {
+				with: { homeTeam: true, awayTeam: true },
+			},
+		},
 	})
 	if (!roundData) throw new Error(`Round ${roundId} not found`)
 
@@ -195,12 +200,15 @@ export async function processGameRound(
 				.map((pk) => {
 					const f = roundData.fixtures.find((fx) => fx.id === pk.fixtureId)
 					const pickedTeam: 'home' | 'away' = pk.teamId === f?.homeTeamId ? 'home' : 'away'
+					const tierDifference = f
+						? computeTierDifference(f.homeTeam, f.awayTeam, gameData.competition.type)
+						: 0
 					return {
 						confidenceRank: pk.confidenceRank ?? 0,
 						pickedTeam,
 						homeScore: f?.homeScore ?? 0,
 						awayScore: f?.awayScore ?? 0,
-						tierDifference: 0, // TODO: store tier_difference on fixture in cup competitions
+						tierDifference,
 					}
 				})
 

--- a/src/lib/game/queries.ts
+++ b/src/lib/game/queries.ts
@@ -1,6 +1,6 @@
 import { and, eq } from 'drizzle-orm'
 import { db } from '@/lib/db'
-import { calculatePot } from '@/lib/game-logic/prizes'
+import { calculatePot, type PotBreakdown } from '@/lib/game-logic/prizes'
 import { gamePlayer, pick } from '@/lib/schema/game'
 import { payment } from '@/lib/schema/payment'
 
@@ -12,7 +12,7 @@ export interface DashboardGame {
 	competition: string
 	playerCount: number
 	aliveCount: number
-	pot: string
+	pot: PotBreakdown
 	entryFee: string | null
 	myStatus: 'alive' | 'eliminated' | 'winner'
 	isAdmin: boolean
@@ -42,7 +42,12 @@ export async function getMyGames(userId: string): Promise<DashboardGame[]> {
 	for (const membership of memberships) {
 		const g = membership.game
 		const aliveCount = g.players.filter((p) => p.status === 'alive').length
-		const pot = calculatePot(g.entryFee, g.players.length)
+
+		// Load payments for this game once and use them for pot + unpaidCount.
+		const payments = await db.query.payment.findMany({
+			where: eq(payment.gameId, g.id),
+		})
+		const pot = calculatePot(payments)
 
 		let myPickSubmitted = false
 		if (g.currentRoundId) {
@@ -59,9 +64,6 @@ export async function getMyGames(userId: string): Promise<DashboardGame[]> {
 		let unpaidCount = 0
 		const winnerName: string | null = null
 		if (g.createdBy === userId) {
-			const payments = await db.query.payment.findMany({
-				where: eq(payment.gameId, g.id),
-			})
 			unpaidCount = payments.filter((p) => p.status !== 'paid').length
 		}
 

--- a/src/lib/schema/payment.ts
+++ b/src/lib/schema/payment.ts
@@ -4,7 +4,12 @@ import { game } from './game'
 
 // -- Enums --
 
-export const paymentStatusEnum = pgEnum('payment_status', ['pending', 'paid', 'refunded'])
+export const paymentStatusEnum = pgEnum('payment_status', [
+	'pending',
+	'claimed',
+	'paid',
+	'refunded',
+])
 
 export const paymentMethodEnum = pgEnum('payment_method', ['manual', 'mangopay'])
 
@@ -21,6 +26,7 @@ export const payment = pgTable('payment', {
 	amount: numeric('amount', { precision: 10, scale: 2 }).notNull(),
 	status: paymentStatusEnum('status').notNull().default('pending'),
 	method: paymentMethodEnum('method').notNull().default('manual'),
+	claimedAt: timestamp('claimed_at'),
 	paidAt: timestamp('paid_at'),
 	createdAt: timestamp('created_at').defaultNow().notNull(),
 })


### PR DESCRIPTION
## Summary

Phase 4b delivers the player-facing surfaces needed for cup mode, classic-mode strategy play, and payment tracking — the last major feature block before the Phase 4.5 launch phase.

**Three internally-ordered sub-phases on one branch:**
- **4b1 — Cup mode UI** (16 commits): tier/heart/+N atoms, lives summary, extended fixture-row, cup-pick interface, cup tier-diff helper, restricted-pick API error, cup standings (grid/ladder/timeline + tab wrapper), game-page + game-detail wiring, dev seed.
- **4b2 — Classic pick planner** (9 commits): chain ribbon, planned-picks pure validation, GET/POST/DELETE API, planner-round card, classic-pick integration, QStash auto-submit plumbing (enqueue helper + handler case + daily-sync round-transition detection).
- **4b3 — Payment claim flow** (13 commits): `claimed` status enum + `claimed_at` column migration, `calculatePot` rewrite with `PotBreakdown` (breaking signature), caller updates, claim/confirm/reject/override API routes, my-payment-strip + other-players-payments + WhatsApp reminder + admin payments-panel + game-header pot split + full wiring.
- **+ 1 latent fix** surfaced during verification: expose `modeConfig` from `getGameDetail` so `startingLives` / `numberOfPicks` stop falling back to defaults.
- **+ 1 critical review-catch fix**: `process-round.ts` was hardcoding `tierDifference: 0` when calling `evaluateCupPicks`, so cup upset-win life awards would never fire. Now passes real tier via `computeTierDifference`.

**Stats:** 39 commits, 62 files changed (+6482 / −154). Lint clean, typecheck clean, 196/196 tests passing (baseline was 135 pre-branch).

## Known deferrals

- **GH Actions live-scores workflow continues to fail** until Phase 4.5 sets `CRON_SECRET` + `VERCEL_PROD_URL` repo secrets. Intentional canary.
- **Auto-submit lands dormant** — first real firing needs QStash live webhook (Phase 4.5).
- **Cup tier-mechanic visual verification deferred** to Phase 4.5 against real WC data (dev seed uses PL where tier diff = 0).
- **Planned-pick cascade cleanup on real-pick loss** not implemented (plan flagged as follow-up).

## Follow-ups logged (non-blocking)

- Payment admin routes should switch to `paymentId`-keyed lookups before rebuys ship (Phase 4c).
- Shared `computeUpsetLives` helper to unify cup tier-diff rule between `cup-pick` compose-time and `cup-standings-queries` read-time.
- Direct unit tests for `submitPlannedPick` and `classic-planner-view` builders.
- Payment API error codes — standardise on short kebab codes across all four endpoints.

## Test plan

- [ ] `pnpm install` then `just dev` — confirm dev server starts.
- [ ] Seed includes a cup-mode game ("Cup Tuesday (GW7)") — verify it renders with cup-pick + cup-standings tab wrapper (Ladder / Grid / Timeline).
- [ ] Classic pick page — verify chain ribbon above, collapsible planner below with localStorage-persisted open state.
- [ ] Payment strip visible on game detail page for a member; admin panel visible to creator only.
- [ ] Mark-as-paid → creator confirm → status chips update correctly after `router.refresh()`.
- [ ] `pnpm exec tsc --noEmit` and `pnpm exec vitest run` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)