### PR TITLE
Phase 4c1: match-day live UI

### DIFF
--- a/.github/workflows/live-scores.yml
+++ b/.github/workflows/live-scores.yml
@@ -2,7 +2,7 @@ name: Live scores poll
 
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '* * * * *'
   workflow_dispatch:
 
 concurrency:

--- a/docs/superpowers/plans/2026-04-24-phase-4c1-live-match-day.md
+++ b/docs/superpowers/plans/2026-04-24-phase-4c1-live-match-day.md
@@ -1,0 +1,1800 @@
+# Phase 4c1: Match-Day Live UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver the client-side polling layer, live score ticker, goal celebrations, pick-row enrichment, and elimination fade that make the app feel alive during match windows — without WebSockets, a new data provider, or a server-side events table.
+
+**Architecture:** A single new React context (`<LiveProvider>`) polls the existing `/api/games/[id]/live` endpoint on an adaptive timer (30s during match windows, 5min otherwise), diffs consecutive payloads to emit synthetic goal + elimination events, and exposes state via `useLiveGame()`. UI components subscribe to render the ticker and apply enrichment overlays. One cron cadence change on the GitHub Actions workflow bumps server freshness from 5min to 1min.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript 5.7, Tailwind v4, lucide-react, Vitest. No new dependencies.
+
+**Design spec:** `docs/superpowers/specs/2026-04-24-phase-4c1-live-match-day-design.md`
+
+---
+
+## Scope
+
+Single sub-phase (4c1), one feature branch (`feature/phase-4c1-live-match-day`). Merges dormant onto `main`; runtime verification happens in Phase 4.5.
+
+## File structure
+
+### Created
+
+| Path | Responsibility |
+|---|---|
+| `src/lib/live/types.ts` | Shared TypeScript types — `LivePayload`, `GoalEvent`, `PickSettlementEvent`. Frozen contract between server `getLivePayload` and all client consumers. |
+| `src/lib/live/derive.ts` | Pure functions — `deriveMatchState`, `projectPickOutcome`. |
+| `src/lib/live/derive.test.ts` | Tests for `derive.ts`. |
+| `src/lib/live/detect.ts` | Pure functions — `detectGoalDeltas`, `detectPickSettlements`. |
+| `src/lib/live/detect.test.ts` | Tests for `detect.ts`. |
+| `src/components/live/live-provider.tsx` | React context + poll timer + fetch + diff + error state. Owns all live-state side effects. |
+| `src/components/live/use-live-game.ts` | Hook reading from context. Public API for consumers. |
+| `src/components/live/use-live-game.test.ts` | Hook tests using `@testing-library/react` + `vi.useFakeTimers`. |
+| `src/components/live/live-score-ticker.tsx` | Top-of-page horizontal strip. Composes `<LiveFixtureCard>` per fixture. Hides when no fixture in window. |
+| `src/components/live/live-fixture-card.tsx` | Per-fixture card: badges, scores, status pill, "My pick" tag, celebration state wiring. |
+| `src/components/live/goal-celebration.tsx` | Decorator managing celebration CSS classes + floating chip via `setTimeout`. |
+| `src/components/live/live-indicators.tsx` | Small shared atoms: `<LiveDot>`, `<ReconnectingChip>`. |
+
+### Modified
+
+- `src/components/game/game-detail-view.tsx` — wrap children in `<LiveProvider>`, render `<LiveScoreTicker>` above existing content.
+- `src/components/standings/cup-grid.tsx` — accept optional `live?: LivePayload` prop; apply viewer-row enrichment + score-bump badges + elimination fade.
+- `src/components/standings/cup-ladder.tsx` — same `live` prop pattern; live fixture cards show live scores.
+- `src/components/standings/cup-timeline.tsx` — same pattern.
+- `src/components/standings/cup-standings.tsx` — tab wrapper threads `live` through to active tab's component.
+- `src/components/game/turbo-standings.tsx` — same `live` pattern.
+- `src/components/standings/progress-grid.tsx` — classic-mode equivalent; same pattern.
+- `.github/workflows/live-scores.yml` — cron cadence `'*/5 * * * *'` → `'* * * * *'`.
+- `scripts/seed.ts` — add a mid-match cup game for dev verification.
+
+## Execution order
+
+Tasks are numbered to match the intended sequence. Within each task, steps run top-to-bottom; TDD is used wherever there's pure logic to test.
+
+---
+
+## Part A — Pure types and logic
+
+### Task 1: Shared types module
+
+**Files:**
+- Create: `src/lib/live/types.ts`
+
+Shared TypeScript types that frame the client/server contract. Every other file in `src/lib/live/` and `src/components/live/` imports from here.
+
+- [ ] **Step 1: Implement types**
+
+```typescript
+// src/lib/live/types.ts
+export type FixtureStatus = 'scheduled' | 'live' | 'finished' | 'postponed' | 'halftime'
+
+export type PickResultState =
+	| 'win'
+	| 'loss'
+	| 'draw'
+	| 'saved_by_life'
+	| 'hidden'
+	| 'restricted'
+	| 'pending'
+
+export interface LiveFixture {
+	id: string
+	kickoff: Date | string | null
+	homeScore: number | null
+	awayScore: number | null
+	status: FixtureStatus
+	homeShort: string
+	awayShort: string
+}
+
+export interface LivePick {
+	gamePlayerId: string
+	fixtureId: string | null
+	teamId: string | null
+	confidenceRank: number | null
+	predictedResult: 'home_win' | 'away_win' | 'draw' | null
+	result: PickResultState | null
+}
+
+export interface LivePlayer {
+	id: string
+	userId: string
+	status: 'active' | 'eliminated'
+	livesRemaining: number
+}
+
+export interface LivePayload {
+	gameId: string
+	gameMode: 'classic' | 'turbo' | 'cup'
+	roundId: string | null
+	fixtures: LiveFixture[]
+	picks: LivePick[]
+	players: LivePlayer[]
+	viewerUserId: string
+	updatedAt: string
+}
+
+export interface GoalEvent {
+	id: string
+	fixtureId: string
+	side: 'home' | 'away'
+	newScore: number
+	previousScore: number
+	observedAt: number
+}
+
+export interface PickSettlementEvent {
+	id: string
+	gamePlayerId: string
+	roundId: string
+	result: 'settled-win' | 'settled-loss' | 'saved-by-life'
+	observedAt: number
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/live/types.ts
+git commit -m "feat(live): add shared live-state types"
+```
+
+---
+
+### Task 2: `deriveMatchState` + `projectPickOutcome`
+
+**Files:**
+- Create: `src/lib/live/derive.ts`
+- Create: `src/lib/live/derive.test.ts`
+
+Pure functions that classify a fixture's live state and project a pick's current outcome from the live score.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// src/lib/live/derive.test.ts
+import { describe, expect, it } from 'vitest'
+import { deriveMatchState, projectPickOutcome } from './derive'
+import type { LiveFixture, LivePick } from './types'
+
+function fx(overrides: Partial<LiveFixture> = {}): LiveFixture {
+	return {
+		id: 'fx1',
+		kickoff: new Date('2026-06-11T19:00:00Z'),
+		homeScore: null,
+		awayScore: null,
+		status: 'scheduled',
+		homeShort: 'ENG',
+		awayShort: 'FRA',
+		...overrides,
+	}
+}
+
+describe('deriveMatchState', () => {
+	it('returns pre when kickoff is more than 10 minutes away', () => {
+		const now = new Date('2026-06-11T18:49:00Z')
+		expect(deriveMatchState(fx(), now)).toBe('pre')
+	})
+
+	it('returns live when kickoff is within 10m before and status is scheduled', () => {
+		const now = new Date('2026-06-11T18:55:00Z')
+		expect(deriveMatchState(fx(), now)).toBe('live')
+	})
+
+	it('returns live when status is live', () => {
+		const now = new Date('2026-06-11T19:30:00Z')
+		expect(deriveMatchState(fx({ status: 'live' }), now)).toBe('live')
+	})
+
+	it('returns ht when status is halftime', () => {
+		const now = new Date('2026-06-11T19:45:00Z')
+		expect(deriveMatchState(fx({ status: 'halftime' }), now)).toBe('ht')
+	})
+
+	it('returns ft when status is finished', () => {
+		const now = new Date('2026-06-11T21:30:00Z')
+		expect(deriveMatchState(fx({ status: 'finished' }), now)).toBe('ft')
+	})
+
+	it('returns ft when kickoff is more than 2.5h ago regardless of status', () => {
+		const now = new Date('2026-06-11T22:00:00Z')
+		expect(deriveMatchState(fx(), now)).toBe('ft')
+	})
+
+	it('returns pre when kickoff is null', () => {
+		expect(deriveMatchState(fx({ kickoff: null }), new Date())).toBe('pre')
+	})
+})
+
+describe('projectPickOutcome', () => {
+	const homeWin: LivePick = {
+		gamePlayerId: 'gp1',
+		fixtureId: 'fx1',
+		teamId: 't-home',
+		confidenceRank: 1,
+		predictedResult: 'home_win',
+		result: null,
+	}
+
+	it('returns winning when home pick and home leads', () => {
+		expect(
+			projectPickOutcome(homeWin, fx({ homeScore: 1, awayScore: 0, status: 'live' }), 'classic'),
+		).toBe('winning')
+	})
+
+	it('returns losing when home pick and away leads', () => {
+		expect(
+			projectPickOutcome(homeWin, fx({ homeScore: 0, awayScore: 1, status: 'live' }), 'classic'),
+		).toBe('losing')
+	})
+
+	it('returns drawing when scores level during live match', () => {
+		expect(
+			projectPickOutcome(homeWin, fx({ homeScore: 1, awayScore: 1, status: 'live' }), 'classic'),
+		).toBe('drawing')
+	})
+
+	it('returns settled-win when status finished and home wins', () => {
+		expect(
+			projectPickOutcome(homeWin, fx({ homeScore: 2, awayScore: 1, status: 'finished' }), 'classic'),
+		).toBe('settled-win')
+	})
+
+	it('returns settled-loss when status finished and home loses', () => {
+		expect(
+			projectPickOutcome(homeWin, fx({ homeScore: 0, awayScore: 1, status: 'finished' }), 'classic'),
+		).toBe('settled-loss')
+	})
+
+	it('returns saved-by-life when pick result is saved_by_life', () => {
+		expect(
+			projectPickOutcome({ ...homeWin, result: 'saved_by_life' }, fx({ status: 'finished' }), 'cup'),
+		).toBe('saved-by-life')
+	})
+
+	it('returns winning for away pick when away leads', () => {
+		const awayWin: LivePick = { ...homeWin, predictedResult: 'away_win' }
+		expect(
+			projectPickOutcome(awayWin, fx({ homeScore: 0, awayScore: 1, status: 'live' }), 'classic'),
+		).toBe('winning')
+	})
+})
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pnpm exec vitest run src/lib/live/derive.test.ts`
+Expected: FAIL with "cannot find module ./derive".
+
+- [ ] **Step 3: Implement `derive.ts`**
+
+```typescript
+// src/lib/live/derive.ts
+import type { LiveFixture, LivePick } from './types'
+
+const LIVE_WINDOW_BEFORE_MS = 10 * 60 * 1000
+const LIVE_WINDOW_AFTER_MS = 150 * 60 * 1000
+
+export function deriveMatchState(
+	fixture: LiveFixture,
+	now: Date = new Date(),
+): 'pre' | 'live' | 'ht' | 'ft' {
+	if (fixture.status === 'halftime') return 'ht'
+	if (fixture.status === 'finished') return 'ft'
+
+	if (!fixture.kickoff) return 'pre'
+	const kickoffMs = typeof fixture.kickoff === 'string' ? Date.parse(fixture.kickoff) : fixture.kickoff.getTime()
+	const nowMs = now.getTime()
+
+	if (nowMs < kickoffMs - LIVE_WINDOW_BEFORE_MS) return 'pre'
+	if (nowMs > kickoffMs + LIVE_WINDOW_AFTER_MS) return 'ft'
+	return 'live'
+}
+
+export type PickOutcome =
+	| 'winning'
+	| 'drawing'
+	| 'losing'
+	| 'saved-by-life'
+	| 'settled-win'
+	| 'settled-loss'
+	| 'pending'
+
+export function projectPickOutcome(
+	pick: LivePick,
+	fixture: LiveFixture,
+	_mode: 'classic' | 'turbo' | 'cup',
+): PickOutcome {
+	if (pick.result === 'saved_by_life') return 'saved-by-life'
+	if (pick.result === 'win') return 'settled-win'
+	if (pick.result === 'loss') return 'settled-loss'
+
+	const { homeScore, awayScore, status } = fixture
+	if (homeScore == null || awayScore == null) return 'pending'
+
+	const isFinished = status === 'finished'
+
+	if (pick.predictedResult === 'home_win') {
+		if (homeScore > awayScore) return isFinished ? 'settled-win' : 'winning'
+		if (homeScore < awayScore) return isFinished ? 'settled-loss' : 'losing'
+		return isFinished ? 'settled-loss' : 'drawing'
+	}
+
+	if (pick.predictedResult === 'away_win') {
+		if (awayScore > homeScore) return isFinished ? 'settled-win' : 'winning'
+		if (awayScore < homeScore) return isFinished ? 'settled-loss' : 'losing'
+		return isFinished ? 'settled-loss' : 'drawing'
+	}
+
+	if (pick.predictedResult === 'draw') {
+		if (homeScore === awayScore) return isFinished ? 'settled-win' : 'drawing'
+		return isFinished ? 'settled-loss' : 'losing'
+	}
+
+	return 'pending'
+}
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `pnpm exec vitest run src/lib/live/derive.test.ts`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/live/derive.ts src/lib/live/derive.test.ts
+git commit -m "feat(live): add deriveMatchState and projectPickOutcome pure functions"
+```
+
+---
+
+### Task 3: `detectGoalDeltas` + `detectPickSettlements`
+
+**Files:**
+- Create: `src/lib/live/detect.ts`
+- Create: `src/lib/live/detect.test.ts`
+
+Pure functions that diff consecutive `LivePayload`s into event streams.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// src/lib/live/detect.test.ts
+import { describe, expect, it } from 'vitest'
+import { detectGoalDeltas, detectPickSettlements } from './detect'
+import type { LiveFixture, LivePayload, LivePick, LivePlayer } from './types'
+
+function payload(overrides: Partial<LivePayload> = {}): LivePayload {
+	return {
+		gameId: 'g1',
+		gameMode: 'classic',
+		roundId: 'r1',
+		fixtures: [],
+		picks: [],
+		players: [],
+		viewerUserId: 'u1',
+		updatedAt: new Date().toISOString(),
+		...overrides,
+	}
+}
+
+function fx(overrides: Partial<LiveFixture> = {}): LiveFixture {
+	return {
+		id: 'fx1',
+		kickoff: new Date('2026-06-11T19:00:00Z'),
+		homeScore: 0,
+		awayScore: 0,
+		status: 'live',
+		homeShort: 'ENG',
+		awayShort: 'FRA',
+		...overrides,
+	}
+}
+
+describe('detectGoalDeltas', () => {
+	it('returns empty when no fixtures changed', () => {
+		const a = payload({ fixtures: [fx({ homeScore: 1 })] })
+		const b = payload({ fixtures: [fx({ homeScore: 1 })] })
+		expect(detectGoalDeltas(a, b)).toEqual([])
+	})
+
+	it('emits one event when home score increments', () => {
+		const a = payload({ fixtures: [fx({ homeScore: 0, awayScore: 0 })] })
+		const b = payload({ fixtures: [fx({ homeScore: 1, awayScore: 0 })] })
+		const events = detectGoalDeltas(a, b)
+		expect(events).toHaveLength(1)
+		expect(events[0].id).toBe('fx1:home:1')
+		expect(events[0].side).toBe('home')
+		expect(events[0].newScore).toBe(1)
+		expect(events[0].previousScore).toBe(0)
+	})
+
+	it('emits one event per increment when score jumps by two', () => {
+		const a = payload({ fixtures: [fx({ homeScore: 0 })] })
+		const b = payload({ fixtures: [fx({ homeScore: 2 })] })
+		const events = detectGoalDeltas(a, b)
+		expect(events).toHaveLength(2)
+		expect(events.map((e) => e.id)).toEqual(['fx1:home:1', 'fx1:home:2'])
+	})
+
+	it('never emits events for score decrements', () => {
+		const a = payload({ fixtures: [fx({ homeScore: 2 })] })
+		const b = payload({ fixtures: [fx({ homeScore: 1 })] })
+		expect(detectGoalDeltas(a, b)).toEqual([])
+	})
+
+	it('ignores transition from null to non-null (treated as initial load)', () => {
+		const a = payload({ fixtures: [fx({ homeScore: null, awayScore: null })] })
+		const b = payload({ fixtures: [fx({ homeScore: 1, awayScore: 0 })] })
+		expect(detectGoalDeltas(a, b)).toEqual([])
+	})
+
+	it('ignores non-null to null transition', () => {
+		const a = payload({ fixtures: [fx({ homeScore: 1 })] })
+		const b = payload({ fixtures: [fx({ homeScore: null })] })
+		expect(detectGoalDeltas(a, b)).toEqual([])
+	})
+
+	it('ignores fixture removed between polls', () => {
+		const a = payload({ fixtures: [fx({ homeScore: 1 })] })
+		const b = payload({ fixtures: [] })
+		expect(detectGoalDeltas(a, b)).toEqual([])
+	})
+
+	it('emits for away-side increments', () => {
+		const a = payload({ fixtures: [fx({ awayScore: 0 })] })
+		const b = payload({ fixtures: [fx({ awayScore: 1 })] })
+		const events = detectGoalDeltas(a, b)
+		expect(events).toHaveLength(1)
+		expect(events[0].side).toBe('away')
+		expect(events[0].id).toBe('fx1:away:1')
+	})
+})
+
+function pk(overrides: Partial<LivePick> = {}): LivePick {
+	return {
+		gamePlayerId: 'gp1',
+		fixtureId: 'fx1',
+		teamId: 't-home',
+		confidenceRank: 1,
+		predictedResult: 'home_win',
+		result: 'pending',
+		...overrides,
+	}
+}
+
+function pl(overrides: Partial<LivePlayer> = {}): LivePlayer {
+	return { id: 'gp1', userId: 'u1', status: 'active', livesRemaining: 1, ...overrides }
+}
+
+describe('detectPickSettlements', () => {
+	it('emits settled-loss when a pending pick transitions to loss', () => {
+		const a = payload({ picks: [pk({ result: 'pending' })], players: [pl()] })
+		const b = payload({ picks: [pk({ result: 'loss' })], players: [pl()] })
+		const events = detectPickSettlements(a, b)
+		expect(events).toHaveLength(1)
+		expect(events[0].id).toBe('gp1:r1:settled-loss')
+		expect(events[0].result).toBe('settled-loss')
+	})
+
+	it('emits settled-win on pending to win', () => {
+		const a = payload({ picks: [pk({ result: 'pending' })], players: [pl()] })
+		const b = payload({ picks: [pk({ result: 'win' })], players: [pl()] })
+		const events = detectPickSettlements(a, b)
+		expect(events).toHaveLength(1)
+		expect(events[0].result).toBe('settled-win')
+	})
+
+	it('emits saved-by-life on pending to saved_by_life', () => {
+		const a = payload({ picks: [pk({ result: 'pending' })], players: [pl()] })
+		const b = payload({ picks: [pk({ result: 'saved_by_life' })], players: [pl()] })
+		const events = detectPickSettlements(a, b)
+		expect(events).toHaveLength(1)
+		expect(events[0].result).toBe('saved-by-life')
+	})
+
+	it('does not re-emit on already-settled pick', () => {
+		const a = payload({ picks: [pk({ result: 'loss' })], players: [pl()] })
+		const b = payload({ picks: [pk({ result: 'loss' })], players: [pl()] })
+		expect(detectPickSettlements(a, b)).toEqual([])
+	})
+
+	it('does not emit for still-pending pick', () => {
+		const a = payload({ picks: [pk({ result: 'pending' })], players: [pl()] })
+		const b = payload({ picks: [pk({ result: 'pending' })], players: [pl()] })
+		expect(detectPickSettlements(a, b)).toEqual([])
+	})
+
+	it('ignores pick removed between polls', () => {
+		const a = payload({ picks: [pk({ result: 'pending' })], players: [pl()] })
+		const b = payload({ picks: [], players: [pl()] })
+		expect(detectPickSettlements(a, b)).toEqual([])
+	})
+})
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pnpm exec vitest run src/lib/live/detect.test.ts`
+Expected: FAIL with "cannot find module ./detect".
+
+- [ ] **Step 3: Implement `detect.ts`**
+
+```typescript
+// src/lib/live/detect.ts
+import type { GoalEvent, LivePayload, PickSettlementEvent } from './types'
+
+export function detectGoalDeltas(previous: LivePayload, next: LivePayload): GoalEvent[] {
+	const events: GoalEvent[] = []
+	const observedAt = Date.now()
+
+	for (const nextFx of next.fixtures) {
+		const prevFx = previous.fixtures.find((f) => f.id === nextFx.id)
+		if (!prevFx) continue
+
+		for (const side of ['home', 'away'] as const) {
+			const prevScore = side === 'home' ? prevFx.homeScore : prevFx.awayScore
+			const nextScore = side === 'home' ? nextFx.homeScore : nextFx.awayScore
+			if (prevScore == null || nextScore == null) continue
+			if (nextScore <= prevScore) continue
+
+			for (let s = prevScore + 1; s <= nextScore; s++) {
+				events.push({
+					id: `${nextFx.id}:${side}:${s}`,
+					fixtureId: nextFx.id,
+					side,
+					newScore: s,
+					previousScore: s - 1,
+					observedAt,
+				})
+			}
+		}
+	}
+	return events
+}
+
+const SETTLED_RESULTS = new Set(['win', 'loss', 'saved_by_life'])
+
+export function detectPickSettlements(
+	previous: LivePayload,
+	next: LivePayload,
+): PickSettlementEvent[] {
+	const events: PickSettlementEvent[] = []
+	const observedAt = Date.now()
+
+	for (const nextPk of next.picks) {
+		const prevPk = previous.picks.find(
+			(p) => p.gamePlayerId === nextPk.gamePlayerId && p.fixtureId === nextPk.fixtureId,
+		)
+		if (!prevPk) continue
+		if (prevPk.result === nextPk.result) continue
+		if (SETTLED_RESULTS.has(String(prevPk.result))) continue
+		if (!SETTLED_RESULTS.has(String(nextPk.result))) continue
+		if (!next.roundId) continue
+
+		const mapped =
+			nextPk.result === 'win'
+				? 'settled-win'
+				: nextPk.result === 'loss'
+					? 'settled-loss'
+					: 'saved-by-life'
+
+		events.push({
+			id: `${nextPk.gamePlayerId}:${next.roundId}:${mapped}`,
+			gamePlayerId: nextPk.gamePlayerId,
+			roundId: next.roundId,
+			result: mapped,
+			observedAt,
+		})
+	}
+	return events
+}
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `pnpm exec vitest run src/lib/live/detect.test.ts`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/live/detect.ts src/lib/live/detect.test.ts
+git commit -m "feat(live): add detectGoalDeltas and detectPickSettlements"
+```
+
+---
+
+## Part B — Provider and hook
+
+### Task 4: `LiveProvider` skeleton + `useLiveGame` hook
+
+**Files:**
+- Create: `src/components/live/live-provider.tsx`
+- Create: `src/components/live/use-live-game.ts`
+
+Context provider shell: state shape, context object, hook. No network yet — just the wiring. Keeps this task small and typecheckable; Task 5 adds the fetch loop.
+
+- [ ] **Step 1: Implement `live-provider.tsx`**
+
+```typescript
+// src/components/live/live-provider.tsx
+'use client'
+import { createContext, type ReactNode, useMemo, useState } from 'react'
+import type { GoalEvent, LivePayload, PickSettlementEvent } from '@/lib/live/types'
+
+export interface LiveContextValue {
+	payload: LivePayload | null
+	events: {
+		goals: GoalEvent[]
+		settlements: PickSettlementEvent[]
+	}
+	isStale: boolean
+	reconnecting: boolean
+}
+
+const defaultValue: LiveContextValue = {
+	payload: null,
+	events: { goals: [], settlements: [] },
+	isStale: false,
+	reconnecting: false,
+}
+
+export const LiveContext = createContext<LiveContextValue>(defaultValue)
+
+interface LiveProviderProps {
+	gameId: string
+	children: ReactNode
+}
+
+export function LiveProvider({ gameId: _gameId, children }: LiveProviderProps) {
+	const [payload] = useState<LivePayload | null>(null)
+	const value = useMemo<LiveContextValue>(
+		() => ({ payload, events: { goals: [], settlements: [] }, isStale: false, reconnecting: false }),
+		[payload],
+	)
+	return <LiveContext.Provider value={value}>{children}</LiveContext.Provider>
+}
+```
+
+- [ ] **Step 2: Implement `use-live-game.ts`**
+
+```typescript
+// src/components/live/use-live-game.ts
+'use client'
+import { useContext } from 'react'
+import { LiveContext, type LiveContextValue } from './live-provider'
+
+export function useLiveGame(): LiveContextValue {
+	return useContext(LiveContext)
+}
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/live/live-provider.tsx src/components/live/use-live-game.ts
+git commit -m "feat(live): add LiveProvider context skeleton and useLiveGame hook"
+```
+
+---
+
+### Task 5: Polling + diffing wired into `LiveProvider`
+
+**Files:**
+- Modify: `src/components/live/live-provider.tsx`
+- Create: `src/components/live/use-live-game.test.tsx`
+
+Adds the fetch loop, adaptive cadence, visibility listener, diff emission, and error handling. Large task but one coherent addition — the provider's real behaviour.
+
+- [ ] **Step 1: Write the failing hook tests**
+
+```typescript
+// src/components/live/use-live-game.test.tsx
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LivePayload } from '@/lib/live/types'
+import { LiveProvider } from './live-provider'
+import { useLiveGame } from './use-live-game'
+
+function wrapperFor(gameId: string) {
+	return function Wrapper({ children }: { children: React.ReactNode }) {
+		return <LiveProvider gameId={gameId}>{children}</LiveProvider>
+	}
+}
+
+function basePayload(overrides: Partial<LivePayload> = {}): LivePayload {
+	return {
+		gameId: 'g1',
+		gameMode: 'classic',
+		roundId: 'r1',
+		fixtures: [],
+		picks: [],
+		players: [],
+		viewerUserId: 'u1',
+		updatedAt: new Date().toISOString(),
+		...overrides,
+	}
+}
+
+describe('useLiveGame', () => {
+	beforeEach(() => {
+		vi.useFakeTimers()
+		vi.stubGlobal('fetch', vi.fn())
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+		vi.unstubAllGlobals()
+	})
+
+	it('fetches immediately on mount and returns payload', async () => {
+		const payload = basePayload()
+		;(fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => payload,
+		})
+		const { result } = renderHook(() => useLiveGame(), { wrapper: wrapperFor('g1') })
+		await vi.runOnlyPendingTimersAsync()
+		await waitFor(() => expect(result.current.payload).not.toBeNull())
+		expect(result.current.payload?.gameId).toBe('g1')
+	})
+
+	it('sets isStale on fetch failure', async () => {
+		;(fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('network down'))
+		const { result } = renderHook(() => useLiveGame(), { wrapper: wrapperFor('g1') })
+		await vi.runOnlyPendingTimersAsync()
+		await waitFor(() => expect(result.current.isStale).toBe(true))
+	})
+})
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `pnpm exec vitest run src/components/live/use-live-game.test.tsx`
+Expected: FAIL — payload stays null / isStale stays false, because Task 4's skeleton doesn't fetch.
+
+- [ ] **Step 3: Implement real `LiveProvider`**
+
+```typescript
+// src/components/live/live-provider.tsx
+'use client'
+import { createContext, type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
+import { detectGoalDeltas, detectPickSettlements } from '@/lib/live/detect'
+import type { GoalEvent, LivePayload, PickSettlementEvent } from '@/lib/live/types'
+
+const LIVE_CADENCE_MS = 30_000
+const IDLE_CADENCE_MS = 5 * 60_000
+const MAX_BACKOFF_MS = 120_000
+const LIVE_WINDOW_BEFORE_MS = 10 * 60_000
+const LIVE_WINDOW_AFTER_MS = 150 * 60_000
+const EVENT_BUFFER_CAP = 20
+
+export interface LiveContextValue {
+	payload: LivePayload | null
+	events: {
+		goals: GoalEvent[]
+		settlements: PickSettlementEvent[]
+	}
+	isStale: boolean
+	reconnecting: boolean
+}
+
+const defaultValue: LiveContextValue = {
+	payload: null,
+	events: { goals: [], settlements: [] },
+	isStale: false,
+	reconnecting: false,
+}
+
+export const LiveContext = createContext<LiveContextValue>(defaultValue)
+
+function hasActiveFixture(payload: LivePayload | null, now = Date.now()): boolean {
+	if (!payload) return false
+	return payload.fixtures.some((f) => {
+		if (!f.kickoff) return false
+		const t = typeof f.kickoff === 'string' ? Date.parse(f.kickoff) : f.kickoff.getTime()
+		return now >= t - LIVE_WINDOW_BEFORE_MS && now <= t + LIVE_WINDOW_AFTER_MS
+	})
+}
+
+interface LiveProviderProps {
+	gameId: string
+	children: ReactNode
+}
+
+export function LiveProvider({ gameId, children }: LiveProviderProps) {
+	const [payload, setPayload] = useState<LivePayload | null>(null)
+	const [goals, setGoals] = useState<GoalEvent[]>([])
+	const [settlements, setSettlements] = useState<PickSettlementEvent[]>([])
+	const [isStale, setIsStale] = useState(false)
+	const [reconnecting, setReconnecting] = useState(false)
+
+	const previousRef = useRef<LivePayload | null>(null)
+	const backoffRef = useRef(0)
+
+	useEffect(() => {
+		let cancelled = false
+		let timer: ReturnType<typeof setTimeout> | null = null
+
+		async function fetchOnce() {
+			try {
+				const res = await fetch(`/api/games/${gameId}/live`, { cache: 'no-store' })
+				if (cancelled) return
+				if (res.status === 401 || res.status === 403 || res.status === 404) {
+					setPayload(null)
+					setIsStale(true)
+					setReconnecting(false)
+					return
+				}
+				if (!res.ok) throw new Error(`HTTP ${res.status}`)
+				const next = (await res.json()) as LivePayload
+				const prev = previousRef.current
+				if (prev) {
+					const newGoals = detectGoalDeltas(prev, next)
+					if (newGoals.length) {
+						setGoals((g) => [...g, ...newGoals].slice(-EVENT_BUFFER_CAP))
+					}
+					const newSettlements = detectPickSettlements(prev, next)
+					if (newSettlements.length) {
+						setSettlements((s) => [...s, ...newSettlements].slice(-EVENT_BUFFER_CAP))
+					}
+				}
+				previousRef.current = next
+				setPayload(next)
+				setIsStale(false)
+				setReconnecting(false)
+				backoffRef.current = 0
+			} catch {
+				if (cancelled) return
+				setIsStale(true)
+				setReconnecting(true)
+				backoffRef.current = Math.min(
+					backoffRef.current > 0 ? backoffRef.current * 2 : LIVE_CADENCE_MS,
+					MAX_BACKOFF_MS,
+				)
+			} finally {
+				if (cancelled) return
+				if (document.visibilityState === 'hidden') return
+				const interval =
+					backoffRef.current > 0
+						? backoffRef.current
+						: hasActiveFixture(previousRef.current)
+							? LIVE_CADENCE_MS
+							: IDLE_CADENCE_MS
+				timer = setTimeout(fetchOnce, interval)
+			}
+		}
+
+		function handleVisibility() {
+			if (document.visibilityState === 'visible') {
+				if (timer) clearTimeout(timer)
+				void fetchOnce()
+			} else if (timer) {
+				clearTimeout(timer)
+				timer = null
+			}
+		}
+
+		document.addEventListener('visibilitychange', handleVisibility)
+		void fetchOnce()
+
+		return () => {
+			cancelled = true
+			if (timer) clearTimeout(timer)
+			document.removeEventListener('visibilitychange', handleVisibility)
+			previousRef.current = null
+		}
+	}, [gameId])
+
+	const value = useMemo<LiveContextValue>(
+		() => ({ payload, events: { goals, settlements }, isStale, reconnecting }),
+		[payload, goals, settlements, isStale, reconnecting],
+	)
+
+	return <LiveContext.Provider value={value}>{children}</LiveContext.Provider>
+}
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `pnpm exec vitest run src/components/live/use-live-game.test.tsx`
+Expected: both tests PASS.
+
+- [ ] **Step 5: Typecheck + full test run**
+
+Run: `pnpm exec tsc --noEmit && pnpm exec vitest run`
+Expected: tsc clean; total test count grew by 2.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/live/live-provider.tsx src/components/live/use-live-game.test.tsx
+git commit -m "feat(live): wire polling, adaptive cadence, diff emission into LiveProvider"
+```
+
+---
+
+## Part C — UI components
+
+### Task 6: Shared live-indicator atoms
+
+**Files:**
+- Create: `src/components/live/live-indicators.tsx`
+
+Small presentational atoms reused by the ticker and any enrichment UI.
+
+- [ ] **Step 1: Implement**
+
+```typescript
+// src/components/live/live-indicators.tsx
+import { cn } from '@/lib/utils'
+
+export function LiveDot({ className }: { className?: string }) {
+	return (
+		<span
+			role="img"
+			aria-label="live"
+			className={cn(
+				'inline-block h-1.5 w-1.5 rounded-full bg-current',
+				'animate-[pulse_1.4s_ease-in-out_infinite]',
+				className,
+			)}
+		/>
+	)
+}
+
+export function ReconnectingChip() {
+	return (
+		<span className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+			<span className="inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground animate-[pulse_1.4s_ease-in-out_infinite]" />
+			Reconnecting…
+		</span>
+	)
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/live/live-indicators.tsx
+git commit -m "feat(live): add LiveDot and ReconnectingChip atoms"
+```
+
+---
+
+### Task 7: `LiveFixtureCard` presentation
+
+**Files:**
+- Create: `src/components/live/live-fixture-card.tsx`
+
+Per-fixture card — badges, scores, status pill, My-pick tag. Static visuals only; Task 8 adds celebration animation.
+
+- [ ] **Step 1: Implement**
+
+```typescript
+// src/components/live/live-fixture-card.tsx
+'use client'
+import { deriveMatchState } from '@/lib/live/derive'
+import type { LiveFixture } from '@/lib/live/types'
+import { cn } from '@/lib/utils'
+import { LiveDot } from './live-indicators'
+
+interface LiveFixtureCardProps {
+	fixture: LiveFixture
+	isMyPick?: boolean
+	now?: Date
+	className?: string
+}
+
+function statusText(
+	state: 'pre' | 'live' | 'ht' | 'ft',
+	kickoff: Date | string | null,
+	now: Date,
+): string {
+	if (state === 'ht') return 'HALF TIME'
+	if (state === 'ft') return 'FULL TIME'
+	if (state === 'live') return 'LIVE'
+	if (!kickoff) return 'TBC'
+	const t = typeof kickoff === 'string' ? Date.parse(kickoff) : kickoff.getTime()
+	const mins = Math.max(0, Math.round((t - now.getTime()) / 60_000))
+	return mins === 0 ? 'KICKING OFF' : `KICKS OFF IN ${mins}m`
+}
+
+export function LiveFixtureCard({
+	fixture,
+	isMyPick = false,
+	now = new Date(),
+	className,
+}: LiveFixtureCardProps) {
+	const state = deriveMatchState(fixture, now)
+	const statusClasses =
+		state === 'live'
+			? 'text-[#ef4444] border-[#ef4444]'
+			: state === 'ht'
+				? 'text-amber-500 border-amber-500'
+				: 'text-muted-foreground border-border'
+	return (
+		<div
+			data-fixture-id={fixture.id}
+			data-state={state}
+			className={cn(
+				'relative flex min-w-[170px] flex-col gap-1 rounded-lg border bg-card px-3 py-2',
+				statusClasses,
+				state === 'pre' && 'opacity-70',
+				className,
+			)}
+		>
+			{isMyPick && (
+				<span className="absolute -top-1.5 right-2 rounded-sm bg-primary px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-primary-foreground">
+					My pick
+				</span>
+			)}
+			<div className="flex items-center justify-between text-sm font-semibold">
+				<span>{fixture.homeShort}</span>
+				<span
+					data-score="home"
+					className="font-variant-numeric: tabular-nums; font-bold"
+				>
+					{fixture.homeScore ?? '−'}
+				</span>
+			</div>
+			<div className="flex items-center justify-between text-sm font-semibold">
+				<span>{fixture.awayShort}</span>
+				<span
+					data-score="away"
+					className="font-variant-numeric: tabular-nums; font-bold"
+				>
+					{fixture.awayScore ?? '−'}
+				</span>
+			</div>
+			<div className="mt-1 flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-wider">
+				{state === 'live' && <LiveDot className="text-[#ef4444]" />}
+				<span className="text-current">{statusText(state, fixture.kickoff, now)}</span>
+			</div>
+		</div>
+	)
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/live/live-fixture-card.tsx
+git commit -m "feat(live): add LiveFixtureCard presentation"
+```
+
+---
+
+### Task 8: `GoalCelebration` wrapper
+
+**Files:**
+- Create: `src/components/live/goal-celebration.tsx`
+
+Wraps a `<LiveFixtureCard>` and applies the celebration state (scale pulse, green glow, floating chip) when a matching `GoalEvent` flows through the hook. Uses CSS classes + `setTimeout` cleanup; no animation framework.
+
+- [ ] **Step 1: Implement**
+
+```typescript
+// src/components/live/goal-celebration.tsx
+'use client'
+import { type ReactNode, useEffect, useRef, useState } from 'react'
+import type { GoalEvent, LivePick } from '@/lib/live/types'
+import { cn } from '@/lib/utils'
+import { useLiveGame } from './use-live-game'
+
+interface GoalCelebrationProps {
+	fixtureId: string
+	viewerPick?: LivePick | null
+	children: ReactNode
+}
+
+interface Celebration {
+	eventId: string
+	side: 'home' | 'away'
+	minute: number
+	friendly: boolean
+}
+
+const HOLD_MS = 2000
+
+export function GoalCelebration({ fixtureId, viewerPick, children }: GoalCelebrationProps) {
+	const { events } = useLiveGame()
+	const [active, setActive] = useState<Celebration | null>(null)
+	const handledIds = useRef<Set<string>>(new Set())
+
+	useEffect(() => {
+		for (const ev of events.goals) {
+			if (ev.fixtureId !== fixtureId) continue
+			if (handledIds.current.has(ev.id)) continue
+			handledIds.current.add(ev.id)
+			const friendly =
+				!!viewerPick &&
+				((ev.side === 'home' && viewerPick.predictedResult === 'home_win') ||
+					(ev.side === 'away' && viewerPick.predictedResult === 'away_win'))
+			setActive({ eventId: ev.id, side: ev.side, minute: 0, friendly })
+			const timer = setTimeout(() => {
+				setActive((current) => (current?.eventId === ev.id ? null : current))
+			}, HOLD_MS)
+			return () => clearTimeout(timer)
+		}
+	}, [events.goals, fixtureId, viewerPick])
+
+	return (
+		<div className="relative">
+			{active && (
+				<span
+					className={cn(
+						'absolute left-1/2 -top-2.5 z-10 -translate-x-1/2 rounded-full px-2.5 py-0.5 text-[10px] font-black uppercase tracking-widest text-white shadow-lg',
+						active.friendly ? 'bg-emerald-500' : 'bg-red-500',
+					)}
+				>
+					GOAL
+				</span>
+			)}
+			<div
+				data-celebrating={active ? active.friendly ? 'friendly' : 'opposing' : undefined}
+				className={cn(
+					'transition-all duration-300',
+					active?.friendly &&
+						'ring-2 ring-emerald-500 shadow-[0_0_20px_rgba(34,197,94,0.4)] scale-[1.03]',
+					active && !active.friendly &&
+						'ring-2 ring-red-500 shadow-[0_0_20px_rgba(239,68,68,0.4)] scale-[1.02]',
+				)}
+			>
+				{children}
+			</div>
+		</div>
+	)
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/live/goal-celebration.tsx
+git commit -m "feat(live): add GoalCelebration wrapper with friendly/opposing treatments"
+```
+
+---
+
+### Task 9: `LiveScoreTicker`
+
+**Files:**
+- Create: `src/components/live/live-score-ticker.tsx`
+
+Top-of-page horizontal strip. Reads `payload` + `events` from `useLiveGame()`. Only renders when any fixture is in its live window. Shows `<ReconnectingChip>` when `reconnecting`.
+
+- [ ] **Step 1: Implement**
+
+```typescript
+// src/components/live/live-score-ticker.tsx
+'use client'
+import { deriveMatchState } from '@/lib/live/derive'
+import type { LivePick } from '@/lib/live/types'
+import { GoalCelebration } from './goal-celebration'
+import { LiveFixtureCard } from './live-fixture-card'
+import { ReconnectingChip } from './live-indicators'
+import { useLiveGame } from './use-live-game'
+
+export function LiveScoreTicker() {
+	const { payload, reconnecting } = useLiveGame()
+	if (!payload) return null
+
+	const now = new Date()
+	const livish = payload.fixtures.filter((f) => {
+		const state = deriveMatchState(f, now)
+		return state === 'pre' || state === 'live' || state === 'ht'
+	})
+	if (livish.length === 0) return null
+
+	const viewerPicksByFixture = new Map<string, LivePick>()
+	const viewerPlayerIds = new Set(
+		payload.players.filter((p) => p.userId === payload.viewerUserId).map((p) => p.id),
+	)
+	for (const pk of payload.picks) {
+		if (viewerPlayerIds.has(pk.gamePlayerId) && pk.fixtureId) {
+			viewerPicksByFixture.set(pk.fixtureId, pk)
+		}
+	}
+
+	return (
+		<div className="mb-4 flex items-start gap-2">
+			<div className="flex flex-1 gap-2 overflow-x-auto pb-1">
+				{livish.map((fixture) => {
+					const viewerPick = viewerPicksByFixture.get(fixture.id) ?? null
+					return (
+						<GoalCelebration
+							key={fixture.id}
+							fixtureId={fixture.id}
+							viewerPick={viewerPick}
+						>
+							<LiveFixtureCard
+								fixture={fixture}
+								isMyPick={Boolean(viewerPick)}
+								now={now}
+							/>
+						</GoalCelebration>
+					)
+				})}
+			</div>
+			{reconnecting && (
+				<div className="shrink-0 pt-1">
+					<ReconnectingChip />
+				</div>
+			)}
+		</div>
+	)
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/live/live-score-ticker.tsx
+git commit -m "feat(live): add LiveScoreTicker composition"
+```
+
+---
+
+## Part D — Integration with existing views
+
+### Task 10: Wire LiveProvider + Ticker into GameDetailView
+
+**Files:**
+- Modify: `src/components/game/game-detail-view.tsx`
+
+Wrap the rendered children in `<LiveProvider gameId={gameId}>` and mount `<LiveScoreTicker />` above the existing content.
+
+- [ ] **Step 1: Read the current component**
+
+Run: `cat src/components/game/game-detail-view.tsx | head -80`
+
+- [ ] **Step 2: Import LiveProvider + LiveScoreTicker at the top of the file**
+
+```typescript
+import { LiveProvider } from '@/components/live/live-provider'
+import { LiveScoreTicker } from '@/components/live/live-score-ticker'
+```
+
+- [ ] **Step 3: Wrap the root element in `<LiveProvider gameId={game.id}>` and mount `<LiveScoreTicker />` as the first child inside the existing outer container**
+
+Replace the outer return with:
+
+```tsx
+return (
+	<LiveProvider gameId={game.id}>
+		<div className="flex flex-col gap-6">
+			<LiveScoreTicker />
+			<GameHeader /* existing props */ />
+			{/* rest of existing content unchanged */}
+		</div>
+	</LiveProvider>
+)
+```
+
+(Engineer: keep all existing children exactly as they were — this only adds `<LiveProvider>` as outer wrapper and `<LiveScoreTicker />` as first child.)
+
+- [ ] **Step 4: Typecheck + full test run**
+
+Run: `pnpm exec tsc --noEmit && pnpm exec vitest run`
+Expected: tsc clean; tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/game/game-detail-view.tsx
+git commit -m "feat(game): mount LiveProvider and LiveScoreTicker on game detail"
+```
+
+---
+
+### Task 11: Enrich `CupGrid` with live state
+
+**Files:**
+- Modify: `src/components/standings/cup-grid.tsx`
+
+Add optional `live?: LivePayload` prop. When present:
+- Apply blue left-border + "LIVE" pulse on the viewer's row when their pick's fixture is live.
+- Show green `+1` / red `-1` score-bump badges on pick cells when a matching `GoalEvent` fires within the last 1.5s.
+- Opacity-fade row + "OUT R{n}" badge when `PickSettlementEvent` with `settled-loss` fires for that player AND their livesRemaining in `live.players` is 0.
+
+- [ ] **Step 1: Read the current file**
+
+Run: `cat src/components/standings/cup-grid.tsx`
+
+- [ ] **Step 2: Add live prop, subscribe to events, apply classes**
+
+Add to `CupGridProps`:
+
+```typescript
+import type { LivePayload } from '@/lib/live/types'
+import { useLiveGame } from '@/components/live/use-live-game'
+
+export interface CupGridProps {
+	data: CupStandingsData
+	live?: LivePayload
+}
+```
+
+Inside `CupGrid` body, just before the existing row rendering:
+
+```typescript
+const liveCtx = useLiveGame()
+const now = Date.now()
+const RECENT_MS = 1500
+const recentGoalByFixture = new Map<string, { side: 'home' | 'away'; id: string }>()
+for (const ev of liveCtx.events.goals) {
+	if (now - ev.observedAt <= RECENT_MS) {
+		recentGoalByFixture.set(ev.fixtureId, { side: ev.side, id: ev.id })
+	}
+}
+const eliminatedGpIds = new Set<string>()
+for (const ev of liveCtx.events.settlements) {
+	if (ev.result !== 'settled-loss') continue
+	const p = liveCtx.payload?.players.find((pp) => pp.id === ev.gamePlayerId)
+	if (p && p.livesRemaining === 0) eliminatedGpIds.add(ev.gamePlayerId)
+}
+const viewerGp = liveCtx.payload?.players.find((p) => p.userId === liveCtx.payload?.viewerUserId)
+const viewerPickFixture = liveCtx.payload?.picks.find(
+	(pk) => pk.gamePlayerId === viewerGp?.id && pk.fixtureId,
+)?.fixtureId
+const viewerFixtureState = viewerPickFixture
+	? liveCtx.payload?.fixtures.find((f) => f.id === viewerPickFixture)?.status
+	: undefined
+const viewerRowIsLive = viewerFixtureState === 'live' || viewerFixtureState === 'halftime'
+```
+
+On the row rendering, annotate:
+
+```tsx
+<div
+	data-gpid={player.gamePlayerId}
+	className={cn(
+		/* existing classes */,
+		player.gamePlayerId === viewerGp?.id && viewerRowIsLive &&
+			'border-l-4 border-l-primary bg-gradient-to-r from-primary/10 to-transparent pl-2',
+		eliminatedGpIds.has(player.gamePlayerId) &&
+			'opacity-45 transition-opacity duration-[400ms]',
+	)}
+>
+	<span className="name">
+		{player.name}
+		{player.gamePlayerId === viewerGp?.id && viewerRowIsLive && (
+			<span className="ml-1.5 rounded-sm bg-primary/15 px-1 py-0.5 text-[9px] font-bold uppercase text-primary animate-[pulse_1.4s_ease-in-out_infinite]">
+				LIVE
+			</span>
+		)}
+		{eliminatedGpIds.has(player.gamePlayerId) && (
+			<span className="ml-1.5 rounded-sm border border-[#ef4444] px-1 py-0.5 text-[9px] font-extrabold uppercase text-[#ef4444]">
+				OUT R{liveCtx.payload?.roundId ? '' : ''}
+			</span>
+		)}
+	</span>
+	{/* existing cells — each pick cell wrapped to show score-bump if the pick's fixtureId matches recentGoalByFixture */}
+</div>
+```
+
+(Engineer: the exact structure of existing cup-grid markup must be preserved; these additions are overlays only.)
+
+- [ ] **Step 3: Typecheck + run tests**
+
+Run: `pnpm exec tsc --noEmit && pnpm exec vitest run`
+Expected: tsc clean; tests still pass (no new tests — visual enrichment).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/standings/cup-grid.tsx
+git commit -m "feat(standings): enrich cup-grid with live pick-row state"
+```
+
+---
+
+### Task 12: Enrich `CupLadder` with live state
+
+**Files:**
+- Modify: `src/components/standings/cup-ladder.tsx`
+
+Same pattern as Task 11. Accept `live?: LivePayload`; for each live fixture card in the ladder, override the stored score with the live score; when a `GoalEvent` matches a ladder fixture, flash the backer group border.
+
+- [ ] **Step 1: Read + add prop**
+
+```typescript
+import type { LivePayload } from '@/lib/live/types'
+import { useLiveGame } from '@/components/live/use-live-game'
+
+export interface CupLadderProps {
+	data: CupLadderData
+	live?: LivePayload
+}
+```
+
+- [ ] **Step 2: Subscribe + override**
+
+Inside the component:
+
+```typescript
+const { payload, events } = useLiveGame()
+const liveFixtureById = new Map(payload?.fixtures.map((f) => [f.id, f]) ?? [])
+const recentGoalByFixture = new Map<string, number>()
+const now = Date.now()
+for (const ev of events.goals) {
+	if (now - ev.observedAt <= 1500) recentGoalByFixture.set(ev.fixtureId, ev.observedAt)
+}
+```
+
+For each fixture card rendered, if `liveFixtureById.has(fixture.id)`, display live scores instead of stored ones, and if `recentGoalByFixture.has(fixture.id)`, add the flashing border class for ~1.5s.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/standings/cup-ladder.tsx
+git commit -m "feat(standings): enrich cup-ladder with live fixture overrides"
+```
+
+---
+
+### Task 13: Enrich `CupTimeline` with live state
+
+**Files:**
+- Modify: `src/components/standings/cup-timeline.tsx`
+
+Same pattern. Accept `live?: LivePayload`; when a `PickSettlementEvent` fires for a player, the matching timeline slot gets the elimination styling applied for the rest of the render.
+
+- [ ] **Step 1: Add prop + subscribe**
+
+```typescript
+import type { LivePayload } from '@/lib/live/types'
+import { useLiveGame } from '@/components/live/use-live-game'
+
+export interface CupTimelineProps {
+	data: CupLadderData
+	live?: LivePayload
+}
+```
+
+Inside component:
+
+```typescript
+const { events } = useLiveGame()
+const eliminatedGpIds = new Set(
+	events.settlements.filter((ev) => ev.result === 'settled-loss').map((ev) => ev.gamePlayerId),
+)
+```
+
+Apply `opacity-45` class to eliminated rows.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/standings/cup-timeline.tsx
+git commit -m "feat(standings): enrich cup-timeline with live elimination state"
+```
+
+---
+
+### Task 14: Thread `live` through `CupStandings` tab wrapper
+
+**Files:**
+- Modify: `src/components/standings/cup-standings.tsx`
+
+Add `live?: LivePayload` prop; pass it to whichever tab's component is active.
+
+- [ ] **Step 1: Implement**
+
+```typescript
+import type { LivePayload } from '@/lib/live/types'
+
+export interface CupStandingsProps {
+	data: CupLadderData
+	onShare?: () => void
+	live?: LivePayload
+}
+
+// in render:
+{viewMode === 'ladder' && <CupLadder data={data} live={live} />}
+{viewMode === 'grid' && <CupGrid data={data} live={live} />}
+{viewMode === 'timeline' && <CupTimeline data={data} live={live} />}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/standings/cup-standings.tsx
+git commit -m "feat(standings): thread live prop through cup-standings tabs"
+```
+
+---
+
+### Task 15: Enrich `TurboStandings` + `ProgressGrid`
+
+**Files:**
+- Modify: `src/components/game/turbo-standings.tsx`
+- Modify: `src/components/standings/progress-grid.tsx`
+
+Same live-prop pattern as Tasks 11-13: viewer-row border when pick fixture is live, score-bump badges on pick cells with recent goals, opacity-fade on elimination events.
+
+- [ ] **Step 1: Turbo standings**
+
+```typescript
+import type { LivePayload } from '@/lib/live/types'
+import { useLiveGame } from '@/components/live/use-live-game'
+
+export interface TurboStandingsProps {
+	data: TurboStandingsData
+	live?: LivePayload
+}
+```
+
+Add the same subscriber block as in Task 11; apply the same viewer-row + eliminated classes on each player row.
+
+- [ ] **Step 2: Progress grid**
+
+Same addition: `live?: LivePayload`, subscribe to hook, apply viewer-row enrichment + elimination fade.
+
+- [ ] **Step 3: Typecheck + run tests**
+
+Run: `pnpm exec tsc --noEmit && pnpm exec vitest run`
+Expected: tsc clean; tests still pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/game/turbo-standings.tsx src/components/standings/progress-grid.tsx
+git commit -m "feat(standings): enrich turbo-standings and progress-grid with live state"
+```
+
+---
+
+### Task 16: Pass `live` through from `GameDetailView`
+
+**Files:**
+- Modify: `src/components/game/game-detail-view.tsx`
+
+`LiveProvider` owns the polled state. The child components inside it (cup/turbo/progress standings) need access via either `useLiveGame` directly (which they now do, per Tasks 11-15) OR via `live` prop threaded from `GameDetailView`. Since we're using the hook directly inside each standings component, **no prop threading is needed** — the hook reads from the surrounding `LiveProvider`.
+
+This task confirms that by running the full test + typecheck.
+
+- [ ] **Step 1: Typecheck + run tests + start dev**
+
+Run:
+```bash
+pnpm exec tsc --noEmit
+pnpm exec vitest run
+```
+
+Expected: tsc clean; tests still pass.
+
+- [ ] **Step 2: Commit (empty commit marking integration milestone)**
+
+Skip — no code change. If helpful for branch log readability, `git commit --allow-empty -m "chore: confirm live integration via useLiveGame hook"`; otherwise skip.
+
+---
+
+## Part E — Server and seed
+
+### Task 17: Bump GH Actions cron cadence
+
+**Files:**
+- Modify: `.github/workflows/live-scores.yml`
+
+One-line change from 5-minute to 1-minute cadence. Isolated commit so it's easy to revert if it causes noise.
+
+- [ ] **Step 1: Read current file**
+
+Run: `cat .github/workflows/live-scores.yml`
+
+- [ ] **Step 2: Change the cron line**
+
+Edit `.github/workflows/live-scores.yml`:
+
+```yaml
+on:
+  schedule:
+    - cron: '* * * * *'
+  workflow_dispatch:
+```
+
+(Was `'*/5 * * * *'`, now `'* * * * *'`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/live-scores.yml
+git commit -m "chore(ci): bump live-scores cron from 5min to 1min"
+```
+
+---
+
+### Task 18: Dev seed — mid-match cup game
+
+**Files:**
+- Modify: `scripts/seed.ts`
+
+Add a cup-mode game whose `currentRound.fixtures` have kickoff ~15 minutes ago + status `'live'` + partial scores. Enables dev testing of the ticker, celebrations, and enrichment layers.
+
+- [ ] **Step 1: Read current seed**
+
+Run: `tail -80 scripts/seed.ts`
+
+- [ ] **Step 2: Add mid-match cup block**
+
+Near the existing cup seed block, after the "Cup Tuesday (GW7)" setup, add:
+
+```typescript
+// --- Mid-match cup game for live UI verification -------------------------
+{
+	const now = new Date()
+	const kickoff = new Date(now.getTime() - 15 * 60_000)
+	// Reuse an existing round (e.g., round 8). Mark two fixtures as live with
+	// partial scores so LiveScoreTicker + enrichment can be exercised in dev.
+	const liveRoundNumber = 8
+	const liveRound = await db.query.round.findFirst({
+		where: and(eq(round.competitionId, plCompetitionId), eq(round.number, liveRoundNumber)),
+	})
+	if (liveRound) {
+		const roundFixtures = await db.query.fixture.findMany({
+			where: eq(fixture.roundId, liveRound.id),
+			limit: 2,
+		})
+		for (const [idx, fx] of roundFixtures.entries()) {
+			await db
+				.update(fixture)
+				.set({
+					kickoff,
+					status: 'live',
+					homeScore: idx === 0 ? 1 : 2,
+					awayScore: idx === 0 ? 0 : 2,
+				})
+				.where(eq(fixture.id, fx.id))
+		}
+	}
+}
+```
+
+(Engineer: use whatever local variable names are already in scope. This block is an additive step, not a replacement.)
+
+- [ ] **Step 3: Run seed to verify**
+
+Run: `just db-reset`
+Expected: seed runs without error; two fixtures in round 8 now have `status: 'live'` and partial scores.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/seed.ts
+git commit -m "chore(seed): add mid-match cup game for live UI verification"
+```
+
+---
+
+## Part F — Verification
+
+### Task 19: Full verification sweep
+
+**Files:**
+- None (may produce a `chore: format` commit if Biome re-writes anything)
+
+Final pass before marking the branch ready for PR.
+
+- [ ] **Step 1: Biome**
+
+Run: `pnpm exec biome check --write .`
+Expected: clean OR formats some files. If changed, stage and plan a chore commit at end.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: clean (no output).
+
+- [ ] **Step 3: Full test suite**
+
+Run: `pnpm exec vitest run`
+Expected: all tests pass; count is `baseline + ~15-20` (`detectGoalDeltas` 8 cases, `detectPickSettlements` 6 cases, `deriveMatchState` 7 cases, `projectPickOutcome` 7 cases, `useLiveGame` 2 cases).
+
+- [ ] **Step 4: Next build**
+
+Run: `pnpm exec next build`
+Expected: compile + TypeScript phases pass cleanly. "Collect page data" step may fail on missing env vars in sandbox — that's sandbox-only, not a code issue.
+
+- [ ] **Step 5: Cron cadence check**
+
+Run: `gh run list --workflow=live-scores.yml --limit 10`
+Expected: once the workflow change lands on main, runs show 1-minute gaps. (Before merge, it's still 5 min — this check is meaningful only after merge.)
+
+- [ ] **Step 6: Manual dev smoke (optional — requires docker)**
+
+```bash
+docker compose up -d
+just db-reset
+just dev
+```
+
+Navigate to the mid-match cup game's detail page. Expected:
+- `<LiveScoreTicker>` renders above the header with two live cards.
+- Manually run `UPDATE fixture SET home_score = home_score + 1 WHERE id = '...' AND status = 'live'` via psql, wait ~30s, observe goal celebration fires.
+- Viewer row in cup standings gets blue border + LIVE pulse.
+
+- [ ] **Step 7: Commit any formatting fixes**
+
+If biome made changes:
+
+```bash
+git add -A
+git commit -m "chore: format and smoke-fix for Phase 4c1"
+```
+
+---
+
+## Out-of-scope reminders (tracked elsewhere)
+
+- Scorer names / minute-level events — requires paid football-data.org tier; deferred post-WC.
+- Server-side `fixture_event` table — not needed for in-session animations.
+- Retroactive animations for goals before page load — users see current score on mount, no replay.
+- Vercel Cron or QStash self-scheduling — considered in brainstorm, rejected for friend-group scale.
+- GitHub Actions repo secrets (`CRON_SECRET`, `VERCEL_PROD_URL`) — Phase 4.5 (see `project_phase_4_5_must_haves.md`).
+
+## Risk mitigation
+
+- **Payload shape drift.** `src/lib/live/types.ts` is the frozen contract. If `getLivePayload` in `detail-queries.ts` ever changes shape, the consumers must update types here too — compile errors will catch this.
+- **Cron log noise.** 1440 GH Actions runs/day will clutter the Actions tab. The runs continue to fail until Phase 4.5 sets secrets, so they'll mostly be red. Mitigation: filter to "failing" or "success" as needed; don't let visual noise drive additional workflow edits.
+- **Event ID clash on 2+ rapid goals.** `detectGoalDeltas` emits one event per increment, IDs derived from the final score. A 0→2 jump produces `fx:home:1` and `fx:home:2` — both unique, correctly ordered, animated sequentially via the consumer's `handledIds` set.
+- **Focus after 20-min absence emits many stale events.** Mitigated in `GoalCelebration` by only animating when the event is within `HOLD_MS` of the current render; older events still update scores but don't re-celebrate. The event buffer cap of 20 also limits how far back we can look.

--- a/docs/superpowers/specs/2026-04-24-phase-4c1-live-match-day-design.md
+++ b/docs/superpowers/specs/2026-04-24-phase-4c1-live-match-day-design.md
@@ -1,0 +1,253 @@
+# Phase 4c1 Design Specification — Match-Day Live UI
+
+## Overview
+
+Phase 4c1 turns the app from "static between match windows" into a live experience during kickoff. Scores update in place, goals celebrate visibly on the ticker card, the viewer's own row highlights while their pick is in play, and players who just went out fade with a clear "OUT" badge. All without WebSockets, a new data provider, or a server-side events table.
+
+4c1 is the first of five sub-phases in Phase 4c (match-day live, admin UX, paid rebuys, Satori share variants, mobile polish). Each 4c sub-phase ships on its own branch — 4b's monolithic pattern trades cleanly for smaller reviewable PRs now that the architecture is settled. 4c1 is independent and can merge dormant onto `main` before the remaining sub-phases start.
+
+Target completion ahead of Phase 4.5 launch preparation; WC 2026-06-11 is the hard deadline for everything in Phase 4c.
+
+---
+
+## Scope
+
+**In scope:**
+- Client-side polling layer with adaptive cadence (30s during match windows, 5min otherwise).
+- `<LiveScoreTicker>` pinned at the top of the game detail page. Horizontal strip of fixture cards; only visible when at least one fixture is in its live window.
+- Goal-delta detection via client-side payload diffing (no server-side event store).
+- On-card goal celebration: scale pulse + score digit bump + floating "GOAL 34'" chip.
+- Pick-row enrichment on standings components: blue left-border + pulsing "LIVE" tag on the viewer's row when their pick's fixture is live, score-bump badges on pick cells when underlying score changes.
+- Elimination fade + "OUT R{n}" badge when a pick transitions `live` → `settled-loss` within the current render window.
+- GitHub Actions `live-scores.yml` cron cadence bump from every 5 minutes to every 1 minute.
+
+**Out of scope** (deferred to later phases or explicitly dropped):
+- Scorer names, minute-level event breakdowns, goal timeline history — all require paid football-data.org tier.
+- Server-side `fixture_event` table — not needed for in-session animation.
+- Retroactive animations for goals scored before the page loaded — users who land mid-match see current scores, no replay of missed events.
+- WebSocket / SSE / push — polling is sufficient for a friend-group app with ≤10 concurrent viewers per game.
+- Vercel Cron upgrade or QStash self-scheduling chain — considered and rejected as over-engineered for a public repo with free GH Actions minutes.
+- Match-day UI for admin-side pick-correction, split-pot, or add-player actions — deferred to 4c2.
+
+---
+
+## Architecture
+
+A single new primitive: a client-side polling layer composed of one React context provider, one hook, and a handful of pure derivation functions. No new API routes, no schema changes, no new data-provider integration.
+
+**`<LiveProvider>`** — React context provider that wraps the `GameDetailView`. Owns the polled payload, the adaptive timer, the network-error state, and the diff-derived event stream. Unmount or game-id change resets state.
+
+**`useLiveGame()`** — hook consumed by every component that wants live data. Returns `{ payload, events, isStale, reconnecting }`. Event stream is per-render — consumers must be stable in what they animate per event id (no replaying the same goal twice).
+
+**Pure derivation functions** (all module-level, fully unit-tested):
+- `detectGoalDeltas(prev, next): GoalEvent[]` — diffs consecutive payloads; returns one event per score increment (never a decrement).
+- `detectPickSettlements(prev, next): PickSettlementEvent[]` — picks transitioning `live`/`pending` → `settled-loss` or `settled-win`.
+- `deriveMatchState(fixture, now): 'pre' | 'live' | 'ht' | 'ft'` — maps stored status + kickoff delta to a UI state.
+- `projectPickOutcome(pick, fixture, mode): 'winning' | 'drawing' | 'losing' | 'saved-by-life' | 'settled-win' | 'settled-loss'` — what does this pick currently look like from the viewer's perspective, given the live score?
+
+**Existing server endpoint (unchanged):** `GET /api/games/[id]/live` from Phase 4a. Returns `{ fixtures, picks, players, viewerUserId, updatedAt }`. The payload shape is already sufficient for diffing; no migration needed.
+
+---
+
+## Server freshness
+
+The polling cadence on the client cannot make scores fresher than the server's copy. The `poll-scores` cron (Phase 4a) is what actually pulls scores from football-data.org into our DB. At its current 5-minute cadence, client polls can be up to 5 minutes stale during matches regardless of how often the client polls.
+
+**Change:** `.github/workflows/live-scores.yml` — `cron: '*/5 * * * *'` → `cron: '* * * * *'`. One line.
+
+**Why it's free:**
+- Repository is public. GitHub Actions minutes on public repos are unlimited, so 1440 invocations/day has zero cost.
+- The `poll-scores` handler (Phase 4a) already short-circuits on `hasActiveFixture(fixturesInRounds)` — runs without live fixtures return `{ updated: 0, reason: 'no-active-fixtures' }` in ~100ms without calling football-data.org.
+
+**API budget check:**
+- Football-data.org free tier: 10 requests/minute.
+- Typical concurrent-live-match count during WC group stage: 1-3.
+- Budget consumed: 1-3 req/min from this workflow, well under the 10 req/min ceiling.
+- `daily-sync` runs once daily on Vercel cron — separate budget envelope, unaffected.
+
+**Explicitly rejected alternatives:**
+- **Vercel Cron on Pro plan ($20/mo)** — unnecessary recurring cost for a friend-group app.
+- **QStash self-scheduling chain** — adds paid-tier Upstash ($10/mo during WC) plus complexity. Option if second-level precision ever matters; not needed here.
+
+**Verification step in implementation plan:** after merging the cadence change, watch `gh run list --workflow=live-scores.yml --limit 10` to confirm the new 1-minute cadence is firing cleanly. (Note that runs will still fail with empty-secrets errors until Phase 4.5 sets `CRON_SECRET` and `VERCEL_PROD_URL` — that's tracked separately in `project_phase_4_5_must_haves.md`.)
+
+---
+
+## Components
+
+### New
+
+| Path | Responsibility |
+|---|---|
+| `src/components/live/live-provider.tsx` | React context provider; owns poll timer, cache, diff event stream, visibility/focus listeners, error state. |
+| `src/components/live/use-live-game.ts` | Hook consuming the context. Public API for all other components. |
+| `src/components/live/live-score-ticker.tsx` | Top-of-page horizontal strip. Renders `<LiveFixtureCard>` per active fixture. Hides itself when no fixture is in `LIVE_WINDOW_BEFORE_MS` window. |
+| `src/components/live/live-fixture-card.tsx` | Per-fixture card: team badges, scores, status, "My pick" tag. Subscribes to goal events for celebration animation. |
+| `src/components/live/goal-celebration.tsx` | Decorator component applied to `<LiveFixtureCard>`. Manages the `celebrating` CSS class + `GOAL 34'` floating chip via `setTimeout` cleanup. |
+| `src/lib/live/derive.ts` | Pure functions: `deriveMatchState`, `projectPickOutcome`. |
+| `src/lib/live/detect.ts` | Pure functions: `detectGoalDeltas`, `detectPickSettlements`. |
+| `src/lib/live/types.ts` | Shared types: `GoalEvent`, `PickSettlementEvent`, `LivePayload` (re-export of `/live` response). |
+
+### Modified
+
+- `src/components/game/game-detail-view.tsx` — wraps children in `<LiveProvider>`, renders `<LiveScoreTicker>` above the existing content.
+- `src/components/standings/cup-grid.tsx` — accepts optional `live?: LivePayload` prop. Threads `viewerLivePick` state into the viewer's row styling and per-cell score-bump badges.
+- `src/components/standings/cup-ladder.tsx` — same pattern: `live?: LivePayload` prop, optional live enrichment on fixture cards.
+- `src/components/standings/cup-timeline.tsx` — same pattern.
+- `src/components/standings/cup-standings.tsx` — tab wrapper passes `live` down to the active tab's component.
+- `src/components/game/turbo-standings.tsx` — same `live?: LivePayload` pattern.
+- `src/components/standings/progress-grid.tsx` — classic-mode standings view. Same pattern.
+- `.github/workflows/live-scores.yml` — cron schedule cadence change (one line).
+
+---
+
+## Data flow
+
+1. `GameDetailView` renders; wraps children in `<LiveProvider value={{ gameId: game.id }}>`.
+2. `LiveProvider`'s `useEffect` mounts a poll timer immediately. First fetch runs on mount.
+3. On each response, `LiveProvider`:
+   - Stores the payload as `current`.
+   - Runs `detectGoalDeltas(previous, current)` and `detectPickSettlements(previous, current)`.
+   - Appends events to an in-memory ring buffer (last 20 events only, cleared on game-id change).
+   - Updates the timer's interval based on `hasActiveFixture(current.fixtures)` — 30s if any fixture in live window, 5min otherwise.
+4. `useLiveGame()` subscribers re-render. Each component reads:
+   - `payload` — current live state.
+   - `events` — ring buffer of recent events for animation triggering.
+   - `isStale` — true if last fetch failed; used for "reconnecting…" chip.
+5. Components register one-shot CSS-class animations against event ids. Each animation class is removed after ~600-2000ms (depends on animation) via `setTimeout`. Event ids are deterministic derivations of the payload state so the same goal never replays:
+   - `GoalEvent.id`: `${fixtureId}:${side}:${newScore}` where `side` is `home` or `away`. A score of 2-0 that became 3-0 emits id `fx_123:home:3`.
+   - `PickSettlementEvent.id`: `${gamePlayerId}:${roundId}:${result}` where `result` is the terminal state (`settled-loss` / `settled-win` / `saved-by-life`).
+   - Consumers maintain a `Set<string>` of already-animated ids; repeat appearances are ignored.
+6. `visibilitychange` listener pauses the timer; `focus` triggers an immediate refetch.
+7. On network error: set `isStale: true`, start exponential back-off (30s → 60s → 120s, cap 120s), continue rendering last good payload.
+8. On 401/403: clear payload, render sign-in prompt. On 404: clear payload, render empty state.
+
+---
+
+## Visual design
+
+The mockups explored during brainstorming are the source of truth for look and feel. Summarised here:
+
+**Ticker (`<LiveScoreTicker>`):**
+- Horizontal strip immediately below the game header. Fixed height ~80px.
+- Only renders if `hasActiveFixture`.
+- Each fixture card: 170px wide, scrollable horizontally on overflow.
+- Card border colour encodes status: red for live, amber for half-time, default for pre-match. Live cards also have an inset 1px border highlight.
+- Status pill at bottom-left of each card: `LIVE 34'` (with pulsing red dot), `HALF TIME`, `KICKS OFF IN 12m`, `FULL TIME`.
+- "My pick" tag (3b2f86 bg, white text) sits top-right when the viewer's pick references the fixture.
+
+**Goal celebration (`<GoalCelebration>`):**
+- Triggered by each `GoalEvent` whose fixtureId matches the card.
+- Animation (~2s total):
+  1. Card scales 1 → 1.05 → 1 over 600ms with a green glow (`box-shadow: 0 0 0 2px #22c55e, 0 0 20px rgba(34,197,94,0.4)`).
+  2. Background gradient transitions to green-tinted for 2s then fades back.
+  3. Score digit bumps in (translateY 8px → 0, opacity 0 → 1) over 500ms.
+  4. "GOAL 34'" chip floats in above the card (translateY 8px → 0 over 300ms) and remains visible for 1.5s before fading.
+- Colour cue: green for my-pick, red for opponent-pick. Same animation timing.
+- No audio (accessibility, plus users may be watching the game elsewhere).
+
+**Pick-row enrichment (standings components):**
+- When the viewer's pick's fixture is `live`, the viewer's row in the standings gets:
+  - `border-left: 3px solid #3b82f6`
+  - subtle blue-tinted gradient background on the left ~60%
+  - pulsing "LIVE" tag inline with the player name (animates 1.4s ease-in-out)
+- When a pick cell's underlying score changes, a score-bump badge appears on the cell for 800ms: green `+1` for my-team-scored, red `-1` for opposition-scored.
+
+**Elimination fade (3b):**
+- Triggered by each `PickSettlementEvent` with `result: 'settled-loss'` when the player's livesRemaining reaches 0.
+- Row opacity animates from 1 → 0.45 over 400ms.
+- `OUT R{n}` badge appears inline with player name: red border (`#ef4444`), transparent bg, red text.
+- No subsequent animation loop; row stays at 45% opacity until next render with fresh data.
+
+---
+
+## Error handling
+
+| Condition | Behaviour |
+|---|---|
+| Network failure (fetch throws / non-2xx) | Keep last payload; set `isStale: true`; show "reconnecting…" chip in ticker; exponential back-off (30s → 60s → 120s, cap 120s). |
+| 401 / 403 | Clear payload; render `<SignInAgain />` inline in ticker slot; stop polling. |
+| 404 | Clear payload; render "Game not found" empty state; stop polling. |
+| Tab hidden | Pause timer; no fetch fires while hidden. |
+| Tab focus | Immediate refetch; resume normal cadence. |
+| Game-id change mid-session | Unmount/remount `LiveProvider`; discard all state; fresh first fetch. |
+| `hasActiveFixture(current) === false` | Cadence drops to 5min. Ticker unmounts if no fixture in `LIVE_WINDOW_BEFORE_MS` window. |
+| Response arrives after game moved past current round | Provider discards payload if `payload.roundId !== gameData.currentRoundId`; UI stays stable. |
+
+---
+
+## Testing
+
+**Unit (Vitest, pure):**
+- `detectGoalDeltas`: single goal, multiple goals in one response, no deltas, score-decrement guarded (never emits), null-score → non-null (emits), non-null → null (ignored), fixture removed between polls (ignored).
+- `detectPickSettlements`: pick transitions to `settled-loss`, to `settled-win`, to `saved-by-life`, still-pending (no event), fixture removed (no event).
+- `deriveMatchState`: kickoff exactly at `now`, kickoff 9min ago (pre), kickoff 11min ago (live), kickoff 2h15m ago (live), kickoff 3h ago (ft-fallback if status missing), explicit `'live'`/`'finished'`/`'halftime'` status overrides.
+- `projectPickOutcome`: all six results × home/away/draw pick sides × cup/classic/turbo modes. Full truth table covered.
+
+**Hook (Vitest + `vi.useFakeTimers`):**
+- `useLiveGame` cadence: 30s poll during live window, 5min otherwise, immediate refetch on focus, paused on hidden.
+- Error recovery: 500 response → exponential back-off → recovery on next success.
+- 401 / 404 handling: no retry.
+- Game-id change: state reset; new game's first fetch triggers.
+
+**Integration (Playwright):**
+- Extend `scripts/seed.ts` with a "mid-match" cup game: `currentRound.fixtures` with `kickoff = now - 15min` + `status = 'live'` + `homeScore: 1, awayScore: 0`.
+- Assert ticker renders with the live card and correct status pill.
+- Mutate DB (`update fixture set home_score = 2 where id = ...`), wait for next poll tick, assert the digit animation fires and the new score renders.
+- Assert elimination fade renders when a loss-result pick is seeded into a player's row.
+
+**Workflow verification:**
+- After the cadence change lands on main, `gh run list --workflow=live-scores.yml --limit 10` should show 1-minute gaps between runs. Runs will still fail until Phase 4.5 adds the secrets, but the cadence shift itself is independently verifiable.
+
+**Post-launch (Phase 4.5 playbook):**
+- During a real WC fixture, open a seeded game detail page and verify scores update within ~60s of goal reports, goal celebrations fire, pick-row enrichment activates. This is the only full end-to-end verification possible; dev seed uses PL data which may or may not be in an active window.
+
+**Baseline tests before 4c1:** 196. Target after: ~215-220 (12-18 new unit + hook cases).
+
+---
+
+## Risk mitigation
+
+- **Polling correctness depends on payload identity.** If `getLivePayload` ever changes the structure of `fixtures[]` or `picks[]`, the diff functions could emit false events. Mitigation: make the payload shape explicit as a frozen TypeScript type shared between server and client (`src/lib/live/types.ts`). Any change to `/live` forces a corresponding type update and a compile error at the consumer.
+- **Goals before page-load are invisible.** Expected trade-off, but worth calling out in release notes so players don't assume the feature is broken when they open mid-match to see `ENG 2-0` without a celebration. Consider a "you missed 2 goals" chip in a future phase.
+- **Cadence bump increases GH Actions log noise.** 1440 workflow runs/day on the main page of the Actions tab. Mitigation: pre-release, set the default filter to "failing" in the repo README.
+- **Adaptive cadence might misfire on timezone edge.** `isFixtureInLiveWindow` is timezone-naive (UTC everywhere). Double-checked during 4a; 4c1 doesn't change it.
+- **Animation triggering on stale events after tab refocus.** If a user comes back after 20min away, the refetch may emit many goal events at once. Mitigation: cap the event ring buffer at 20, skip animation for events whose timestamp is >60s old (animate only "current" goals), still bump the scores.
+
+---
+
+## Rollout
+
+Phase 4c1 merges dormant onto `main` alongside 4a and 4b. No production activity until Phase 4.5. Dev verification is limited by the PL-only seed data: we can exercise the ticker layout and the static live states, but the cadence change and real football-data.org behaviour both only matter once prod is reachable and a real fixture window is active.
+
+Implementation plan (to be written next, via `superpowers:writing-plans`) should:
+- Land all pure-logic functions first (TDD-friendly).
+- Wire `LiveProvider` into `GameDetailView` before any component edits, so everything else can assume the hook works.
+- Gate the cron cadence change behind a separate commit so it's easy to revert if it causes unforeseen noise.
+- End with a verification pass modelled on Phase 4b's Task 37: full typecheck, full test suite, lint, `next build`, plus the `gh run list` cadence sanity-check.
+
+---
+
+## Dependencies on other sub-phases
+
+- 4c1 does not depend on 4c2-4c5. Ships independently.
+- 4c4 (Satori share variants) will consume the live payload to build a "live share" card image. Its design should reuse `LivePayload` from `src/lib/live/types.ts` — 4c1 pre-shapes this cleanly.
+- 4c5 (mobile polish) will include the ticker card's horizontal scroll behaviour and the pick-row enrichment spacing on narrow viewports.
+
+---
+
+## Acceptance criteria
+
+A Phase 4c1 PR is ready to merge when:
+
+- [ ] `<LiveScoreTicker>` renders at the top of the game detail page only when `hasActiveFixture` is true.
+- [ ] Each live fixture card shows team badges, current scores, correct status pill, and the "My pick" tag where applicable.
+- [ ] A manual DB score mutation on a live seed fixture triggers the on-card goal celebration (scale pulse, digit bump, floating chip) on the next poll tick.
+- [ ] The viewer's row in cup/classic/turbo standings gets blue left-border + "LIVE" pulse when their pick's fixture is in its live window.
+- [ ] A manual DB mutation transitioning a player's current pick to `settled-loss` (and `livesRemaining: 0`) renders the elimination fade + "OUT R{n}" badge on the correct row on the next poll tick.
+- [ ] Adaptive cadence verified in Chrome devtools: 30s between fetches when mid-match dev seed is loaded, 5min otherwise.
+- [ ] Cron change landed; `gh run list --workflow=live-scores.yml --limit 10` shows 1-minute gaps.
+- [ ] `pnpm exec tsc --noEmit` clean.
+- [ ] `pnpm exec biome check` clean.
+- [ ] `pnpm exec vitest run` all pass; test count increased by ~12-18.
+- [ ] `pnpm exec next build` compile + typecheck phases pass.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.12",
 		"@tailwindcss/postcss": "^4",
+		"@testing-library/dom": "^10.4.1",
+		"@testing-library/react": "^16.3.2",
 		"@types/node": "^20.19.39",
 		"@types/react": "^19",
 		"@types/react-dom": "^19",
@@ -44,6 +46,7 @@
 		"@vitejs/plugin-react": "^6.0.1",
 		"drizzle-kit": "^0.31.10",
 		"husky": "^9.1.7",
+		"jsdom": "^29.0.2",
 		"lint-staged": "^16.4.0",
 		"tailwindcss": "^4",
 		"tsx": "^4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 2.10.1
       better-auth:
         specifier: ^1.6.3
-        version: 1.6.3(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9))(next@16.2.3(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.6.3(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9))(next@16.2.3(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -72,6 +72,12 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.2
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/node':
         specifier: ^20.19.39
         version: 20.19.39
@@ -93,6 +99,9 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2(@noble/hashes@2.2.0)
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
@@ -107,13 +116,40 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@better-auth/core@1.6.3':
     resolution: {integrity: sha512-HefGR2SNfAi2RhT6XvSYViH4a0xoCGGL10bSDiv6sQGrmY6ulEQEV1X4nebTHeG0P6jdBmXAoEW3k37nhpk99w==}
@@ -248,6 +284,46 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.0':
+    resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -740,6 +816,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -1894,8 +1979,30 @@ packages:
   '@tailwindcss/postcss@4.2.2':
     resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -1976,9 +2083,17 @@ packages:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
@@ -1987,6 +2102,9 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -2067,6 +2185,9 @@ packages:
       zod:
         optional: true
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -2108,11 +2229,26 @@ packages:
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -2120,6 +2256,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   drizzle-kit@0.31.10:
     resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
@@ -2224,6 +2363,10 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -2290,6 +2433,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
@@ -2298,6 +2445,9 @@ packages:
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -2308,6 +2458,18 @@ packages:
 
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@29.0.2:
+    resolution: {integrity: sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -2403,13 +2565,24 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
+    engines: {node: 20 || >=22}
+
   lucide-react@1.8.0:
     resolution: {integrity: sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
@@ -2462,6 +2635,9 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-to-regexp@6.1.0:
     resolution: {integrity: sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==}
 
@@ -2494,6 +2670,10 @@ packages:
     resolution: {integrity: sha512-xtXazslu25CdnGnUkByU1RoOjK55TqwatJkjjJLg5ZAdz2Lngko/mmaUgeET36P2GMlNwh3fdM7FWBO717pNcw==}
     engines: {node: '>=12.13'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -2515,6 +2695,9 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -2550,6 +2733,10 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -2567,6 +2754,10 @@ packages:
 
   rou3@0.7.12:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -2650,6 +2841,9 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
@@ -2679,6 +2873,21 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.28:
+    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
+  tldts@7.0.28:
+    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
+    hasBin: true
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -2697,6 +2906,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -2810,6 +3023,22 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -2818,6 +3047,13 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
@@ -2833,6 +3069,36 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/runtime@7.29.2': {}
 
   '@better-auth/core@1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)':
     dependencies:
@@ -2922,6 +3188,34 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.4.12':
     optional: true
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
     dependencies:
@@ -3204,6 +3498,10 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.7':
     optional: true
+
+  '@exodus/bytes@1.15.0(@noble/hashes@2.2.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.2.0
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -4256,10 +4554,33 @@ snapshots:
       postcss: 8.5.9
       tailwindcss: 4.2.2
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -4359,7 +4680,11 @@ snapshots:
     dependencies:
       environment: 1.1.0
 
+  ansi-regex@5.0.1: {}
+
   ansi-regex@6.2.2: {}
+
+  ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.3: {}
 
@@ -4367,11 +4692,15 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
   assertion-error@2.0.1: {}
 
   baseline-browser-mapping@2.10.19: {}
 
-  better-auth@1.6.3(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9))(next@16.2.3(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))):
+  better-auth@1.6.3(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9))(next@16.2.3(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))):
     dependencies:
       '@better-auth/core': 1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.6.3(@better-auth/core@1.6.3(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.9))
@@ -4396,7 +4725,7 @@ snapshots:
       next: 16.2.3(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -4409,6 +4738,10 @@ snapshots:
       set-cookie-parser: 3.1.0
     optionalDependencies:
       zod: 4.3.6
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   buffer-from@1.1.2: {}
 
@@ -4441,13 +4774,31 @@ snapshots:
 
   crypto-js@4.2.0: {}
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.2.3: {}
 
+  data-urls@7.0.0(@noble/hashes@2.2.0):
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  decimal.js@10.6.0: {}
+
   defu@6.1.7: {}
+
+  dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   drizzle-kit@0.31.10:
     dependencies:
@@ -4468,6 +4819,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  entities@8.0.0: {}
 
   environment@1.1.0: {}
 
@@ -4587,17 +4940,53 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   husky@9.1.7: {}
 
   is-fullwidth-code-point@5.1.0:
     dependencies:
       get-east-asian-width: 1.5.0
 
+  is-potential-custom-element-name@1.0.1: {}
+
   jiti@2.6.1: {}
 
   jose@5.10.0: {}
 
   jose@6.2.2: {}
+
+  js-tokens@4.0.0: {}
+
+  jsdom@29.0.2(@noble/hashes@2.2.0):
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
+      css-tree: 3.2.1
+      data-urls: 7.0.0(@noble/hashes@2.2.0)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.5
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   json-schema-traverse@0.4.1:
     optional: true
@@ -4679,13 +5068,19 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
+  lru-cache@11.3.5: {}
+
   lucide-react@1.8.0(react@19.2.4):
     dependencies:
       react: 19.2.4
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  mdn-data@2.27.1: {}
 
   mimic-function@5.0.1: {}
 
@@ -4731,6 +5126,10 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-to-regexp@6.1.0: {}
 
   path-to-regexp@6.3.0: {}
@@ -4759,8 +5158,13 @@ snapshots:
     dependencies:
       timestring: 6.0.0
 
-  punycode@2.3.1:
-    optional: true
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  punycode@2.3.1: {}
 
   radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -4830,6 +5234,8 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-is@17.0.2: {}
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -4858,6 +5264,8 @@ snapshots:
       '@types/react': 19.2.14
 
   react@19.2.4: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -4890,6 +5298,10 @@ snapshots:
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
 
   rou3@0.7.12: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -4984,6 +5396,8 @@ snapshots:
       client-only: 0.0.1
       react: 19.2.4
 
+  symbol-tree@3.2.4: {}
+
   tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.2: {}
@@ -5003,6 +5417,20 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@7.0.28: {}
+
+  tldts@7.0.28:
+    dependencies:
+      tldts-core: 7.0.28
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.28
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
+
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -5017,6 +5445,8 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  undici@7.25.0: {}
 
   uri-js@4.4.1:
     dependencies:
@@ -5057,7 +5487,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -5082,8 +5512,25 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 20.19.39
+      jsdom: 29.0.2(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1(@noble/hashes@2.2.0):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@2.2.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   why-is-node-running@2.3.0:
     dependencies:
@@ -5095,6 +5542,10 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yaml@2.8.3: {}
 

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -707,6 +707,29 @@ async function seed() {
 		console.log(`Created "${seed.name}" (${seed.mode}) — ${seed.players.length} players`)
 	}
 
+	// --- Mid-match Cup game for live UI verification ---
+	const round8 = rounds.find((r) => r.number === 8)
+	if (round8) {
+		const round8Fixtures = fixturesByRound.get(round8.id) ?? []
+		const kickoffTime = round8Fixtures[0]?.kickoff ?? now
+		const kickoff15MinAgo = new Date(kickoffTime.getTime() - 15 * 60 * 1000)
+
+		// Update first two fixtures to live status with partial scores
+		for (let i = 0; i < Math.min(2, round8Fixtures.length); i++) {
+			const f = round8Fixtures[i]
+			await db
+				.update(fixture)
+				.set({
+					status: 'live',
+					homeScore: 1,
+					awayScore: Math.floor(rng() * 2),
+					kickoff: kickoff15MinAgo,
+				})
+				.where(eq(fixture.id, f.id))
+		}
+		console.log(`Updated 2 fixtures in round 8 to live status for verification`)
+	}
+
 	console.log('\nSeed complete!')
 	console.log('\nLog in with any of these (password: password123):')
 	for (const u of DEV_USERS) console.log(`  ${u.email}`)

--- a/src/components/game/game-detail-view.tsx
+++ b/src/components/game/game-detail-view.tsx
@@ -8,6 +8,8 @@ import { OtherPlayersPayments } from '@/components/game/other-players-payments'
 import type { PaymentStatus } from '@/components/game/payment-status-chip'
 import { type AdminPayment, PaymentsPanel } from '@/components/game/payments-panel'
 import { ShareDialog } from '@/components/game/share-dialog'
+import { LiveProvider } from '@/components/live/live-provider'
+import { LiveScoreTicker } from '@/components/live/live-score-ticker'
 import { CupStandings } from '@/components/standings/cup-standings'
 import { type GridPlayer, type GridRound, ProgressGrid } from '@/components/standings/progress-grid'
 import { type TurboRoundSummary, TurboStandings } from '@/components/standings/turbo-standings'
@@ -63,86 +65,90 @@ export function GameDetailView({
 		typeof window !== 'undefined' ? `${window.location.origin}/join/${game.inviteCode}` : ''
 
 	return (
-		<div>
-			<GameHeader
-				name={game.name}
-				mode={game.gameMode}
-				competition={game.competition}
-				potBreakdown={game.pot}
-				target={game.target}
-				unpaid={game.unpaid}
-				entryFee={game.entryFee}
-				playerCount={game.playerCount}
-				aliveCount={game.aliveCount}
-				status={game.status}
-				inviteCode={game.inviteCode}
-				onShare={() => setShareOpen(true)}
-			/>
+		<LiveProvider gameId={game.id}>
+			<div>
+				<LiveScoreTicker />
 
-			{game.myPayment && (
-				<div className="mb-4">
-					<MyPaymentStrip
+				<GameHeader
+					name={game.name}
+					mode={game.gameMode}
+					competition={game.competition}
+					potBreakdown={game.pot}
+					target={game.target}
+					unpaid={game.unpaid}
+					entryFee={game.entryFee}
+					playerCount={game.playerCount}
+					aliveCount={game.aliveCount}
+					status={game.status}
+					inviteCode={game.inviteCode}
+					onShare={() => setShareOpen(true)}
+				/>
+
+				{game.myPayment && (
+					<div className="mb-4">
+						<MyPaymentStrip
+							gameId={game.id}
+							status={game.myPayment.status}
+							amount={game.myPayment.amount}
+							creatorName={game.creatorName}
+							onClaimed={refresh}
+						/>
+					</div>
+				)}
+
+				{game.otherPayments.length > 0 && (
+					<div className="mb-6">
+						<OtherPlayersPayments payments={game.otherPayments} />
+					</div>
+				)}
+
+				<div className="mb-6">{pickSection}</div>
+
+				{classicGrid && (
+					<ProgressGrid
+						rounds={classicGrid.rounds}
+						players={classicGrid.players}
+						aliveCount={classicGrid.aliveCount}
+						eliminatedCount={classicGrid.eliminatedCount}
+						pot={classicGrid.pot}
 						gameId={game.id}
-						status={game.myPayment.status}
-						amount={game.myPayment.amount}
-						creatorName={game.creatorName}
-						onClaimed={refresh}
+						onShare={() => setShareOpen(true)}
 					/>
-				</div>
-			)}
+				)}
 
-			{game.otherPayments.length > 0 && (
-				<div className="mb-6">
-					<OtherPlayersPayments payments={game.otherPayments} />
-				</div>
-			)}
+				{turboStandings && (
+					<TurboStandings
+						rounds={turboStandings.rounds}
+						numberOfPicks={turboStandings.numberOfPicks}
+						onShare={() => setShareOpen(true)}
+					/>
+				)}
 
-			<div className="mb-6">{pickSection}</div>
+				{cupStandings && <CupStandings data={cupStandings} onShare={() => setShareOpen(true)} />}
 
-			{classicGrid && (
-				<ProgressGrid
-					rounds={classicGrid.rounds}
-					players={classicGrid.players}
-					aliveCount={classicGrid.aliveCount}
-					eliminatedCount={classicGrid.eliminatedCount}
-					pot={classicGrid.pot}
+				{game.isAdmin && game.adminPayments && game.adminPayments.length > 0 && (
+					<div className="mt-6">
+						<PaymentsPanel
+							gameId={game.id}
+							gameName={game.name}
+							inviteCode={game.inviteCode}
+							totals={game.pot}
+							payments={game.adminPayments}
+							onChange={refresh}
+						/>
+					</div>
+				)}
+
+				<ShareDialog
+					open={shareOpen}
+					onOpenChange={setShareOpen}
 					gameId={game.id}
-					onShare={() => setShareOpen(true)}
+					gameName={game.name}
+					pot={game.pot.total}
+					inviteUrl={inviteUrl}
+					inviteCode={game.inviteCode}
 				/>
-			)}
-
-			{turboStandings && (
-				<TurboStandings
-					rounds={turboStandings.rounds}
-					numberOfPicks={turboStandings.numberOfPicks}
-					onShare={() => setShareOpen(true)}
-				/>
-			)}
-
-			{cupStandings && <CupStandings data={cupStandings} onShare={() => setShareOpen(true)} />}
-
-			{game.isAdmin && game.adminPayments && game.adminPayments.length > 0 && (
-				<div className="mt-6">
-					<PaymentsPanel
-						gameId={game.id}
-						gameName={game.name}
-						inviteCode={game.inviteCode}
-						totals={game.pot}
-						payments={game.adminPayments}
-						onChange={refresh}
-					/>
-				</div>
-			)}
-
-			<ShareDialog
-				open={shareOpen}
-				onOpenChange={setShareOpen}
-				gameId={game.id}
-				gameName={game.name}
-				pot={game.pot.total}
-				inviteUrl={inviteUrl}
-				inviteCode={game.inviteCode}
-			/>
-		</div>
+			</div>
+		</LiveProvider>
 	)
 }

--- a/src/components/live/goal-celebration.tsx
+++ b/src/components/live/goal-celebration.tsx
@@ -25,20 +25,21 @@ export function GoalCelebration({ fixtureId, viewerPick, children }: GoalCelebra
 	const handledIds = useRef<Set<string>>(new Set())
 
 	useEffect(() => {
-		for (const ev of events.goals) {
-			if (ev.fixtureId !== fixtureId) continue
-			if (handledIds.current.has(ev.id)) continue
-			handledIds.current.add(ev.id)
-			const friendly =
-				!!viewerPick &&
-				((ev.side === 'home' && viewerPick.predictedResult === 'home_win') ||
-					(ev.side === 'away' && viewerPick.predictedResult === 'away_win'))
-			setActive({ eventId: ev.id, side: ev.side, minute: 0, friendly })
-			const timer = setTimeout(() => {
-				setActive((current) => (current?.eventId === ev.id ? null : current))
-			}, HOLD_MS)
-			return () => clearTimeout(timer)
-		}
+		const newForThisFixture = events.goals.filter(
+			(ev) => ev.fixtureId === fixtureId && !handledIds.current.has(ev.id),
+		)
+		if (newForThisFixture.length === 0) return
+		for (const ev of newForThisFixture) handledIds.current.add(ev.id)
+		const latest = newForThisFixture[newForThisFixture.length - 1]
+		const friendly =
+			!!viewerPick &&
+			((latest.side === 'home' && viewerPick.predictedResult === 'home_win') ||
+				(latest.side === 'away' && viewerPick.predictedResult === 'away_win'))
+		setActive({ eventId: latest.id, side: latest.side, minute: 0, friendly })
+		const timer = setTimeout(() => {
+			setActive((current) => (current?.eventId === latest.id ? null : current))
+		}, HOLD_MS)
+		return () => clearTimeout(timer)
 	}, [events.goals, fixtureId, viewerPick])
 
 	return (

--- a/src/components/live/goal-celebration.tsx
+++ b/src/components/live/goal-celebration.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { type ReactNode, useEffect, useRef, useState } from 'react'
-import type { GoalEvent, LivePick } from '@/lib/live/types'
+import type { LivePick } from '@/lib/live/types'
 import { cn } from '@/lib/utils'
 import { useLiveGame } from './use-live-game'
 

--- a/src/components/live/goal-celebration.tsx
+++ b/src/components/live/goal-celebration.tsx
@@ -1,0 +1,71 @@
+'use client'
+import { type ReactNode, useEffect, useRef, useState } from 'react'
+import type { GoalEvent, LivePick } from '@/lib/live/types'
+import { cn } from '@/lib/utils'
+import { useLiveGame } from './use-live-game'
+
+interface GoalCelebrationProps {
+	fixtureId: string
+	viewerPick?: LivePick | null
+	children: ReactNode
+}
+
+interface Celebration {
+	eventId: string
+	side: 'home' | 'away'
+	minute: number
+	friendly: boolean
+}
+
+const HOLD_MS = 2000
+
+export function GoalCelebration({ fixtureId, viewerPick, children }: GoalCelebrationProps) {
+	const { events } = useLiveGame()
+	const [active, setActive] = useState<Celebration | null>(null)
+	const handledIds = useRef<Set<string>>(new Set())
+
+	useEffect(() => {
+		for (const ev of events.goals) {
+			if (ev.fixtureId !== fixtureId) continue
+			if (handledIds.current.has(ev.id)) continue
+			handledIds.current.add(ev.id)
+			const friendly =
+				!!viewerPick &&
+				((ev.side === 'home' && viewerPick.predictedResult === 'home_win') ||
+					(ev.side === 'away' && viewerPick.predictedResult === 'away_win'))
+			setActive({ eventId: ev.id, side: ev.side, minute: 0, friendly })
+			const timer = setTimeout(() => {
+				setActive((current) => (current?.eventId === ev.id ? null : current))
+			}, HOLD_MS)
+			return () => clearTimeout(timer)
+		}
+	}, [events.goals, fixtureId, viewerPick])
+
+	return (
+		<div className="relative">
+			{active && (
+				<span
+					className={cn(
+						'absolute left-1/2 -top-2.5 z-10 -translate-x-1/2 rounded-full px-2.5 py-0.5 text-[10px] font-black uppercase tracking-widest text-white shadow-lg',
+						active.friendly ? 'bg-emerald-500' : 'bg-red-500',
+					)}
+				>
+					GOAL
+				</span>
+			)}
+			<div
+				data-celebrating={active ? (active.friendly ? 'friendly' : 'opposing') : undefined}
+				className={cn(
+					'transition-all duration-300',
+					active?.friendly &&
+						'ring-2 ring-emerald-500 shadow-[0_0_20px_rgba(34,197,94,0.4)] scale-[1.03]',
+					active &&
+						!active.friendly &&
+						'ring-2 ring-red-500 shadow-[0_0_20px_rgba(239,68,68,0.4)] scale-[1.02]',
+				)}
+			>
+				{children}
+			</div>
+		</div>
+	)
+}

--- a/src/components/live/live-fixture-card.tsx
+++ b/src/components/live/live-fixture-card.tsx
@@ -1,0 +1,75 @@
+'use client'
+import { deriveMatchState } from '@/lib/live/derive'
+import type { LiveFixture } from '@/lib/live/types'
+import { cn } from '@/lib/utils'
+import { LiveDot } from './live-indicators'
+
+interface LiveFixtureCardProps {
+	fixture: LiveFixture
+	isMyPick?: boolean
+	now?: Date
+	className?: string
+}
+
+function statusText(
+	state: 'pre' | 'live' | 'ht' | 'ft',
+	kickoff: Date | string | null,
+	now: Date,
+): string {
+	if (state === 'ht') return 'HALF TIME'
+	if (state === 'ft') return 'FULL TIME'
+	if (state === 'live') return 'LIVE'
+	if (!kickoff) return 'TBC'
+	const t = typeof kickoff === 'string' ? Date.parse(kickoff) : kickoff.getTime()
+	const mins = Math.max(0, Math.round((t - now.getTime()) / 60_000))
+	return mins === 0 ? 'KICKING OFF' : `KICKS OFF IN ${mins}m`
+}
+
+export function LiveFixtureCard({
+	fixture,
+	isMyPick = false,
+	now = new Date(),
+	className,
+}: LiveFixtureCardProps) {
+	const state = deriveMatchState(fixture, now)
+	const statusClasses =
+		state === 'live'
+			? 'text-[#ef4444] border-[#ef4444]'
+			: state === 'ht'
+				? 'text-amber-500 border-amber-500'
+				: 'text-muted-foreground border-border'
+	return (
+		<div
+			data-fixture-id={fixture.id}
+			data-state={state}
+			className={cn(
+				'relative flex min-w-[170px] flex-col gap-1 rounded-lg border bg-card px-3 py-2',
+				statusClasses,
+				state === 'pre' && 'opacity-70',
+				className,
+			)}
+		>
+			{isMyPick && (
+				<span className="absolute -top-1.5 right-2 rounded-sm bg-primary px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-primary-foreground">
+					My pick
+				</span>
+			)}
+			<div className="flex items-center justify-between text-sm font-semibold">
+				<span>{fixture.homeShort}</span>
+				<span data-score="home" className="font-variant-numeric: tabular-nums; font-bold">
+					{fixture.homeScore ?? '−'}
+				</span>
+			</div>
+			<div className="flex items-center justify-between text-sm font-semibold">
+				<span>{fixture.awayShort}</span>
+				<span data-score="away" className="font-variant-numeric: tabular-nums; font-bold">
+					{fixture.awayScore ?? '−'}
+				</span>
+			</div>
+			<div className="mt-1 flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-wider">
+				{state === 'live' && <LiveDot className="text-[#ef4444]" />}
+				<span className="text-current">{statusText(state, fixture.kickoff, now)}</span>
+			</div>
+		</div>
+	)
+}

--- a/src/components/live/live-fixture-card.tsx
+++ b/src/components/live/live-fixture-card.tsx
@@ -56,13 +56,13 @@ export function LiveFixtureCard({
 			)}
 			<div className="flex items-center justify-between text-sm font-semibold">
 				<span>{fixture.homeShort}</span>
-				<span data-score="home" className="font-variant-numeric: tabular-nums; font-bold">
+				<span data-score="home" className="tabular-nums font-bold">
 					{fixture.homeScore ?? '−'}
 				</span>
 			</div>
 			<div className="flex items-center justify-between text-sm font-semibold">
 				<span>{fixture.awayShort}</span>
-				<span data-score="away" className="font-variant-numeric: tabular-nums; font-bold">
+				<span data-score="away" className="tabular-nums font-bold">
 					{fixture.awayScore ?? '−'}
 				</span>
 			</div>

--- a/src/components/live/live-indicators.tsx
+++ b/src/components/live/live-indicators.tsx
@@ -1,0 +1,24 @@
+import { cn } from '@/lib/utils'
+
+export function LiveDot({ className }: { className?: string }) {
+	return (
+		<span
+			role="img"
+			aria-label="live"
+			className={cn(
+				'inline-block h-1.5 w-1.5 rounded-full bg-current',
+				'animate-[pulse_1.4s_ease-in-out_infinite]',
+				className,
+			)}
+		/>
+	)
+}
+
+export function ReconnectingChip() {
+	return (
+		<span className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+			<span className="inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground animate-[pulse_1.4s_ease-in-out_infinite]" />
+			Reconnecting…
+		</span>
+	)
+}

--- a/src/components/live/live-provider.tsx
+++ b/src/components/live/live-provider.tsx
@@ -1,6 +1,14 @@
 'use client'
-import { createContext, type ReactNode, useMemo, useState } from 'react'
+import { createContext, type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
+import { detectGoalDeltas, detectPickSettlements } from '@/lib/live/detect'
 import type { GoalEvent, LivePayload, PickSettlementEvent } from '@/lib/live/types'
+
+const LIVE_CADENCE_MS = 30_000
+const IDLE_CADENCE_MS = 5 * 60_000
+const MAX_BACKOFF_MS = 120_000
+const LIVE_WINDOW_BEFORE_MS = 10 * 60_000
+const LIVE_WINDOW_AFTER_MS = 150 * 60_000
+const EVENT_BUFFER_CAP = 20
 
 export interface LiveContextValue {
 	payload: LivePayload | null
@@ -21,21 +29,116 @@ const defaultValue: LiveContextValue = {
 
 export const LiveContext = createContext<LiveContextValue>(defaultValue)
 
+function hasActiveFixture(payload: LivePayload | null, now = Date.now()): boolean {
+	if (!payload) return false
+	return payload.fixtures.some((f) => {
+		if (!f.kickoff) return false
+		const t = typeof f.kickoff === 'string' ? Date.parse(f.kickoff) : f.kickoff.getTime()
+		return now >= t - LIVE_WINDOW_BEFORE_MS && now <= t + LIVE_WINDOW_AFTER_MS
+	})
+}
+
 interface LiveProviderProps {
 	gameId: string
 	children: ReactNode
 }
 
-export function LiveProvider({ gameId: _gameId, children }: LiveProviderProps) {
-	const [payload] = useState<LivePayload | null>(null)
+export function LiveProvider({ gameId, children }: LiveProviderProps) {
+	const [payload, setPayload] = useState<LivePayload | null>(null)
+	const [goals, setGoals] = useState<GoalEvent[]>([])
+	const [settlements, setSettlements] = useState<PickSettlementEvent[]>([])
+	const [isStale, setIsStale] = useState(false)
+	const [reconnecting, setReconnecting] = useState(false)
+
+	const previousRef = useRef<LivePayload | null>(null)
+	const backoffRef = useRef(0)
+
+	useEffect(() => {
+		let cancelled = false
+		let timer: ReturnType<typeof setTimeout> | null = null
+
+		async function fetchOnce() {
+			let scheduleNext = true
+			try {
+				const res = await fetch(`/api/games/${gameId}/live`, { cache: 'no-store' })
+				if (cancelled) {
+					scheduleNext = false
+					return
+				}
+				if (res.status === 401 || res.status === 403 || res.status === 404) {
+					setPayload(null)
+					setIsStale(true)
+					setReconnecting(false)
+					return
+				}
+				if (!res.ok) throw new Error(`HTTP ${res.status}`)
+				const next = (await res.json()) as LivePayload
+				const prev = previousRef.current
+				if (prev) {
+					const newGoals = detectGoalDeltas(prev, next)
+					if (newGoals.length) {
+						setGoals((g) => [...g, ...newGoals].slice(-EVENT_BUFFER_CAP))
+					}
+					const newSettlements = detectPickSettlements(prev, next)
+					if (newSettlements.length) {
+						setSettlements((s) => [...s, ...newSettlements].slice(-EVENT_BUFFER_CAP))
+					}
+				}
+				previousRef.current = next
+				setPayload(next)
+				setIsStale(false)
+				setReconnecting(false)
+				backoffRef.current = 0
+			} catch {
+				if (cancelled) {
+					scheduleNext = false
+					return
+				}
+				setIsStale(true)
+				setReconnecting(true)
+				backoffRef.current = Math.min(
+					backoffRef.current > 0 ? backoffRef.current * 2 : LIVE_CADENCE_MS,
+					MAX_BACKOFF_MS,
+				)
+			}
+
+			if (!scheduleNext) return
+			if (cancelled) return
+			if (document.visibilityState === 'hidden') return
+			const interval =
+				backoffRef.current > 0
+					? backoffRef.current
+					: hasActiveFixture(previousRef.current)
+						? LIVE_CADENCE_MS
+						: IDLE_CADENCE_MS
+			timer = setTimeout(fetchOnce, interval)
+		}
+
+		function handleVisibility() {
+			if (document.visibilityState === 'visible') {
+				if (timer) clearTimeout(timer)
+				void fetchOnce()
+			} else if (timer) {
+				clearTimeout(timer)
+				timer = null
+			}
+		}
+
+		document.addEventListener('visibilitychange', handleVisibility)
+		void fetchOnce()
+
+		return () => {
+			cancelled = true
+			if (timer) clearTimeout(timer)
+			document.removeEventListener('visibilitychange', handleVisibility)
+			previousRef.current = null
+		}
+	}, [gameId])
+
 	const value = useMemo<LiveContextValue>(
-		() => ({
-			payload,
-			events: { goals: [], settlements: [] },
-			isStale: false,
-			reconnecting: false,
-		}),
-		[payload],
+		() => ({ payload, events: { goals, settlements }, isStale, reconnecting }),
+		[payload, goals, settlements, isStale, reconnecting],
 	)
+
 	return <LiveContext.Provider value={value}>{children}</LiveContext.Provider>
 }

--- a/src/components/live/live-provider.tsx
+++ b/src/components/live/live-provider.tsx
@@ -1,0 +1,41 @@
+'use client'
+import { createContext, type ReactNode, useMemo, useState } from 'react'
+import type { GoalEvent, LivePayload, PickSettlementEvent } from '@/lib/live/types'
+
+export interface LiveContextValue {
+	payload: LivePayload | null
+	events: {
+		goals: GoalEvent[]
+		settlements: PickSettlementEvent[]
+	}
+	isStale: boolean
+	reconnecting: boolean
+}
+
+const defaultValue: LiveContextValue = {
+	payload: null,
+	events: { goals: [], settlements: [] },
+	isStale: false,
+	reconnecting: false,
+}
+
+export const LiveContext = createContext<LiveContextValue>(defaultValue)
+
+interface LiveProviderProps {
+	gameId: string
+	children: ReactNode
+}
+
+export function LiveProvider({ gameId: _gameId, children }: LiveProviderProps) {
+	const [payload] = useState<LivePayload | null>(null)
+	const value = useMemo<LiveContextValue>(
+		() => ({
+			payload,
+			events: { goals: [], settlements: [] },
+			isStale: false,
+			reconnecting: false,
+		}),
+		[payload],
+	)
+	return <LiveContext.Provider value={value}>{children}</LiveContext.Provider>
+}

--- a/src/components/live/live-score-ticker.tsx
+++ b/src/components/live/live-score-ticker.tsx
@@ -1,0 +1,49 @@
+'use client'
+import { deriveMatchState } from '@/lib/live/derive'
+import type { LivePick } from '@/lib/live/types'
+import { GoalCelebration } from './goal-celebration'
+import { LiveFixtureCard } from './live-fixture-card'
+import { ReconnectingChip } from './live-indicators'
+import { useLiveGame } from './use-live-game'
+
+export function LiveScoreTicker() {
+	const { payload, reconnecting } = useLiveGame()
+	if (!payload) return null
+
+	const now = new Date()
+	const livish = payload.fixtures.filter((f) => {
+		const state = deriveMatchState(f, now)
+		return state === 'pre' || state === 'live' || state === 'ht'
+	})
+	if (livish.length === 0) return null
+
+	const viewerPicksByFixture = new Map<string, LivePick>()
+	const viewerPlayerIds = new Set(
+		payload.players.filter((p) => p.userId === payload.viewerUserId).map((p) => p.id),
+	)
+	for (const pk of payload.picks) {
+		if (viewerPlayerIds.has(pk.gamePlayerId) && pk.fixtureId) {
+			viewerPicksByFixture.set(pk.fixtureId, pk)
+		}
+	}
+
+	return (
+		<div className="mb-4 flex items-start gap-2">
+			<div className="flex flex-1 gap-2 overflow-x-auto pb-1">
+				{livish.map((fixture) => {
+					const viewerPick = viewerPicksByFixture.get(fixture.id) ?? null
+					return (
+						<GoalCelebration key={fixture.id} fixtureId={fixture.id} viewerPick={viewerPick}>
+							<LiveFixtureCard fixture={fixture} isMyPick={Boolean(viewerPick)} now={now} />
+						</GoalCelebration>
+					)
+				})}
+			</div>
+			{reconnecting && (
+				<div className="shrink-0 pt-1">
+					<ReconnectingChip />
+				</div>
+			)}
+		</div>
+	)
+}

--- a/src/components/live/use-live-game.test.tsx
+++ b/src/components/live/use-live-game.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LivePayload } from '@/lib/live/types'
+import { LiveProvider } from './live-provider'
+import { useLiveGame } from './use-live-game'
+
+function wrapperFor(gameId: string) {
+	return function Wrapper({ children }: { children: React.ReactNode }) {
+		return <LiveProvider gameId={gameId}>{children}</LiveProvider>
+	}
+}
+
+function basePayload(overrides: Partial<LivePayload> = {}): LivePayload {
+	return {
+		gameId: 'g1',
+		gameMode: 'classic',
+		roundId: 'r1',
+		fixtures: [],
+		picks: [],
+		players: [],
+		viewerUserId: 'u1',
+		updatedAt: new Date().toISOString(),
+		...overrides,
+	}
+}
+
+describe('useLiveGame', () => {
+	beforeEach(() => {
+		vi.stubGlobal('fetch', vi.fn())
+	})
+
+	afterEach(() => {
+		vi.unstubAllGlobals()
+	})
+
+	it('fetches immediately on mount and returns payload', async () => {
+		const payload = basePayload()
+		;(fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => payload,
+		})
+		const { result, unmount } = renderHook(() => useLiveGame(), { wrapper: wrapperFor('g1') })
+		await waitFor(() => expect(result.current.payload).not.toBeNull())
+		expect(result.current.payload?.gameId).toBe('g1')
+		unmount()
+	})
+
+	it('sets isStale on fetch failure', async () => {
+		;(fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('network down'))
+		const { result, unmount } = renderHook(() => useLiveGame(), { wrapper: wrapperFor('g1') })
+		await waitFor(() => expect(result.current.isStale).toBe(true))
+		unmount()
+	})
+})

--- a/src/components/live/use-live-game.ts
+++ b/src/components/live/use-live-game.ts
@@ -1,0 +1,7 @@
+'use client'
+import { useContext } from 'react'
+import { LiveContext, type LiveContextValue } from './live-provider'
+
+export function useLiveGame(): LiveContextValue {
+	return useContext(LiveContext)
+}

--- a/src/components/standings/cup-grid.tsx
+++ b/src/components/standings/cup-grid.tsx
@@ -2,12 +2,10 @@
 
 import { useLiveGame } from '@/components/live/use-live-game'
 import type { CupStandingsData } from '@/lib/game/cup-standings-queries'
-import type { LivePayload } from '@/lib/live/types'
 import { cn } from '@/lib/utils'
 
 interface CupGridProps {
 	data: CupStandingsData
-	live?: LivePayload
 }
 
 const LIVE_RECENT_MS = 1500

--- a/src/components/standings/cup-grid.tsx
+++ b/src/components/standings/cup-grid.tsx
@@ -1,13 +1,70 @@
 'use client'
 
+import { useLiveGame } from '@/components/live/use-live-game'
 import type { CupStandingsData } from '@/lib/game/cup-standings-queries'
+import type { LivePayload } from '@/lib/live/types'
 import { cn } from '@/lib/utils'
 
 interface CupGridProps {
 	data: CupStandingsData
+	live?: LivePayload
+}
+
+const LIVE_RECENT_MS = 1500
+
+interface LiveRowMeta {
+	viewerGamePlayerId: string | undefined
+	viewerRowIsLive: boolean
+	eliminatedGpIds: Set<string>
+	recentGoalByFixture: Map<string, { side: 'home' | 'away' }>
 }
 
 export function CupGrid({ data }: CupGridProps) {
+	const liveCtx = useLiveGame()
+	const now = Date.now()
+
+	const recentGoalByFixture = new Map<string, { side: 'home' | 'away' }>()
+	for (const ev of liveCtx.events.goals) {
+		if (now - ev.observedAt <= LIVE_RECENT_MS) {
+			recentGoalByFixture.set(ev.fixtureId, { side: ev.side })
+		}
+	}
+
+	const eliminatedGpIds = new Set<string>()
+	for (const ev of liveCtx.events.settlements) {
+		if (ev.result !== 'settled-loss') continue
+		const p = liveCtx.payload?.players.find((pp) => pp.id === ev.gamePlayerId)
+		if (p && p.livesRemaining === 0) eliminatedGpIds.add(ev.gamePlayerId)
+	}
+
+	const viewerUserId = liveCtx.payload?.viewerUserId
+	const viewerGp = viewerUserId
+		? liveCtx.payload?.players.find((p) => p.userId === viewerUserId)
+		: undefined
+	const viewerPickFixtureId = viewerGp
+		? (liveCtx.payload?.picks.find((pk) => pk.gamePlayerId === viewerGp.id && pk.fixtureId)
+				?.fixtureId ?? undefined)
+		: undefined
+	const viewerFixtureStatus = viewerPickFixtureId
+		? liveCtx.payload?.fixtures.find((f) => f.id === viewerPickFixtureId)?.status
+		: undefined
+	const viewerRowIsLive = viewerFixtureStatus === 'live' || viewerFixtureStatus === 'halftime'
+
+	const liveMeta: LiveRowMeta = {
+		viewerGamePlayerId: viewerGp?.id,
+		viewerRowIsLive,
+		eliminatedGpIds,
+		recentGoalByFixture,
+	}
+
+	const pickFixtureByPlayer = new Map<string, Map<number, string>>()
+	for (const pk of liveCtx.payload?.picks ?? []) {
+		if (!pk.fixtureId || pk.confidenceRank == null) continue
+		const inner = pickFixtureByPlayer.get(pk.gamePlayerId) ?? new Map<number, string>()
+		inner.set(pk.confidenceRank, pk.fixtureId)
+		pickFixtureByPlayer.set(pk.gamePlayerId, inner)
+	}
+
 	const alive = data.players
 		.filter((p) => p.status !== 'eliminated')
 		.sort((a, b) => b.streak - a.streak || b.goals - a.goals)
@@ -38,6 +95,9 @@ export function CupGrid({ data }: CupGridProps) {
 						numberOfPicks={data.numberOfPicks}
 						maxLives={data.maxLives}
 						position={idx + 1}
+						roundNumber={data.roundNumber}
+						liveMeta={liveMeta}
+						pickFixtureByRank={pickFixtureByPlayer.get(player.id)}
 					/>
 				))}
 				{out.length > 0 && (
@@ -52,6 +112,9 @@ export function CupGrid({ data }: CupGridProps) {
 								numberOfPicks={data.numberOfPicks}
 								maxLives={data.maxLives}
 								position={alive.length + idx + 1}
+								roundNumber={data.roundNumber}
+								liveMeta={liveMeta}
+								pickFixtureByRank={pickFixtureByPlayer.get(player.id)}
 								isOut
 							/>
 						))}
@@ -91,19 +154,32 @@ function PlayerRow({
 	numberOfPicks,
 	maxLives,
 	position,
+	roundNumber,
+	liveMeta,
+	pickFixtureByRank,
 	isOut,
 }: {
 	player: CupStandingsData['players'][number]
 	numberOfPicks: number
 	maxLives: number
 	position: number
+	roundNumber: number
+	liveMeta: LiveRowMeta
+	pickFixtureByRank?: Map<number, string>
 	isOut?: boolean
 }) {
+	const isViewer = liveMeta.viewerGamePlayerId === player.id
+	const viewerLiveStyle = isViewer && liveMeta.viewerRowIsLive
+	const liveEliminated = liveMeta.eliminatedGpIds.has(player.id)
 	return (
 		<div
+			data-gpid={player.id}
 			className={cn(
 				'grid grid-cols-[24px_140px_80px_48px_48px_repeat(var(--picks),62px)] gap-1.5 px-1 py-1.5 items-center border-t border-border',
 				isOut && 'opacity-55',
+				viewerLiveStyle &&
+					'border-l-4 border-l-primary bg-gradient-to-r from-primary/10 to-transparent pl-2',
+				liveEliminated && 'opacity-45 transition-opacity duration-[400ms]',
 			)}
 			style={{ ['--picks' as string]: numberOfPicks }}
 		>
@@ -111,8 +187,14 @@ function PlayerRow({
 			<div className="flex items-center gap-2 min-w-0">
 				<Avatar name={player.name} />
 				<span className="text-sm font-semibold truncate">{player.name}</span>
+				{viewerLiveStyle && (
+					<span className="ml-0.5 rounded-sm bg-primary/15 px-1 py-0.5 text-[9px] font-bold uppercase text-primary animate-[pulse_1.4s_ease-in-out_infinite]">
+						LIVE
+					</span>
+				)}
 				{!player.hasSubmitted && <Badge tone="warn">NO PICKS</Badge>}
 				{isOut && <Badge tone="danger">OUT GW{player.eliminatedRoundNumber ?? '?'}</Badge>}
+				{!isOut && liveEliminated && <Badge tone="danger">OUT GW{roundNumber}</Badge>}
 			</div>
 			<LivesCell remaining={player.livesRemaining} max={maxLives} />
 			<div className="text-center font-bold">{player.streak || '—'}</div>
@@ -120,7 +202,10 @@ function PlayerRow({
 			{Array.from({ length: numberOfPicks }, (_, i) => {
 				const rank = i + 1
 				const pick = player.picks.find((p) => p.confidenceRank === rank)
-				return <GridCell key={rank} pick={pick} />
+				const fixtureId = pick?.fixtureId ?? pickFixtureByRank?.get(rank)
+				const recentGoal = fixtureId ? liveMeta.recentGoalByFixture.get(fixtureId) : undefined
+				const bump = recentGoal ? (recentGoal.side === pick?.pickedSide ? 'up' : 'down') : null
+				return <GridCell key={rank} pick={pick} bump={bump} />
 			})}
 		</div>
 	)
@@ -152,21 +237,31 @@ function LivesCell({ remaining, max }: { remaining: number; max: number }) {
 	)
 }
 
-function GridCell({ pick }: { pick?: CupStandingsData['players'][number]['picks'][number] }) {
+function GridCell({
+	pick,
+	bump,
+}: {
+	pick?: CupStandingsData['players'][number]['picks'][number]
+	bump?: 'up' | 'down' | null
+}) {
 	if (!pick) {
-		return <div className="h-9 w-14 rounded border border-dashed border-border bg-muted/40" />
+		return (
+			<div className="relative h-9 w-14 rounded border border-dashed border-border bg-muted/40">
+				{bump && <BumpBadge kind={bump} />}
+			</div>
+		)
 	}
 	if (pick.result === 'hidden') {
 		return (
-			<div className="h-9 w-14 rounded border border-dashed border-border bg-muted/40 flex items-center justify-center text-xs text-muted-foreground">
-				🔒
+			<div className="relative h-9 w-14 rounded border border-dashed border-border bg-muted/40 flex items-center justify-center text-xs text-muted-foreground">
+				🔒{bump && <BumpBadge kind={bump} />}
 			</div>
 		)
 	}
 	if (pick.result === 'restricted') {
 		return (
-			<div className="h-9 w-14 rounded border border-dashed border-border bg-muted/40 flex items-center justify-center text-xs text-muted-foreground">
-				—
+			<div className="relative h-9 w-14 rounded border border-dashed border-border bg-muted/40 flex items-center justify-center text-xs text-muted-foreground">
+				—{bump && <BumpBadge kind={bump} />}
 			</div>
 		)
 	}
@@ -202,7 +297,21 @@ function GridCell({ pick }: { pick?: CupStandingsData['players'][number]['picks'
 					-{pick.livesSpent}
 				</span>
 			)}
+			{bump && <BumpBadge kind={bump} />}
 		</div>
+	)
+}
+
+function BumpBadge({ kind }: { kind: 'up' | 'down' }) {
+	return (
+		<span
+			className={cn(
+				'absolute -top-2 -left-1.5 rounded-full px-1 py-0.5 text-[8px] font-extrabold leading-none text-white shadow animate-[pulse_1s_ease-in-out_2]',
+				kind === 'up' ? 'bg-emerald-600' : 'bg-red-600',
+			)}
+		>
+			{kind === 'up' ? '+1' : '-1'}
+		</span>
 	)
 }
 

--- a/src/components/standings/cup-ladder.tsx
+++ b/src/components/standings/cup-ladder.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { AlertTriangle, CheckCircle2, Flame, Target, Zap } from 'lucide-react'
+import { useLiveGame } from '@/components/live/use-live-game'
 import { HeartIcon } from '@/components/picks/heart-icon'
 import { PlusNBadge } from '@/components/picks/plus-n-badge'
 import { TeamBadge } from '@/components/picks/team-badge'
@@ -11,13 +12,32 @@ import type {
 	CupLadderFixture,
 	CupStandingsPlayer,
 } from '@/lib/game/cup-standings-queries'
+import type { LiveFixture, LivePayload } from '@/lib/live/types'
 import { cn } from '@/lib/utils'
 
 interface CupLadderProps {
 	data: CupLadderData
+	live?: LivePayload
 }
 
+const LIVE_FLASH_MS = 1500
+
 export function CupLadder({ data }: CupLadderProps) {
+	const { payload, events } = useLiveGame()
+	const now = Date.now()
+
+	const liveFixtureById = new Map<string, LiveFixture>()
+	for (const f of payload?.fixtures ?? []) {
+		liveFixtureById.set(f.id, f)
+	}
+
+	const recentGoalByFixture = new Map<string, 'home' | 'away'>()
+	for (const ev of events.goals) {
+		if (now - ev.observedAt <= LIVE_FLASH_MS) {
+			recentGoalByFixture.set(ev.fixtureId, ev.side)
+		}
+	}
+
 	const played = data.fixtures.filter((f) => f.actualOutcome != null)
 	const unplayed = data.fixtures.filter((f) => f.actualOutcome == null)
 	const top3 = [...data.players]
@@ -36,7 +56,12 @@ export function CupLadder({ data }: CupLadderProps) {
 					</h3>
 					<div className="space-y-2">
 						{unplayed.map((f) => (
-							<CupFixtureCard key={f.id} fixture={f} />
+							<CupFixtureCard
+								key={f.id}
+								fixture={f}
+								liveFixture={liveFixtureById.get(f.id)}
+								recentGoalSide={recentGoalByFixture.get(f.id)}
+							/>
 						))}
 					</div>
 				</section>
@@ -49,7 +74,12 @@ export function CupLadder({ data }: CupLadderProps) {
 					</h3>
 					<div className="space-y-2">
 						{played.map((f) => (
-							<CupFixtureCard key={f.id} fixture={f} />
+							<CupFixtureCard
+								key={f.id}
+								fixture={f}
+								liveFixture={liveFixtureById.get(f.id)}
+								recentGoalSide={recentGoalByFixture.get(f.id)}
+							/>
 						))}
 					</div>
 				</section>
@@ -111,18 +141,30 @@ function Podium({ players, maxLives }: { players: CupStandingsPlayer[]; maxLives
 	)
 }
 
-function CupFixtureCard({ fixture }: { fixture: CupLadderFixture }) {
+function CupFixtureCard({
+	fixture,
+	liveFixture,
+	recentGoalSide,
+}: {
+	fixture: CupLadderFixture
+	liveFixture?: LiveFixture
+	recentGoalSide?: 'home' | 'away'
+}) {
 	const isPlayed = fixture.actualOutcome != null
-	const score =
-		fixture.homeScore != null && fixture.awayScore != null
-			? `${fixture.homeScore}–${fixture.awayScore}`
-			: null
+	const liveStatus = liveFixture?.status
+	const liveInProgress = liveStatus === 'live' || liveStatus === 'halftime'
+	// Override stored scores with live values when we have them (covers pre-settlement).
+	const displayHome = liveFixture?.homeScore != null ? liveFixture.homeScore : fixture.homeScore
+	const displayAway = liveFixture?.awayScore != null ? liveFixture.awayScore : fixture.awayScore
+	const score = displayHome != null && displayAway != null ? `${displayHome}–${displayAway}` : null
 
 	return (
 		<div
 			className={cn(
-				'rounded-lg border bg-card overflow-hidden',
+				'rounded-lg border bg-card overflow-hidden transition-shadow duration-300',
 				fixture.crucial && 'border-[var(--draw)] shadow-[0_0_0_1px_var(--draw)]',
+				liveInProgress && 'border-primary/60 shadow-[0_0_0_1px_var(--primary,#2563eb)]',
+				recentGoalSide && 'ring-2 ring-emerald-400 animate-[pulse_0.9s_ease-in-out_2]',
 			)}
 		>
 			{fixture.crucial && (
@@ -151,8 +193,21 @@ function CupFixtureCard({ fixture }: { fixture: CupLadderFixture }) {
 					{score ? (
 						<>
 							<span className="font-display font-bold text-lg leading-none">{score}</span>
-							<span className="text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground mt-1">
-								{outcomeLabel(fixture.actualOutcome as 'home_win' | 'draw' | 'away_win')}
+							<span
+								className={cn(
+									'text-[0.65rem] font-semibold uppercase tracking-wider mt-1',
+									liveInProgress
+										? 'text-primary animate-[pulse_1.4s_ease-in-out_infinite]'
+										: 'text-muted-foreground',
+								)}
+							>
+								{liveInProgress
+									? liveStatus === 'halftime'
+										? 'HT'
+										: 'LIVE'
+									: fixture.actualOutcome
+										? outcomeLabel(fixture.actualOutcome as 'home_win' | 'draw' | 'away_win')
+										: ''}
 							</span>
 						</>
 					) : (

--- a/src/components/standings/cup-ladder.tsx
+++ b/src/components/standings/cup-ladder.tsx
@@ -12,12 +12,11 @@ import type {
 	CupLadderFixture,
 	CupStandingsPlayer,
 } from '@/lib/game/cup-standings-queries'
-import type { LiveFixture, LivePayload } from '@/lib/live/types'
+import type { LiveFixture } from '@/lib/live/types'
 import { cn } from '@/lib/utils'
 
 interface CupLadderProps {
 	data: CupLadderData
-	live?: LivePayload
 }
 
 const LIVE_FLASH_MS = 1500

--- a/src/components/standings/cup-standings.tsx
+++ b/src/components/standings/cup-standings.tsx
@@ -3,7 +3,6 @@
 import { Clock, LayoutGrid, ListTree } from 'lucide-react'
 import { useState } from 'react'
 import type { CupLadderData } from '@/lib/game/cup-standings-queries'
-import type { LivePayload } from '@/lib/live/types'
 import { cn } from '@/lib/utils'
 import { CupGrid } from './cup-grid'
 import { CupLadder } from './cup-ladder'
@@ -14,10 +13,9 @@ type ViewMode = 'ladder' | 'grid' | 'timeline'
 interface CupStandingsProps {
 	data: CupLadderData
 	onShare?: () => void
-	live?: LivePayload
 }
 
-export function CupStandings({ data, onShare, live }: CupStandingsProps) {
+export function CupStandings({ data, onShare }: CupStandingsProps) {
 	const [view, setView] = useState<ViewMode>('ladder')
 	return (
 		<div className="rounded-xl border border-border bg-card overflow-hidden">
@@ -65,9 +63,9 @@ export function CupStandings({ data, onShare, live }: CupStandingsProps) {
 				</div>
 			</div>
 			<div className="p-4 md:p-5">
-				{view === 'ladder' && <CupLadder data={data} live={live} />}
-				{view === 'grid' && <CupGrid data={data} live={live} />}
-				{view === 'timeline' && <CupTimeline data={data} live={live} />}
+				{view === 'ladder' && <CupLadder data={data} />}
+				{view === 'grid' && <CupGrid data={data} />}
+				{view === 'timeline' && <CupTimeline data={data} />}
 			</div>
 		</div>
 	)

--- a/src/components/standings/cup-standings.tsx
+++ b/src/components/standings/cup-standings.tsx
@@ -3,6 +3,7 @@
 import { Clock, LayoutGrid, ListTree } from 'lucide-react'
 import { useState } from 'react'
 import type { CupLadderData } from '@/lib/game/cup-standings-queries'
+import type { LivePayload } from '@/lib/live/types'
 import { cn } from '@/lib/utils'
 import { CupGrid } from './cup-grid'
 import { CupLadder } from './cup-ladder'
@@ -13,9 +14,10 @@ type ViewMode = 'ladder' | 'grid' | 'timeline'
 interface CupStandingsProps {
 	data: CupLadderData
 	onShare?: () => void
+	live?: LivePayload
 }
 
-export function CupStandings({ data, onShare }: CupStandingsProps) {
+export function CupStandings({ data, onShare, live }: CupStandingsProps) {
 	const [view, setView] = useState<ViewMode>('ladder')
 	return (
 		<div className="rounded-xl border border-border bg-card overflow-hidden">
@@ -63,9 +65,9 @@ export function CupStandings({ data, onShare }: CupStandingsProps) {
 				</div>
 			</div>
 			<div className="p-4 md:p-5">
-				{view === 'ladder' && <CupLadder data={data} />}
-				{view === 'grid' && <CupGrid data={data} />}
-				{view === 'timeline' && <CupTimeline data={data} />}
+				{view === 'ladder' && <CupLadder data={data} live={live} />}
+				{view === 'grid' && <CupGrid data={data} live={live} />}
+				{view === 'timeline' && <CupTimeline data={data} live={live} />}
 			</div>
 		</div>
 	)

--- a/src/components/standings/cup-timeline.tsx
+++ b/src/components/standings/cup-timeline.tsx
@@ -3,12 +3,10 @@
 import { XCircle } from 'lucide-react'
 import { useLiveGame } from '@/components/live/use-live-game'
 import type { CupLadderData, CupLadderFixture } from '@/lib/game/cup-standings-queries'
-import type { LivePayload } from '@/lib/live/types'
 import { cn } from '@/lib/utils'
 
 interface CupTimelineProps {
 	data: CupLadderData
-	live?: LivePayload
 }
 
 // A "kickoff slot" is a unique kickoff time across the round's fixtures.

--- a/src/components/standings/cup-timeline.tsx
+++ b/src/components/standings/cup-timeline.tsx
@@ -1,11 +1,14 @@
 'use client'
 
 import { XCircle } from 'lucide-react'
+import { useLiveGame } from '@/components/live/use-live-game'
 import type { CupLadderData, CupLadderFixture } from '@/lib/game/cup-standings-queries'
+import type { LivePayload } from '@/lib/live/types'
 import { cn } from '@/lib/utils'
 
 interface CupTimelineProps {
 	data: CupLadderData
+	live?: LivePayload
 }
 
 // A "kickoff slot" is a unique kickoff time across the round's fixtures.
@@ -34,6 +37,11 @@ interface PlayerTimeline {
 }
 
 export function CupTimeline({ data }: CupTimelineProps) {
+	const { events } = useLiveGame()
+	const eliminatedGpIds = new Set(
+		events.settlements.filter((ev) => ev.result === 'settled-loss').map((ev) => ev.gamePlayerId),
+	)
+
 	// Build kickoff slots
 	const slotMap = new Map<string, KickoffSlot>()
 	for (const f of data.fixtures) {
@@ -166,7 +174,10 @@ export function CupTimeline({ data }: CupTimelineProps) {
 				{timelines.map((t) => (
 					<div
 						key={t.playerId}
-						className="grid gap-2 items-stretch"
+						className={cn(
+							'grid gap-2 items-stretch',
+							eliminatedGpIds.has(t.playerId) && 'opacity-45 transition-opacity duration-[400ms]',
+						)}
 						style={{
 							gridTemplateColumns: `180px repeat(${slots.length}, ${slotWidth})`,
 						}}

--- a/src/components/standings/progress-grid.tsx
+++ b/src/components/standings/progress-grid.tsx
@@ -5,7 +5,6 @@ import { useState } from 'react'
 import { useLiveGame } from '@/components/live/use-live-game'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import type { LivePayload } from '@/lib/live/types'
 import { cn } from '@/lib/utils'
 import { GridFilter } from './grid-filter'
 
@@ -62,7 +61,6 @@ interface ProgressGridProps {
 	defaultFilter?: 'all' | 'last5' | 'last3'
 	gameId?: string
 	onShare?: () => void
-	live?: LivePayload
 }
 
 export function ProgressGrid({

--- a/src/components/standings/progress-grid.tsx
+++ b/src/components/standings/progress-grid.tsx
@@ -2,10 +2,23 @@
 
 import { Eye, EyeOff, Share2, UsersRound } from 'lucide-react'
 import { useState } from 'react'
+import { useLiveGame } from '@/components/live/use-live-game'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import type { LivePayload } from '@/lib/live/types'
 import { cn } from '@/lib/utils'
 import { GridFilter } from './grid-filter'
+
+const LIVE_RECENT_MS = 1500
+
+interface ProgressLiveMeta {
+	viewerGamePlayerId: string | undefined
+	viewerRowIsLive: boolean
+	eliminatedGpIds: Set<string>
+	recentGoalByFixture: Map<string, { side: 'home' | 'away' }>
+	pickFixtureByPlayer: Map<string, string>
+	pickSideByPlayer: Map<string, 'home' | 'away' | null>
+}
 
 export interface GridRound {
 	id: string
@@ -49,6 +62,7 @@ interface ProgressGridProps {
 	defaultFilter?: 'all' | 'last5' | 'last3'
 	gameId?: string
 	onShare?: () => void
+	live?: LivePayload
 }
 
 export function ProgressGrid({
@@ -62,6 +76,59 @@ export function ProgressGrid({
 	const [filter, setFilter] = useState<'all' | 'last5' | 'last3'>(defaultFilter)
 	const [showOpponents, setShowOpponents] = useState(false)
 	const [hideEliminated, setHideEliminated] = useState(false)
+	const liveCtx = useLiveGame()
+
+	const liveMeta: ProgressLiveMeta = (() => {
+		const now = Date.now()
+		const recentGoalByFixture = new Map<string, { side: 'home' | 'away' }>()
+		for (const ev of liveCtx.events.goals) {
+			if (now - ev.observedAt <= LIVE_RECENT_MS) {
+				recentGoalByFixture.set(ev.fixtureId, { side: ev.side })
+			}
+		}
+		const eliminatedGpIds = new Set<string>()
+		for (const ev of liveCtx.events.settlements) {
+			if (ev.result !== 'settled-loss') continue
+			const p = liveCtx.payload?.players.find((pp) => pp.id === ev.gamePlayerId)
+			if (p && p.livesRemaining === 0) eliminatedGpIds.add(ev.gamePlayerId)
+		}
+		const viewerUserId = liveCtx.payload?.viewerUserId
+		const viewerGp = viewerUserId
+			? liveCtx.payload?.players.find((p) => p.userId === viewerUserId)
+			: undefined
+		const viewerPickFixtureId = viewerGp
+			? (liveCtx.payload?.picks.find((pk) => pk.gamePlayerId === viewerGp.id && pk.fixtureId)
+					?.fixtureId ?? undefined)
+			: undefined
+		const viewerFixtureStatus = viewerPickFixtureId
+			? liveCtx.payload?.fixtures.find((f) => f.id === viewerPickFixtureId)?.status
+			: undefined
+		const viewerRowIsLive = viewerFixtureStatus === 'live' || viewerFixtureStatus === 'halftime'
+
+		// Classic mode: one pick per player for the current round.
+		const pickFixtureByPlayer = new Map<string, string>()
+		const pickSideByPlayer = new Map<string, 'home' | 'away' | null>()
+		for (const pk of liveCtx.payload?.picks ?? []) {
+			if (!pk.fixtureId) continue
+			pickFixtureByPlayer.set(pk.gamePlayerId, pk.fixtureId)
+			const side: 'home' | 'away' | null =
+				pk.predictedResult === 'home_win'
+					? 'home'
+					: pk.predictedResult === 'away_win'
+						? 'away'
+						: null
+			pickSideByPlayer.set(pk.gamePlayerId, side)
+		}
+
+		return {
+			viewerGamePlayerId: viewerGp?.id,
+			viewerRowIsLive,
+			eliminatedGpIds,
+			recentGoalByFixture,
+			pickFixtureByPlayer,
+			pickSideByPlayer,
+		}
+	})()
 
 	const visibleRounds =
 		filter === 'all' ? rounds : filter === 'last5' ? rounds.slice(-5) : rounds.slice(-3)
@@ -144,46 +211,82 @@ export function ProgressGrid({
 							</tr>
 						</thead>
 						<tbody>
-							{visiblePlayers.map((player) => (
-								<tr
-									key={player.id}
-									className={cn(
-										'border-t border-border',
-										player.status === 'eliminated' && 'opacity-50',
-									)}
-								>
-									<td className="py-2 pr-4 font-medium whitespace-nowrap sticky left-0 bg-card z-10">
-										{player.name}
-									</td>
-									{visibleRounds.map((r) => {
-										const cell = player.cellsByRoundId[r.id] ?? { result: 'empty' }
-										return (
-											<td key={r.id} className="px-1 text-center align-middle">
-												<GridCellView
-													cell={cell}
-													roundNumber={r.number}
-													showOpponents={showOpponents}
-												/>
-											</td>
-										)
-									})}
-									<td className="pl-4 text-right">
-										{player.status === 'alive' ? (
-											<span className="text-[0.7rem] font-semibold px-2 py-0.5 rounded bg-[var(--alive-bg)] text-[var(--alive)]">
-												alive
-											</span>
-										) : player.status === 'eliminated' ? (
-											<span className="text-[0.7rem] font-semibold px-2 py-0.5 rounded bg-[var(--eliminated-bg)] text-[var(--eliminated)]">
-												GW{player.eliminatedRoundNumber}
-											</span>
-										) : (
-											<span className="text-[0.7rem] font-semibold px-2 py-0.5 rounded bg-yellow-100 text-yellow-900">
-												won
-											</span>
+							{visiblePlayers.map((player) => {
+								const isViewer = liveMeta.viewerGamePlayerId === player.id
+								const viewerLiveStyle = isViewer && liveMeta.viewerRowIsLive
+								const liveEliminated = liveMeta.eliminatedGpIds.has(player.id)
+								const currentPickFixtureId = liveMeta.pickFixtureByPlayer.get(player.id)
+								const currentPickSide = liveMeta.pickSideByPlayer.get(player.id)
+								const recentGoal = currentPickFixtureId
+									? liveMeta.recentGoalByFixture.get(currentPickFixtureId)
+									: undefined
+								const rowBump = recentGoal
+									? currentPickSide && recentGoal.side === currentPickSide
+										? 'up'
+										: 'down'
+									: null
+								// The live pick almost always maps to the last visible round.
+								const bumpRoundId = visibleRounds.at(-1)?.id
+								return (
+									<tr
+										key={player.id}
+										className={cn(
+											'border-t border-border',
+											player.status === 'eliminated' && 'opacity-50',
+											viewerLiveStyle && 'bg-gradient-to-r from-primary/10 to-transparent',
+											liveEliminated && 'opacity-45 transition-opacity duration-[400ms]',
 										)}
-									</td>
-								</tr>
-							))}
+									>
+										<td
+											className={cn(
+												'py-2 pr-4 font-medium whitespace-nowrap sticky left-0 bg-card z-10',
+												viewerLiveStyle && 'border-l-4 border-l-primary pl-2',
+											)}
+										>
+											{player.name}
+											{viewerLiveStyle && (
+												<span className="ml-1.5 rounded-sm bg-primary/15 px-1 py-0.5 text-[9px] font-bold uppercase text-primary animate-[pulse_1.4s_ease-in-out_infinite]">
+													LIVE
+												</span>
+											)}
+											{liveEliminated && (
+												<span className="ml-1.5 rounded-sm border border-[#ef4444] px-1 py-0.5 text-[9px] font-extrabold uppercase text-[#ef4444]">
+													OUT
+												</span>
+											)}
+										</td>
+										{visibleRounds.map((r) => {
+											const cell = player.cellsByRoundId[r.id] ?? { result: 'empty' }
+											const bump = rowBump && r.id === bumpRoundId ? rowBump : null
+											return (
+												<td key={r.id} className="px-1 text-center align-middle">
+													<GridCellView
+														cell={cell}
+														roundNumber={r.number}
+														showOpponents={showOpponents}
+														bump={bump}
+													/>
+												</td>
+											)
+										})}
+										<td className="pl-4 text-right">
+											{player.status === 'alive' ? (
+												<span className="text-[0.7rem] font-semibold px-2 py-0.5 rounded bg-[var(--alive-bg)] text-[var(--alive)]">
+													alive
+												</span>
+											) : player.status === 'eliminated' ? (
+												<span className="text-[0.7rem] font-semibold px-2 py-0.5 rounded bg-[var(--eliminated-bg)] text-[var(--eliminated)]">
+													GW{player.eliminatedRoundNumber}
+												</span>
+											) : (
+												<span className="text-[0.7rem] font-semibold px-2 py-0.5 rounded bg-yellow-100 text-yellow-900">
+													won
+												</span>
+											)}
+										</td>
+									</tr>
+								)
+							})}
 						</tbody>
 					</table>
 				</div>
@@ -196,21 +299,29 @@ function GridCellView({
 	cell,
 	roundNumber,
 	showOpponents,
+	bump,
 }: {
 	cell: GridCell
 	roundNumber: number
 	showOpponents: boolean
+	bump?: 'up' | 'down' | null
 }) {
 	const width = showOpponents ? 'w-20' : 'w-12'
 	const height = 'h-9'
 
 	if (cell.result === 'empty') {
-		return <span className={cn('inline-block', width, height)} />
+		return (
+			<span className={cn('relative inline-block', width, height)}>
+				{bump && <BumpBadge kind={bump} />}
+			</span>
+		)
 	}
 	if (cell.result === 'skull') {
 		return (
-			<span className={cn('inline-flex items-center justify-center text-lg', width, height)}>
-				💀
+			<span
+				className={cn('relative inline-flex items-center justify-center text-lg', width, height)}
+			>
+				💀{bump && <BumpBadge kind={bump} />}
 			</span>
 		)
 	}
@@ -220,13 +331,14 @@ function GridCellView({
 				<TooltipTrigger asChild>
 					<span
 						className={cn(
-							'inline-flex flex-col items-center justify-center rounded bg-[var(--draw-bg)] text-[var(--draw)] font-bold leading-tight cursor-help',
+							'relative inline-flex flex-col items-center justify-center rounded bg-[var(--draw-bg)] text-[var(--draw)] font-bold leading-tight cursor-help',
 							width,
 							height,
 						)}
 					>
 						<span className="text-sm">?</span>
 						{showOpponents && <span className="text-[0.5rem] font-medium">No pick</span>}
+						{bump && <BumpBadge kind={bump} />}
 					</span>
 				</TooltipTrigger>
 				<TooltipContent>
@@ -241,13 +353,14 @@ function GridCellView({
 				<TooltipTrigger asChild>
 					<span
 						className={cn(
-							'inline-flex flex-col items-center justify-center rounded border border-dashed border-border bg-muted/40 text-muted-foreground leading-tight cursor-help',
+							'relative inline-flex flex-col items-center justify-center rounded border border-dashed border-border bg-muted/40 text-muted-foreground leading-tight cursor-help',
 							width,
 							height,
 						)}
 					>
 						<span className="text-xs">🔒</span>
 						{showOpponents && <span className="text-[0.5rem] font-medium">Locked</span>}
+						{bump && <BumpBadge kind={bump} />}
 					</span>
 				</TooltipTrigger>
 				<TooltipContent>
@@ -298,7 +411,7 @@ function GridCellView({
 			<TooltipTrigger asChild>
 				<span
 					className={cn(
-						'inline-flex flex-col items-center justify-center rounded text-[0.7rem] font-bold cursor-help leading-tight',
+						'relative inline-flex flex-col items-center justify-center rounded text-[0.7rem] font-bold cursor-help leading-tight',
 						width,
 						height,
 						colour,
@@ -308,11 +421,25 @@ function GridCellView({
 					{showOpponents && opponentLabel && (
 						<span className="text-[0.55rem] font-normal opacity-80">{opponentLabel}</span>
 					)}
+					{bump && <BumpBadge kind={bump} />}
 				</span>
 			</TooltipTrigger>
 			<TooltipContent>
 				<p className="text-xs">{tooltipLabel}</p>
 			</TooltipContent>
 		</Tooltip>
+	)
+}
+
+function BumpBadge({ kind }: { kind: 'up' | 'down' }) {
+	return (
+		<span
+			className={cn(
+				'absolute -top-2 -left-1.5 rounded-full px-1 py-0.5 text-[8px] font-extrabold leading-none text-white shadow animate-[pulse_1s_ease-in-out_2]',
+				kind === 'up' ? 'bg-emerald-600' : 'bg-red-600',
+			)}
+		>
+			{kind === 'up' ? '+1' : '-1'}
+		</span>
 	)
 }

--- a/src/components/standings/turbo-standings.tsx
+++ b/src/components/standings/turbo-standings.tsx
@@ -5,7 +5,6 @@ import { useState } from 'react'
 import { useLiveGame } from '@/components/live/use-live-game'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import type { LivePayload } from '@/lib/live/types'
 import { cn } from '@/lib/utils'
 import { type LadderFixture, TurboLadder } from './turbo-ladder'
 import { TurboTimeline } from './turbo-timeline'
@@ -53,7 +52,6 @@ interface TurboStandingsProps {
 	rounds: TurboRoundSummary[]
 	numberOfPicks: number
 	onShare?: () => void
-	live?: LivePayload
 }
 
 const _PRED_ABBREV = { home_win: 'H', draw: 'D', away_win: 'A' } as const

--- a/src/components/standings/turbo-standings.tsx
+++ b/src/components/standings/turbo-standings.tsx
@@ -2,11 +2,24 @@
 
 import { Clock, Flame, LayoutGrid, ListTree, Target } from 'lucide-react'
 import { useState } from 'react'
+import { useLiveGame } from '@/components/live/use-live-game'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import type { LivePayload } from '@/lib/live/types'
 import { cn } from '@/lib/utils'
 import { type LadderFixture, TurboLadder } from './turbo-ladder'
 import { TurboTimeline } from './turbo-timeline'
+
+const LIVE_RECENT_MS = 1500
+
+interface TurboLiveMeta {
+	viewerGamePlayerId: string | undefined
+	viewerRowIsLive: boolean
+	eliminatedGpIds: Set<string>
+	recentGoalByFixture: Map<string, { side: 'home' | 'away' }>
+	pickFixtureByPlayer: Map<string, Map<number, string>>
+	pickSideByPlayer: Map<string, Map<number, 'home' | 'away' | null>>
+}
 
 export interface TurboPickCell {
 	rank: number
@@ -40,6 +53,7 @@ interface TurboStandingsProps {
 	rounds: TurboRoundSummary[]
 	numberOfPicks: number
 	onShare?: () => void
+	live?: LivePayload
 }
 
 const _PRED_ABBREV = { home_win: 'H', draw: 'D', away_win: 'A' } as const
@@ -50,7 +64,11 @@ export function TurboStandings({ rounds, numberOfPicks, onShare }: TurboStanding
 	const initial = rounds[rounds.length - 1]?.id
 	const [roundId, setRoundId] = useState<string>(initial ?? '')
 	const [view, setView] = useState<ViewMode>('ladder')
+	const liveCtx = useLiveGame()
 	const round = rounds.find((r) => r.id === roundId) ?? rounds[rounds.length - 1]
+
+	// Build live metadata (hook must run unconditionally — compute before the early return).
+	const liveMeta = buildTurboLiveMeta(liveCtx)
 
 	if (!round) {
 		return (
@@ -161,17 +179,78 @@ export function TurboStandings({ rounds, numberOfPicks, onShare }: TurboStanding
 				</div>
 			)}
 
-			{view === 'grid' && <GridView sortedPlayers={sortedPlayers} numberOfPicks={numberOfPicks} />}
+			{view === 'grid' && (
+				<GridView sortedPlayers={sortedPlayers} numberOfPicks={numberOfPicks} liveMeta={liveMeta} />
+			)}
 		</div>
 	)
+}
+
+function buildTurboLiveMeta(liveCtx: ReturnType<typeof useLiveGame>): TurboLiveMeta {
+	const now = Date.now()
+
+	const recentGoalByFixture = new Map<string, { side: 'home' | 'away' }>()
+	for (const ev of liveCtx.events.goals) {
+		if (now - ev.observedAt <= LIVE_RECENT_MS) {
+			recentGoalByFixture.set(ev.fixtureId, { side: ev.side })
+		}
+	}
+
+	const eliminatedGpIds = new Set<string>()
+	for (const ev of liveCtx.events.settlements) {
+		if (ev.result !== 'settled-loss') continue
+		const p = liveCtx.payload?.players.find((pp) => pp.id === ev.gamePlayerId)
+		if (p && p.livesRemaining === 0) eliminatedGpIds.add(ev.gamePlayerId)
+	}
+
+	const viewerUserId = liveCtx.payload?.viewerUserId
+	const viewerGp = viewerUserId
+		? liveCtx.payload?.players.find((p) => p.userId === viewerUserId)
+		: undefined
+	const viewerPickFixtureId = viewerGp
+		? (liveCtx.payload?.picks.find((pk) => pk.gamePlayerId === viewerGp.id && pk.fixtureId)
+				?.fixtureId ?? undefined)
+		: undefined
+	const viewerFixtureStatus = viewerPickFixtureId
+		? liveCtx.payload?.fixtures.find((f) => f.id === viewerPickFixtureId)?.status
+		: undefined
+	const viewerRowIsLive = viewerFixtureStatus === 'live' || viewerFixtureStatus === 'halftime'
+
+	const pickFixtureByPlayer = new Map<string, Map<number, string>>()
+	const pickSideByPlayer = new Map<string, Map<number, 'home' | 'away' | null>>()
+	for (const pk of liveCtx.payload?.picks ?? []) {
+		if (pk.confidenceRank == null) continue
+		if (pk.fixtureId) {
+			const inner = pickFixtureByPlayer.get(pk.gamePlayerId) ?? new Map<number, string>()
+			inner.set(pk.confidenceRank, pk.fixtureId)
+			pickFixtureByPlayer.set(pk.gamePlayerId, inner)
+		}
+		const sideInner =
+			pickSideByPlayer.get(pk.gamePlayerId) ?? new Map<number, 'home' | 'away' | null>()
+		const side: 'home' | 'away' | null =
+			pk.predictedResult === 'home_win' ? 'home' : pk.predictedResult === 'away_win' ? 'away' : null
+		sideInner.set(pk.confidenceRank, side)
+		pickSideByPlayer.set(pk.gamePlayerId, sideInner)
+	}
+
+	return {
+		viewerGamePlayerId: viewerGp?.id,
+		viewerRowIsLive,
+		eliminatedGpIds,
+		recentGoalByFixture,
+		pickFixtureByPlayer,
+		pickSideByPlayer,
+	}
 }
 
 function GridView({
 	sortedPlayers,
 	numberOfPicks,
+	liveMeta,
 }: {
 	sortedPlayers: TurboPlayerRow[]
 	numberOfPicks: number
+	liveMeta: TurboLiveMeta
 }) {
 	return (
 		<TooltipProvider delayDuration={100}>
@@ -207,40 +286,78 @@ function GridView({
 						</tr>
 					</thead>
 					<tbody>
-						{sortedPlayers.map((player, idx) => (
-							<tr
-								key={player.id}
-								className={cn('border-t border-border', !player.hasSubmitted && 'opacity-60')}
-							>
-								<td className="py-2 pr-3 font-semibold text-muted-foreground sticky left-0 bg-card z-10">
-									{idx + 1}
-								</td>
-								<td className="py-2 pr-4 font-medium whitespace-nowrap sticky left-10 bg-card z-10">
-									{player.name}
-									{!player.hasSubmitted && (
-										<span className="ml-2 text-[0.65rem] font-semibold text-[var(--draw)] bg-[var(--draw-bg)] px-1.5 py-0.5 rounded">
-											no picks
-										</span>
+						{sortedPlayers.map((player, idx) => {
+							const isViewer = liveMeta.viewerGamePlayerId === player.id
+							const viewerLiveStyle = isViewer && liveMeta.viewerRowIsLive
+							const liveEliminated = liveMeta.eliminatedGpIds.has(player.id)
+							const pickFixtureByRank = liveMeta.pickFixtureByPlayer.get(player.id)
+							const pickSideByRank = liveMeta.pickSideByPlayer.get(player.id)
+							return (
+								<tr
+									key={player.id}
+									className={cn(
+										'border-t border-border',
+										!player.hasSubmitted && 'opacity-60',
+										viewerLiveStyle && 'bg-gradient-to-r from-primary/10 to-transparent',
+										liveEliminated && 'opacity-45 transition-opacity duration-[400ms]',
 									)}
-								</td>
-								<td className="text-center px-2 py-2 font-display font-semibold text-lg">
-									{player.streak}
-								</td>
-								<td className="text-center px-2 py-2 text-muted-foreground">{player.goals}</td>
-								{Array.from({ length: numberOfPicks }, (_, i) => {
-									const cell = player.picks.find((c) => c.rank === i + 1)
-									return (
-										<td
-											// biome-ignore lint/suspicious/noArrayIndexKey: rank columns are stable
-											key={i}
-											className="px-0.5 text-center"
-										>
-											<TurboCell cell={cell} />
-										</td>
-									)
-								})}
-							</tr>
-						))}
+								>
+									<td className="py-2 pr-3 font-semibold text-muted-foreground sticky left-0 bg-card z-10">
+										{idx + 1}
+									</td>
+									<td
+										className={cn(
+											'py-2 pr-4 font-medium whitespace-nowrap sticky left-10 bg-card z-10',
+											viewerLiveStyle && 'border-l-4 border-l-primary pl-2',
+										)}
+									>
+										{player.name}
+										{viewerLiveStyle && (
+											<span className="ml-1.5 rounded-sm bg-primary/15 px-1 py-0.5 text-[9px] font-bold uppercase text-primary animate-[pulse_1.4s_ease-in-out_infinite]">
+												LIVE
+											</span>
+										)}
+										{liveEliminated && (
+											<span className="ml-1.5 rounded-sm border border-[#ef4444] px-1 py-0.5 text-[9px] font-extrabold uppercase text-[#ef4444]">
+												OUT
+											</span>
+										)}
+										{!player.hasSubmitted && (
+											<span className="ml-2 text-[0.65rem] font-semibold text-[var(--draw)] bg-[var(--draw-bg)] px-1.5 py-0.5 rounded">
+												no picks
+											</span>
+										)}
+									</td>
+									<td className="text-center px-2 py-2 font-display font-semibold text-lg">
+										{player.streak}
+									</td>
+									<td className="text-center px-2 py-2 text-muted-foreground">{player.goals}</td>
+									{Array.from({ length: numberOfPicks }, (_, i) => {
+										const rank = i + 1
+										const cell = player.picks.find((c) => c.rank === rank)
+										const fixtureId = pickFixtureByRank?.get(rank)
+										const recentGoal = fixtureId
+											? liveMeta.recentGoalByFixture.get(fixtureId)
+											: undefined
+										const pickedSide = pickSideByRank?.get(rank)
+										const bump = recentGoal
+											? pickedSide && recentGoal.side === pickedSide
+												? 'up'
+												: 'down'
+											: null
+										return (
+											<td
+												// biome-ignore lint/suspicious/noArrayIndexKey: rank columns are stable
+												key={i}
+												className="px-0.5 text-center"
+											>
+												<TurboCell cell={cell} bump={bump} />
+											</td>
+										)
+									})}
+								</tr>
+							)
+						})}
 					</tbody>
 				</table>
 			</div>
@@ -248,10 +365,12 @@ function GridView({
 	)
 }
 
-function TurboCell({ cell }: { cell?: TurboPickCell }) {
+function TurboCell({ cell, bump }: { cell?: TurboPickCell; bump?: 'up' | 'down' | null }) {
 	if (!cell) {
 		return (
-			<span className="inline-flex w-[68px] h-10 rounded bg-muted/40 border border-dashed border-border" />
+			<span className="relative inline-flex w-[68px] h-10 rounded bg-muted/40 border border-dashed border-border">
+				{bump && <BumpBadge kind={bump} />}
+			</span>
 		)
 	}
 
@@ -259,8 +378,8 @@ function TurboCell({ cell }: { cell?: TurboPickCell }) {
 		return (
 			<Tooltip>
 				<TooltipTrigger asChild>
-					<span className="inline-flex items-center justify-center w-[68px] h-10 rounded border border-dashed border-border bg-muted/40 text-muted-foreground text-xs">
-						🔒
+					<span className="relative inline-flex items-center justify-center w-[68px] h-10 rounded border border-dashed border-border bg-muted/40 text-muted-foreground text-xs">
+						🔒{bump && <BumpBadge kind={bump} />}
 					</span>
 				</TooltipTrigger>
 				<TooltipContent>
@@ -309,7 +428,7 @@ function TurboCell({ cell }: { cell?: TurboPickCell }) {
 			<TooltipTrigger asChild>
 				<span
 					className={cn(
-						'inline-flex flex-col items-center justify-center w-[68px] h-10 rounded text-[0.7rem] font-bold cursor-help leading-tight px-1',
+						'relative inline-flex flex-col items-center justify-center w-[68px] h-10 rounded text-[0.7rem] font-bold cursor-help leading-tight px-1',
 						colour,
 					)}
 				>
@@ -317,6 +436,7 @@ function TurboCell({ cell }: { cell?: TurboPickCell }) {
 					<span className="text-[0.55rem] font-medium opacity-85 truncate w-full text-center">
 						{secondary}
 					</span>
+					{bump && <BumpBadge kind={bump} />}
 				</span>
 			</TooltipTrigger>
 			<TooltipContent>
@@ -327,5 +447,18 @@ function TurboCell({ cell }: { cell?: TurboPickCell }) {
 				</p>
 			</TooltipContent>
 		</Tooltip>
+	)
+}
+
+function BumpBadge({ kind }: { kind: 'up' | 'down' }) {
+	return (
+		<span
+			className={cn(
+				'absolute -top-2 -left-1.5 rounded-full px-1 py-0.5 text-[8px] font-extrabold leading-none text-white shadow animate-[pulse_1s_ease-in-out_2]',
+				kind === 'up' ? 'bg-emerald-600' : 'bg-red-600',
+			)}
+		>
+			{kind === 'up' ? '+1' : '-1'}
+		</span>
 	)
 }

--- a/src/lib/live/derive.test.ts
+++ b/src/lib/live/derive.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import { deriveMatchState, projectPickOutcome } from './derive'
+import type { LiveFixture, LivePick } from './types'
+
+function fx(overrides: Partial<LiveFixture> = {}): LiveFixture {
+	return {
+		id: 'fx1',
+		kickoff: new Date('2026-06-11T19:00:00Z'),
+		homeScore: null,
+		awayScore: null,
+		status: 'scheduled',
+		homeShort: 'ENG',
+		awayShort: 'FRA',
+		...overrides,
+	}
+}
+
+describe('deriveMatchState', () => {
+	it('returns pre when kickoff is more than 10 minutes away', () => {
+		const now = new Date('2026-06-11T18:49:00Z')
+		expect(deriveMatchState(fx(), now)).toBe('pre')
+	})
+
+	it('returns live when kickoff is within 10m before and status is scheduled', () => {
+		const now = new Date('2026-06-11T18:55:00Z')
+		expect(deriveMatchState(fx(), now)).toBe('live')
+	})
+
+	it('returns live when status is live', () => {
+		const now = new Date('2026-06-11T19:30:00Z')
+		expect(deriveMatchState(fx({ status: 'live' }), now)).toBe('live')
+	})
+
+	it('returns ht when status is halftime', () => {
+		const now = new Date('2026-06-11T19:45:00Z')
+		expect(deriveMatchState(fx({ status: 'halftime' }), now)).toBe('ht')
+	})
+
+	it('returns ft when status is finished', () => {
+		const now = new Date('2026-06-11T21:30:00Z')
+		expect(deriveMatchState(fx({ status: 'finished' }), now)).toBe('ft')
+	})
+
+	it('returns ft when kickoff is more than 2.5h ago regardless of status', () => {
+		const now = new Date('2026-06-11T22:00:00Z')
+		expect(deriveMatchState(fx(), now)).toBe('ft')
+	})
+
+	it('returns pre when kickoff is null', () => {
+		expect(deriveMatchState(fx({ kickoff: null }), new Date())).toBe('pre')
+	})
+})
+
+describe('projectPickOutcome', () => {
+	const homeWin: LivePick = {
+		gamePlayerId: 'gp1',
+		fixtureId: 'fx1',
+		teamId: 't-home',
+		confidenceRank: 1,
+		predictedResult: 'home_win',
+		result: null,
+	}
+
+	it('returns winning when home pick and home leads', () => {
+		expect(
+			projectPickOutcome(homeWin, fx({ homeScore: 1, awayScore: 0, status: 'live' }), 'classic'),
+		).toBe('winning')
+	})
+
+	it('returns losing when home pick and away leads', () => {
+		expect(
+			projectPickOutcome(homeWin, fx({ homeScore: 0, awayScore: 1, status: 'live' }), 'classic'),
+		).toBe('losing')
+	})
+
+	it('returns drawing when scores level during live match', () => {
+		expect(
+			projectPickOutcome(homeWin, fx({ homeScore: 1, awayScore: 1, status: 'live' }), 'classic'),
+		).toBe('drawing')
+	})
+
+	it('returns settled-win when status finished and home wins', () => {
+		expect(
+			projectPickOutcome(
+				homeWin,
+				fx({ homeScore: 2, awayScore: 1, status: 'finished' }),
+				'classic',
+			),
+		).toBe('settled-win')
+	})
+
+	it('returns settled-loss when status finished and home loses', () => {
+		expect(
+			projectPickOutcome(
+				homeWin,
+				fx({ homeScore: 0, awayScore: 1, status: 'finished' }),
+				'classic',
+			),
+		).toBe('settled-loss')
+	})
+
+	it('returns saved-by-life when pick result is saved_by_life', () => {
+		expect(
+			projectPickOutcome(
+				{ ...homeWin, result: 'saved_by_life' },
+				fx({ status: 'finished' }),
+				'cup',
+			),
+		).toBe('saved-by-life')
+	})
+
+	it('returns winning for away pick when away leads', () => {
+		const awayWin: LivePick = { ...homeWin, predictedResult: 'away_win' }
+		expect(
+			projectPickOutcome(awayWin, fx({ homeScore: 0, awayScore: 1, status: 'live' }), 'classic'),
+		).toBe('winning')
+	})
+})

--- a/src/lib/live/derive.ts
+++ b/src/lib/live/derive.ts
@@ -1,0 +1,64 @@
+import type { LiveFixture, LivePick } from './types'
+
+const LIVE_WINDOW_BEFORE_MS = 10 * 60 * 1000
+const LIVE_WINDOW_AFTER_MS = 150 * 60 * 1000
+
+export function deriveMatchState(
+	fixture: LiveFixture,
+	now: Date = new Date(),
+): 'pre' | 'live' | 'ht' | 'ft' {
+	if (fixture.status === 'halftime') return 'ht'
+	if (fixture.status === 'finished') return 'ft'
+
+	if (!fixture.kickoff) return 'pre'
+	const kickoffMs =
+		typeof fixture.kickoff === 'string' ? Date.parse(fixture.kickoff) : fixture.kickoff.getTime()
+	const nowMs = now.getTime()
+
+	if (nowMs < kickoffMs - LIVE_WINDOW_BEFORE_MS) return 'pre'
+	if (nowMs > kickoffMs + LIVE_WINDOW_AFTER_MS) return 'ft'
+	return 'live'
+}
+
+export type PickOutcome =
+	| 'winning'
+	| 'drawing'
+	| 'losing'
+	| 'saved-by-life'
+	| 'settled-win'
+	| 'settled-loss'
+	| 'pending'
+
+export function projectPickOutcome(
+	pick: LivePick,
+	fixture: LiveFixture,
+	_mode: 'classic' | 'turbo' | 'cup',
+): PickOutcome {
+	if (pick.result === 'saved_by_life') return 'saved-by-life'
+	if (pick.result === 'win') return 'settled-win'
+	if (pick.result === 'loss') return 'settled-loss'
+
+	const { homeScore, awayScore, status } = fixture
+	if (homeScore == null || awayScore == null) return 'pending'
+
+	const isFinished = status === 'finished'
+
+	if (pick.predictedResult === 'home_win') {
+		if (homeScore > awayScore) return isFinished ? 'settled-win' : 'winning'
+		if (homeScore < awayScore) return isFinished ? 'settled-loss' : 'losing'
+		return isFinished ? 'settled-loss' : 'drawing'
+	}
+
+	if (pick.predictedResult === 'away_win') {
+		if (awayScore > homeScore) return isFinished ? 'settled-win' : 'winning'
+		if (awayScore < homeScore) return isFinished ? 'settled-loss' : 'losing'
+		return isFinished ? 'settled-loss' : 'drawing'
+	}
+
+	if (pick.predictedResult === 'draw') {
+		if (homeScore === awayScore) return isFinished ? 'settled-win' : 'drawing'
+		return isFinished ? 'settled-loss' : 'losing'
+	}
+
+	return 'pending'
+}

--- a/src/lib/live/detect.test.ts
+++ b/src/lib/live/detect.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+import { detectGoalDeltas, detectPickSettlements } from './detect'
+import type { LiveFixture, LivePayload, LivePick, LivePlayer } from './types'
+
+function payload(overrides: Partial<LivePayload> = {}): LivePayload {
+	return {
+		gameId: 'g1',
+		gameMode: 'classic',
+		roundId: 'r1',
+		fixtures: [],
+		picks: [],
+		players: [],
+		viewerUserId: 'u1',
+		updatedAt: new Date().toISOString(),
+		...overrides,
+	}
+}
+
+function fx(overrides: Partial<LiveFixture> = {}): LiveFixture {
+	return {
+		id: 'fx1',
+		kickoff: new Date('2026-06-11T19:00:00Z'),
+		homeScore: 0,
+		awayScore: 0,
+		status: 'live',
+		homeShort: 'ENG',
+		awayShort: 'FRA',
+		...overrides,
+	}
+}
+
+describe('detectGoalDeltas', () => {
+	it('returns empty when no fixtures changed', () => {
+		const a = payload({ fixtures: [fx({ homeScore: 1 })] })
+		const b = payload({ fixtures: [fx({ homeScore: 1 })] })
+		expect(detectGoalDeltas(a, b)).toEqual([])
+	})
+
+	it('emits one event when home score increments', () => {
+		const a = payload({ fixtures: [fx({ homeScore: 0, awayScore: 0 })] })
+		const b = payload({ fixtures: [fx({ homeScore: 1, awayScore: 0 })] })
+		const events = detectGoalDeltas(a, b)
+		expect(events).toHaveLength(1)
+		expect(events[0].id).toBe('fx1:home:1')
+		expect(events[0].side).toBe('home')
+		expect(events[0].newScore).toBe(1)
+		expect(events[0].previousScore).toBe(0)
+	})
+
+	it('emits one event per increment when score jumps by two', () => {
+		const a = payload({ fixtures: [fx({ homeScore: 0 })] })
+		const b = payload({ fixtures: [fx({ homeScore: 2 })] })
+		const events = detectGoalDeltas(a, b)
+		expect(events).toHaveLength(2)
+		expect(events.map((e) => e.id)).toEqual(['fx1:home:1', 'fx1:home:2'])
+	})
+
+	it('never emits events for score decrements', () => {
+		const a = payload({ fixtures: [fx({ homeScore: 2 })] })
+		const b = payload({ fixtures: [fx({ homeScore: 1 })] })
+		expect(detectGoalDeltas(a, b)).toEqual([])
+	})
+
+	it('ignores transition from null to non-null (treated as initial load)', () => {
+		const a = payload({ fixtures: [fx({ homeScore: null, awayScore: null })] })
+		const b = payload({ fixtures: [fx({ homeScore: 1, awayScore: 0 })] })
+		expect(detectGoalDeltas(a, b)).toEqual([])
+	})
+
+	it('ignores non-null to null transition', () => {
+		const a = payload({ fixtures: [fx({ homeScore: 1 })] })
+		const b = payload({ fixtures: [fx({ homeScore: null })] })
+		expect(detectGoalDeltas(a, b)).toEqual([])
+	})
+
+	it('ignores fixture removed between polls', () => {
+		const a = payload({ fixtures: [fx({ homeScore: 1 })] })
+		const b = payload({ fixtures: [] })
+		expect(detectGoalDeltas(a, b)).toEqual([])
+	})
+
+	it('emits for away-side increments', () => {
+		const a = payload({ fixtures: [fx({ awayScore: 0 })] })
+		const b = payload({ fixtures: [fx({ awayScore: 1 })] })
+		const events = detectGoalDeltas(a, b)
+		expect(events).toHaveLength(1)
+		expect(events[0].side).toBe('away')
+		expect(events[0].id).toBe('fx1:away:1')
+	})
+})
+
+function pk(overrides: Partial<LivePick> = {}): LivePick {
+	return {
+		gamePlayerId: 'gp1',
+		fixtureId: 'fx1',
+		teamId: 't-home',
+		confidenceRank: 1,
+		predictedResult: 'home_win',
+		result: 'pending',
+		...overrides,
+	}
+}
+
+function pl(overrides: Partial<LivePlayer> = {}): LivePlayer {
+	return { id: 'gp1', userId: 'u1', status: 'active', livesRemaining: 1, ...overrides }
+}
+
+describe('detectPickSettlements', () => {
+	it('emits settled-loss when a pending pick transitions to loss', () => {
+		const a = payload({ picks: [pk({ result: 'pending' })], players: [pl()] })
+		const b = payload({ picks: [pk({ result: 'loss' })], players: [pl()] })
+		const events = detectPickSettlements(a, b)
+		expect(events).toHaveLength(1)
+		expect(events[0].id).toBe('gp1:r1:settled-loss')
+		expect(events[0].result).toBe('settled-loss')
+	})
+
+	it('emits settled-win on pending to win', () => {
+		const a = payload({ picks: [pk({ result: 'pending' })], players: [pl()] })
+		const b = payload({ picks: [pk({ result: 'win' })], players: [pl()] })
+		const events = detectPickSettlements(a, b)
+		expect(events).toHaveLength(1)
+		expect(events[0].result).toBe('settled-win')
+	})
+
+	it('emits saved-by-life on pending to saved_by_life', () => {
+		const a = payload({ picks: [pk({ result: 'pending' })], players: [pl()] })
+		const b = payload({ picks: [pk({ result: 'saved_by_life' })], players: [pl()] })
+		const events = detectPickSettlements(a, b)
+		expect(events).toHaveLength(1)
+		expect(events[0].result).toBe('saved-by-life')
+	})
+
+	it('does not re-emit on already-settled pick', () => {
+		const a = payload({ picks: [pk({ result: 'loss' })], players: [pl()] })
+		const b = payload({ picks: [pk({ result: 'loss' })], players: [pl()] })
+		expect(detectPickSettlements(a, b)).toEqual([])
+	})
+
+	it('does not emit for still-pending pick', () => {
+		const a = payload({ picks: [pk({ result: 'pending' })], players: [pl()] })
+		const b = payload({ picks: [pk({ result: 'pending' })], players: [pl()] })
+		expect(detectPickSettlements(a, b)).toEqual([])
+	})
+
+	it('ignores pick removed between polls', () => {
+		const a = payload({ picks: [pk({ result: 'pending' })], players: [pl()] })
+		const b = payload({ picks: [], players: [pl()] })
+		expect(detectPickSettlements(a, b)).toEqual([])
+	})
+})

--- a/src/lib/live/detect.ts
+++ b/src/lib/live/detect.ts
@@ -1,0 +1,67 @@
+import type { GoalEvent, LivePayload, PickSettlementEvent } from './types'
+
+export function detectGoalDeltas(previous: LivePayload, next: LivePayload): GoalEvent[] {
+	const events: GoalEvent[] = []
+	const observedAt = Date.now()
+
+	for (const nextFx of next.fixtures) {
+		const prevFx = previous.fixtures.find((f) => f.id === nextFx.id)
+		if (!prevFx) continue
+
+		for (const side of ['home', 'away'] as const) {
+			const prevScore = side === 'home' ? prevFx.homeScore : prevFx.awayScore
+			const nextScore = side === 'home' ? nextFx.homeScore : nextFx.awayScore
+			if (prevScore == null || nextScore == null) continue
+			if (nextScore <= prevScore) continue
+
+			for (let s = prevScore + 1; s <= nextScore; s++) {
+				events.push({
+					id: `${nextFx.id}:${side}:${s}`,
+					fixtureId: nextFx.id,
+					side,
+					newScore: s,
+					previousScore: s - 1,
+					observedAt,
+				})
+			}
+		}
+	}
+	return events
+}
+
+const SETTLED_RESULTS = new Set(['win', 'loss', 'saved_by_life'])
+
+export function detectPickSettlements(
+	previous: LivePayload,
+	next: LivePayload,
+): PickSettlementEvent[] {
+	const events: PickSettlementEvent[] = []
+	const observedAt = Date.now()
+
+	for (const nextPk of next.picks) {
+		const prevPk = previous.picks.find(
+			(p) => p.gamePlayerId === nextPk.gamePlayerId && p.fixtureId === nextPk.fixtureId,
+		)
+		if (!prevPk) continue
+		if (prevPk.result === nextPk.result) continue
+		if (SETTLED_RESULTS.has(String(prevPk.result))) continue
+		if (!SETTLED_RESULTS.has(String(nextPk.result))) continue
+		if (!next.roundId) continue
+
+		const mapped =
+			nextPk.result === 'win'
+				? 'settled-win'
+				: nextPk.result === 'loss'
+					? 'settled-loss'
+					: 'saved-by-life'
+
+		events.push({
+			id: `${nextPk.gamePlayerId}:${next.roundId}:${mapped}`,
+			gamePlayerId: nextPk.gamePlayerId,
+			roundId: next.roundId,
+			result: mapped,
+			observedAt,
+		})
+	}
+	return events
+}

--- a/src/lib/live/types.ts
+++ b/src/lib/live/types.ts
@@ -1,0 +1,64 @@
+export type FixtureStatus = 'scheduled' | 'live' | 'finished' | 'postponed' | 'halftime'
+
+export type PickResultState =
+	| 'win'
+	| 'loss'
+	| 'draw'
+	| 'saved_by_life'
+	| 'hidden'
+	| 'restricted'
+	| 'pending'
+
+export interface LiveFixture {
+	id: string
+	kickoff: Date | string | null
+	homeScore: number | null
+	awayScore: number | null
+	status: FixtureStatus
+	homeShort: string
+	awayShort: string
+}
+
+export interface LivePick {
+	gamePlayerId: string
+	fixtureId: string | null
+	teamId: string | null
+	confidenceRank: number | null
+	predictedResult: 'home_win' | 'away_win' | 'draw' | null
+	result: PickResultState | null
+}
+
+export interface LivePlayer {
+	id: string
+	userId: string
+	status: 'active' | 'eliminated'
+	livesRemaining: number
+}
+
+export interface LivePayload {
+	gameId: string
+	gameMode: 'classic' | 'turbo' | 'cup'
+	roundId: string | null
+	fixtures: LiveFixture[]
+	picks: LivePick[]
+	players: LivePlayer[]
+	viewerUserId: string
+	updatedAt: string
+}
+
+export interface GoalEvent {
+	id: string
+	fixtureId: string
+	side: 'home' | 'away'
+	newScore: number
+	previousScore: number
+	observedAt: number
+}
+
+export interface PickSettlementEvent {
+	id: string
+	gamePlayerId: string
+	roundId: string
+	result: 'settled-win' | 'settled-loss' | 'saved-by-life'
+	observedAt: number
+}


### PR DESCRIPTION
## Summary

Phase 4c1 turns the app from "static between match windows" into a live experience. During kickoff, scores update in place, goals celebrate on the ticker card, the viewer's own row highlights while their pick is in play, and players who just went out fade with an "OUT" badge. All without WebSockets, a new data provider, or a server-side events table.

**What shipped:**
- **Client polling layer** (`<LiveProvider>` + `useLiveGame()`) — polls `/api/games/[id]/live` at adaptive cadence (30s during match windows, 5min otherwise), diffs consecutive payloads to emit synthetic `GoalEvent` + `PickSettlementEvent` streams. Visibility-aware; pauses on hidden tab, refetches on focus. Exponential back-off on network error.
- **`<LiveScoreTicker>`** — pinned at top of game detail page, horizontal strip of `<LiveFixtureCard>`s showing per-fixture badges + scores + status pill + "My pick" tag. Only renders when a fixture is in its live window.
- **`<GoalCelebration>`** — scale-pulse + ring glow + floating "GOAL" chip per `GoalEvent`. Green for my-pick, red for opposition.
- **Standings enrichment** — cup-grid, cup-ladder, cup-timeline, cup-standings wrapper, turbo-standings, progress-grid all subscribe to the hook. Viewer's row gets blue left-border + "LIVE" pulse when their pick's match is active. Pick cells get `+1`/`-1` score-bump badges when scores change. Rows fade + pick up an "OUT" badge when a settled-loss event fires.
- **GH Actions cron cadence** bumped from every 5 min to every 1 min (free on public repo; server short-circuits on `hasActiveFixture`).
- **Dev seed** — one round's fixtures marked as live with partial scores so the feature is exercisable locally.

**Stats:** 22 commits, 226 tests (baseline 196; +30 new: 7×2 derive, 8+6 detect, 2 hook), typecheck + biome + next compile/TS all clean.

## Known deferrals

- **GH Actions workflow continues to fail** until Phase 4.5 sets `CRON_SECRET` + `VERCEL_PROD_URL` repo secrets (tracked in `project_phase_4_5_must_haves.md` memory).
- **Real WC fixture end-to-end verification** only possible once live data is flowing — Phase 4.5.
- **Hook-test cadence assertions** dropped because of fake-timers + RTL `waitFor` conflict. Tests cover happy-path + error-path only. Cadence behaviour validated post-launch.
- **Scorer names / minute-level events** require paid football-data.org tier. Deferred post-WC.
- **Retroactive animations** for goals scored before page load are deliberately not emitted (no server-side event store).

## Follow-ups logged (non-blocking, flagged by final reviewer)

- **I2** — `LiveProvider` visibility handler can spawn concurrent fetches on rapid hide/show. Low impact; worth hardening with an in-flight ref or AbortController.
- **M4** — `LIVE_WINDOW_BEFORE_MS` / `LIVE_WINDOW_AFTER_MS` constants duplicated in `derive.ts` and `live-provider.tsx`. Extract to shared module.
- **M7** — Ticker lacks ARIA region + `aria-live` for screen readers; horizontal scroll isn't keyboard-navigable. Accessibility polish for Phase 4c5 (mobile + a11y pass).
- **Hook-test timing** — re-introduce cadence assertions using `act(async () => vi.advanceTimersByTimeAsync(...))` or MSW. Currently covered only via real-world smoke.

Reviewer's three pre-merge findings (**I1** simultaneous-goal dedup, **I3** six dead `live?` props, **M6** Tailwind `tabular-nums` typo) are fixed in commit `8985297`.

## Test plan

- [ ] `pnpm install` then `just db-reset` to seed the mid-match cup game, then `just dev`.
- [ ] Navigate to the seeded mid-match game detail page. Confirm `<LiveScoreTicker>` renders at top with two live cards showing partial scores.
- [ ] Manually `UPDATE fixture SET home_score = home_score + 1 WHERE id = '...' AND status = 'live'` in psql. Wait ~30s. Confirm the on-card celebration fires (scale pulse + green/red glow + "GOAL" chip).
- [ ] Viewer's row in cup standings shows blue left-border + pulsing "LIVE" tag while their pick's match is in the live window.
- [ ] Trigger a settled-loss via DB mutation; row fades to 45% opacity with red "OUT" badge.
- [ ] `pnpm exec tsc --noEmit`, `pnpm exec biome check .`, `pnpm exec vitest run` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)