### PR TITLE
Phase 4c2: admin UX + no-pick engine rules

### DIFF
--- a/docs/superpowers/plans/2026-04-24-phase-4c2-admin-ux.md
+++ b/docs/superpowers/plans/2026-04-24-phase-4c2-admin-ux.md
@@ -1,0 +1,1942 @@
+# Phase 4c2: Admin UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver three admin-only actions (add player, pick for player, split pot) plus engine rules for no-pick handling (classic auto-pick from round 3+, turbo/cup refund-and-eliminate) so the app is usable in practice for friend-group game management.
+
+**Architecture:** Dedicated `<AdminPanel>` card on game detail hosts the two game-wide actions (add player, split pot). Contextual `✎` icons on standings rows trigger pick-for-player URL-param mode that reuses the existing `ClassicPick` / `TurboPick` / `CupPick` interfaces. Engine rules fire from the existing daily-sync cron's deadline-lock hook.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript 5.7, Drizzle ORM + postgres.js, Vitest. No new dependencies.
+
+**Design spec:** `docs/superpowers/specs/2026-04-24-phase-4c2-admin-ux-design.md`
+
+---
+
+## Scope
+
+Single sub-phase (4c2), one feature branch (`feature/phase-4c2-admin-ux`). Merges dormant onto `main`; runtime verification happens in Phase 4.5.
+
+## File structure
+
+### Created
+
+| Path | Responsibility |
+|---|---|
+| `drizzle/NNNN_<name>.sql` | Generated migration — adds `pick.is_auto`, `game_player.eliminated_reason`, `team.league_position`, `payment.refunded_at`. |
+| `src/lib/game/auto-pick.ts` | Pure function `pickLowestRankedUnusedTeam`. |
+| `src/lib/game/auto-pick.test.ts` | Unit tests for `pickLowestRankedUnusedTeam`. |
+| `src/lib/game/no-pick-handler.ts` | Orchestrator `processDeadlineLock` — invoked from daily-sync, dispatches to rule 2 (classic auto-pick) or rule 3 (turbo/cup refund-eliminate). |
+| `src/lib/game/no-pick-handler.test.ts` | Integration tests against a test DB. |
+| `src/app/api/users/search/route.ts` | `GET /api/users/search?q=...` — returns up to 10 users matching name/email. |
+| `src/app/api/users/search/route.test.ts` | Route tests. |
+| `src/app/api/games/[id]/admin/add-player/route.ts` | `POST /api/games/[id]/admin/add-player` — admin-gated, inserts `gamePlayer`. |
+| `src/app/api/games/[id]/admin/add-player/route.test.ts` | Route tests. |
+| `src/components/game/admin-panel.tsx` | Always-visible-to-admin card with "+ Add player" + "Split pot" buttons. |
+| `src/components/game/add-player-modal.tsx` | Search-and-select modal with post-submit chain to pick-for-player. |
+| `src/components/game/split-pot-modal.tsx` | Confirmation modal wrapping the existing split-pot POST route. |
+| `src/components/game/acting-as-banner.tsx` | Contained card banner shown on pick page when `?actingAs=...` is present. |
+| `src/components/game/auto-pick-banner.tsx` | One-time dismissible banner for the affected player. |
+
+### Modified
+
+- `src/lib/schema/game.ts` — add `isAuto` column to `pick`, `eliminatedReason` to `gamePlayer`.
+- `src/lib/schema/competition.ts` — add `leaguePosition` to `team`.
+- `src/lib/schema/payment.ts` — add `refundedAt` to `payment`.
+- `src/lib/game/bootstrap-competitions.ts` — persist `league_position` during standings sync.
+- `src/app/api/picks/[gameId]/[roundId]/route.ts` — accept `actingAs` body field; apply rule 1 un-elimination.
+- `src/app/api/cron/daily-sync/route.ts` — invoke `processDeadlineLock()` after competition sync.
+- `src/components/game/game-detail-view.tsx` — render `<AdminPanel />` + `<AutoPickBanner />` for admins / affected players.
+- `src/components/standings/progress-grid.tsx` — contextual `✎` icon + auto-pick ribbon/amber treatment on pick cells.
+- `src/components/standings/cup-grid.tsx` — contextual `✎` icon (ribbon threaded through for parity though cup won't trigger rule 2).
+- `src/components/standings/cup-ladder.tsx` — contextual `✎` on backer chips.
+- `src/components/standings/turbo-standings.tsx` — contextual `✎` icon.
+- `src/app/(app)/game/[id]/pick/page.tsx` (or wherever pick route lives — may need to check existing structure) — read `?actingAs` URL param, render `<ActingAsBanner />`, load target player's pick history.
+- `scripts/seed.ts` — add a game scenario with a missed deadline to exercise rule 2 + rule 1.
+
+## Execution order
+
+Tasks are numbered to match the intended sequence. TDD is used wherever there's pure logic to test; for UI and routes, tests are written before implementation where the test harness supports it.
+
+---
+
+## Part A — Schema and pure logic
+
+### Task 1: Schema migration
+
+**Files:**
+- Modify: `src/lib/schema/game.ts`
+- Modify: `src/lib/schema/competition.ts`
+- Modify: `src/lib/schema/payment.ts`
+- Create (generated): `drizzle/NNNN_<name>.sql`
+
+Adds four nullable/default-safe columns across four tables. No enum extensions; `eliminated_reason` is free-form text with TS-enforced union.
+
+- [ ] **Step 1: Edit `src/lib/schema/game.ts`**
+
+In the `pick` table definition, add after the existing columns (before closing parenthesis):
+
+```typescript
+isAuto: boolean('is_auto').notNull().default(false),
+```
+
+In the `gamePlayer` table definition, add after `eliminatedRoundNumber`:
+
+```typescript
+eliminatedReason: text('eliminated_reason'),
+```
+
+Document the valid values above the column with a comment:
+
+```typescript
+// Valid values: 'loss' | 'missed_rebuy_pick' | 'no_pick_no_fallback' | 'admin_removed'
+eliminatedReason: text('eliminated_reason'),
+```
+
+- [ ] **Step 2: Edit `src/lib/schema/competition.ts`**
+
+In the `team` table definition, add after the existing columns:
+
+```typescript
+leaguePosition: integer('league_position'),
+```
+
+- [ ] **Step 3: Edit `src/lib/schema/payment.ts`**
+
+In the `payment` table definition, add after `claimedAt`:
+
+```typescript
+refundedAt: timestamp('refunded_at'),
+```
+
+- [ ] **Step 4: Generate migration**
+
+Run: `just db-generate`
+Expected: new file `drizzle/NNNN_<name>.sql` created with `ALTER TABLE` statements adding the four columns.
+
+- [ ] **Step 5: Apply migration locally**
+
+Run: `just db-migrate`
+Expected: migration applies cleanly; no errors.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/schema/ drizzle/
+git commit -m "feat(schema): add auto-pick flag, elimination reason, league position, refunded timestamp"
+```
+
+---
+
+### Task 2: `pickLowestRankedUnusedTeam` pure function
+
+**Files:**
+- Create: `src/lib/game/auto-pick.ts`
+- Create: `src/lib/game/auto-pick.test.ts`
+
+Pure function: given a round's fixtures, a set of already-used team ids, and a team-position lookup, returns the id of the lowest-ranked unused team (or `null` if none available).
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// src/lib/game/auto-pick.test.ts
+import { describe, expect, it } from 'vitest'
+import { pickLowestRankedUnusedTeam } from './auto-pick'
+
+interface TestFixture {
+	id: string
+	homeTeamId: string
+	awayTeamId: string
+}
+
+describe('pickLowestRankedUnusedTeam', () => {
+	const fixtures: TestFixture[] = [
+		{ id: 'fx1', homeTeamId: 't-ars', awayTeamId: 't-che' },
+		{ id: 'fx2', homeTeamId: 't-liv', awayTeamId: 't-eve' },
+		{ id: 'fx3', homeTeamId: 't-mci', awayTeamId: 't-wba' },
+	]
+	const positions = new Map([
+		['t-ars', 3],
+		['t-che', 6],
+		['t-liv', 2],
+		['t-eve', 12],
+		['t-mci', 1],
+		['t-wba', 20],
+	])
+
+	it('returns the team with highest league_position (worst rank) when none used', () => {
+		expect(
+			pickLowestRankedUnusedTeam({ fixtures, usedTeamIds: new Set(), teamPositions: positions }),
+		).toBe('t-wba')
+	})
+
+	it('excludes used teams', () => {
+		expect(
+			pickLowestRankedUnusedTeam({
+				fixtures,
+				usedTeamIds: new Set(['t-wba']),
+				teamPositions: positions,
+			}),
+		).toBe('t-eve')
+	})
+
+	it('returns null when all teams in round are used', () => {
+		expect(
+			pickLowestRankedUnusedTeam({
+				fixtures,
+				usedTeamIds: new Set(['t-ars', 't-che', 't-liv', 't-eve', 't-mci', 't-wba']),
+				teamPositions: positions,
+			}),
+		).toBe(null)
+	})
+
+	it('treats teams with null/missing position as lowest-ranked (safe default)', () => {
+		const positionsWithMissing = new Map([
+			['t-ars', 3],
+			['t-che', 6],
+			['t-liv', 2],
+			['t-eve', 12],
+			['t-mci', 1],
+			// t-wba missing — treated as position Infinity
+		])
+		expect(
+			pickLowestRankedUnusedTeam({
+				fixtures,
+				usedTeamIds: new Set(),
+				teamPositions: positionsWithMissing,
+			}),
+		).toBe('t-wba')
+	})
+
+	it('tie-breaks by team id alphabetically', () => {
+		const tied = new Map([
+			['t-aaa', 20],
+			['t-zzz', 20],
+		])
+		const tiedFixtures: TestFixture[] = [{ id: 'fx1', homeTeamId: 't-aaa', awayTeamId: 't-zzz' }]
+		expect(
+			pickLowestRankedUnusedTeam({
+				fixtures: tiedFixtures,
+				usedTeamIds: new Set(),
+				teamPositions: tied,
+			}),
+		).toBe('t-aaa')
+	})
+
+	it('returns null when fixtures array is empty', () => {
+		expect(
+			pickLowestRankedUnusedTeam({
+				fixtures: [],
+				usedTeamIds: new Set(),
+				teamPositions: positions,
+			}),
+		).toBe(null)
+	})
+})
+```
+
+- [ ] **Step 2: Run the tests — verify FAIL**
+
+Run: `pnpm exec vitest run src/lib/game/auto-pick.test.ts`
+Expected: FAIL with "cannot find module ./auto-pick".
+
+- [ ] **Step 3: Implement `auto-pick.ts`**
+
+```typescript
+// src/lib/game/auto-pick.ts
+interface FixtureRef {
+	id: string
+	homeTeamId: string
+	awayTeamId: string
+}
+
+interface PickLowestRankedInput {
+	fixtures: FixtureRef[]
+	usedTeamIds: Set<string>
+	teamPositions: Map<string, number>
+}
+
+export function pickLowestRankedUnusedTeam({
+	fixtures,
+	usedTeamIds,
+	teamPositions,
+}: PickLowestRankedInput): string | null {
+	const candidates = new Set<string>()
+	for (const fx of fixtures) {
+		if (!usedTeamIds.has(fx.homeTeamId)) candidates.add(fx.homeTeamId)
+		if (!usedTeamIds.has(fx.awayTeamId)) candidates.add(fx.awayTeamId)
+	}
+	if (candidates.size === 0) return null
+
+	let best: { teamId: string; position: number } | null = null
+	for (const teamId of candidates) {
+		const position = teamPositions.get(teamId) ?? Number.POSITIVE_INFINITY
+		if (best === null) {
+			best = { teamId, position }
+			continue
+		}
+		if (position > best.position) {
+			best = { teamId, position }
+		} else if (position === best.position && teamId < best.teamId) {
+			best = { teamId, position }
+		}
+	}
+	return best?.teamId ?? null
+}
+```
+
+- [ ] **Step 4: Run the tests — verify PASS**
+
+Run: `pnpm exec vitest run src/lib/game/auto-pick.test.ts`
+Expected: all 6 tests PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/game/auto-pick.ts src/lib/game/auto-pick.test.ts
+git commit -m "feat(game): add pickLowestRankedUnusedTeam pure function"
+```
+
+---
+
+## Part B — User search and add-player API
+
+### Task 3: User search route
+
+**Files:**
+- Create: `src/app/api/users/search/route.ts`
+- Create: `src/app/api/users/search/route.test.ts`
+
+`GET /api/users/search?q=<string>` — returns up to 10 users matching name or email (case-insensitive prefix match). Any authenticated user can call it.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// src/app/api/users/search/route.test.ts
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GET } from './route'
+
+vi.mock('@/lib/auth-helpers', () => ({
+	requireSession: vi.fn(),
+}))
+vi.mock('@/lib/db', () => ({
+	db: {
+		select: vi.fn(),
+	},
+}))
+
+import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+
+describe('GET /api/users/search', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.mocked(requireSession).mockResolvedValue({ user: { id: 'u-me' } } as never)
+	})
+
+	it('returns [] for empty query', async () => {
+		const req = new Request('http://localhost/api/users/search?q=')
+		const res = await GET(req)
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({ users: [] })
+	})
+
+	it('returns matching users limited to 10', async () => {
+		const mockUsers = Array.from({ length: 15 }, (_, i) => ({
+			id: `u-${i}`,
+			name: `User ${i}`,
+			email: `u${i}@example.com`,
+		}))
+		const selectChain = {
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockReturnValue({
+					limit: vi.fn().mockResolvedValue(mockUsers.slice(0, 10)),
+				}),
+			}),
+		}
+		vi.mocked(db.select).mockReturnValue(selectChain as never)
+
+		const req = new Request('http://localhost/api/users/search?q=user')
+		const res = await GET(req)
+		expect(res.status).toBe(200)
+		const body = await res.json()
+		expect(body.users).toHaveLength(10)
+	})
+})
+```
+
+- [ ] **Step 2: Run — verify FAIL**
+
+Run: `pnpm exec vitest run src/app/api/users/search/route.test.ts`
+Expected: FAIL with "cannot find module ./route".
+
+- [ ] **Step 3: Implement route**
+
+```typescript
+// src/app/api/users/search/route.ts
+import { or, sql } from 'drizzle-orm'
+import { NextResponse } from 'next/server'
+import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { user } from '@/lib/schema/auth'
+
+export async function GET(request: Request): Promise<Response> {
+	await requireSession()
+
+	const { searchParams } = new URL(request.url)
+	const q = (searchParams.get('q') ?? '').trim()
+	if (q.length === 0) {
+		return NextResponse.json({ users: [] })
+	}
+
+	const pattern = `${q.toLowerCase()}%`
+	const results = await db
+		.select({ id: user.id, name: user.name, email: user.email })
+		.from(user)
+		.where(
+			or(sql`lower(${user.name}) like ${pattern}`, sql`lower(${user.email}) like ${pattern}`),
+		)
+		.limit(10)
+
+	return NextResponse.json({ users: results })
+}
+```
+
+- [ ] **Step 4: Run tests — verify PASS**
+
+Run: `pnpm exec vitest run src/app/api/users/search/route.test.ts`
+Expected: both tests PASS.
+
+- [ ] **Step 5: Typecheck + full test run**
+
+Run: `pnpm exec tsc --noEmit && pnpm exec vitest run`
+Expected: tsc clean; all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/api/users/search/
+git commit -m "feat(api): add user search endpoint"
+```
+
+---
+
+### Task 4: Add-player route
+
+**Files:**
+- Create: `src/app/api/games/[id]/admin/add-player/route.ts`
+- Create: `src/app/api/games/[id]/admin/add-player/route.test.ts`
+
+`POST /api/games/[id]/admin/add-player` — body `{ userId }`. Admin-gated. Inserts `gamePlayer` row or returns 409 if duplicate, 404 if user not found.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// src/app/api/games/[id]/admin/add-player/route.test.ts
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { POST } from './route'
+
+vi.mock('@/lib/auth-helpers', () => ({
+	requireSession: vi.fn(),
+}))
+vi.mock('@/lib/db', () => ({
+	db: { query: { game: { findFirst: vi.fn() }, user: { findFirst: vi.fn() }, gamePlayer: { findFirst: vi.fn() } }, insert: vi.fn() },
+}))
+
+import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+
+function makeReq(body: unknown) {
+	return new Request('http://localhost/api/games/g1/admin/add-player', {
+		method: 'POST',
+		body: JSON.stringify(body),
+	})
+}
+
+const params = { params: Promise.resolve({ id: 'g1' }) }
+
+describe('POST /api/games/[id]/admin/add-player', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.mocked(requireSession).mockResolvedValue({ user: { id: 'u-admin' } } as never)
+	})
+
+	it('returns 403 for non-admin', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({ id: 'g1', createdBy: 'u-other', modeConfig: { startingLives: 3 }, gameMode: 'classic' } as never)
+		const res = await POST(makeReq({ userId: 'u-new' }), params)
+		expect(res.status).toBe(403)
+	})
+
+	it('returns 404 when target user not found', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({ id: 'g1', createdBy: 'u-admin', modeConfig: { startingLives: 3 }, gameMode: 'classic' } as never)
+		vi.mocked(db.query.user.findFirst).mockResolvedValue(undefined as never)
+		const res = await POST(makeReq({ userId: 'u-new' }), params)
+		expect(res.status).toBe(404)
+	})
+
+	it('returns 409 when user already in game', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({ id: 'g1', createdBy: 'u-admin', modeConfig: { startingLives: 3 }, gameMode: 'classic' } as never)
+		vi.mocked(db.query.user.findFirst).mockResolvedValue({ id: 'u-new' } as never)
+		vi.mocked(db.query.gamePlayer.findFirst).mockResolvedValue({ id: 'gp-exist', userId: 'u-new' } as never)
+		const res = await POST(makeReq({ userId: 'u-new' }), params)
+		expect(res.status).toBe(409)
+	})
+
+	it('inserts gamePlayer and returns 200', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({ id: 'g1', createdBy: 'u-admin', modeConfig: { startingLives: 3 }, gameMode: 'classic' } as never)
+		vi.mocked(db.query.user.findFirst).mockResolvedValue({ id: 'u-new' } as never)
+		vi.mocked(db.query.gamePlayer.findFirst).mockResolvedValue(undefined as never)
+		const insertChain = { values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: 'gp-new', userId: 'u-new' }]) }) }
+		vi.mocked(db.insert).mockReturnValue(insertChain as never)
+
+		const res = await POST(makeReq({ userId: 'u-new' }), params)
+		expect(res.status).toBe(200)
+		const body = await res.json()
+		expect(body.gamePlayer.id).toBe('gp-new')
+	})
+})
+```
+
+- [ ] **Step 2: Run — verify FAIL**
+
+Run: `pnpm exec vitest run src/app/api/games/[id]/admin/add-player/route.test.ts`
+Expected: FAIL with "cannot find module ./route".
+
+- [ ] **Step 3: Implement route**
+
+```typescript
+// src/app/api/games/[id]/admin/add-player/route.ts
+import { and, eq } from 'drizzle-orm'
+import { NextResponse } from 'next/server'
+import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { game, gamePlayer } from '@/lib/schema/game'
+import { user } from '@/lib/schema/auth'
+
+export async function POST(
+	request: Request,
+	{ params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+	const session = await requireSession()
+	const { id: gameId } = await params
+	const body = (await request.json()) as { userId?: string }
+
+	if (!body.userId) {
+		return NextResponse.json({ error: 'missing-userId' }, { status: 400 })
+	}
+
+	const gameRow = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+	if (!gameRow) {
+		return NextResponse.json({ error: 'not-found' }, { status: 404 })
+	}
+	if (gameRow.createdBy !== session.user.id) {
+		return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+	}
+
+	const targetUser = await db.query.user.findFirst({ where: eq(user.id, body.userId) })
+	if (!targetUser) {
+		return NextResponse.json({ error: 'user-not-found' }, { status: 404 })
+	}
+
+	const existing = await db.query.gamePlayer.findFirst({
+		where: and(eq(gamePlayer.gameId, gameId), eq(gamePlayer.userId, body.userId)),
+	})
+	if (existing) {
+		return NextResponse.json({ error: 'already-in-game' }, { status: 409 })
+	}
+
+	const startingLives = (gameRow.modeConfig as { startingLives?: number } | null)?.startingLives ?? 1
+	const [inserted] = await db
+		.insert(gamePlayer)
+		.values({
+			gameId,
+			userId: body.userId,
+			status: 'alive',
+			livesRemaining: startingLives,
+		})
+		.returning()
+
+	return NextResponse.json({ gamePlayer: inserted })
+}
+```
+
+- [ ] **Step 4: Run tests — verify PASS**
+
+Run: `pnpm exec vitest run src/app/api/games/[id]/admin/add-player/route.test.ts`
+Expected: all 4 tests PASS.
+
+- [ ] **Step 5: Typecheck + full tests**
+
+Run: `pnpm exec tsc --noEmit && pnpm exec vitest run`
+Expected: tsc clean; all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/api/games/[id]/admin/add-player/
+git commit -m "feat(api): add admin add-player route"
+```
+
+---
+
+## Part C — Pick-for-player API
+
+### Task 5: Extend pick route with `actingAs` + rule 1
+
+**Files:**
+- Modify: `src/app/api/picks/[gameId]/[roundId]/route.ts`
+- Modify (test): `src/app/api/picks/[gameId]/[roundId]/route.test.ts` (create if doesn't exist)
+
+Accept optional `actingAs` body field. When present:
+- Require the session user to be the game admin (`game.createdBy`).
+- Require `actingAs` to reference a `gamePlayer` in this game.
+- Target that player's pick history + used-teams for validation, not the admin's.
+- On successful write, if target's `eliminatedReason === 'missed_rebuy_pick'`, flip status back to `alive` in the same transaction.
+
+- [ ] **Step 1: Read the existing route**
+
+Run: `cat src/app/api/picks/\[gameId\]/\[roundId\]/route.ts`
+
+Note the current structure: session check, gameData load, pick validation, pick insert, cup-mode restricted check (from 4b). The `actingAs` handling is an override layer on top.
+
+- [ ] **Step 2: Add the `actingAs` resolution block**
+
+Near the top of the POST handler, after the session + gameData load, add:
+
+```typescript
+const body = (await request.json()) as { picks?: unknown[]; actingAs?: string }
+let targetGamePlayer = await db.query.gamePlayer.findFirst({
+	where: and(eq(gamePlayer.gameId, gameId), eq(gamePlayer.userId, session.user.id)),
+})
+
+if (body.actingAs) {
+	// Admin is picking for another player.
+	if (gameData.createdBy !== session.user.id) {
+		return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+	}
+	const actingAsPlayer = await db.query.gamePlayer.findFirst({
+		where: and(eq(gamePlayer.id, body.actingAs), eq(gamePlayer.gameId, gameId)),
+	})
+	if (!actingAsPlayer) {
+		return NextResponse.json({ error: 'actingAs-not-in-game' }, { status: 404 })
+	}
+	targetGamePlayer = actingAsPlayer
+}
+
+if (!targetGamePlayer) {
+	return NextResponse.json({ error: 'not-in-game' }, { status: 403 })
+}
+```
+
+All subsequent references to "this player's picks" should use `targetGamePlayer.id` / `.userId`. Search the file for the existing `gamePlayer` lookup and replace with `targetGamePlayer`. Used-teams lookups must query `pick.gamePlayerId = targetGamePlayer.id`.
+
+- [ ] **Step 3: Add rule 1 un-elimination after successful pick write**
+
+After the pick insert succeeds (and before the response), add:
+
+```typescript
+let unEliminated = false
+if (body.actingAs && targetGamePlayer.eliminatedReason === 'missed_rebuy_pick') {
+	await db
+		.update(gamePlayer)
+		.set({ status: 'alive', eliminatedReason: null, eliminatedRoundNumber: null })
+		.where(eq(gamePlayer.id, targetGamePlayer.id))
+	unEliminated = true
+}
+```
+
+Return `{ ...existing, unEliminated }` in the JSON response.
+
+- [ ] **Step 4: Add tests for `actingAs`**
+
+In `src/app/api/picks/[gameId]/[roundId]/route.test.ts`, add these tests (if no file exists, create one using the mock pattern from Task 3):
+
+```typescript
+it('rejects actingAs from non-admin with 403', async () => {
+	// mock gameData.createdBy = 'u-other', session.user.id = 'u-admin'
+	// POST body: { picks: [...], actingAs: 'gp-target' }
+	// expect 403
+})
+
+it('rejects actingAs referencing a player not in this game with 404', async () => {
+	// mock gameData.createdBy = 'u-admin', session.user.id = 'u-admin'
+	// actingAs lookup returns undefined
+	// expect 404
+})
+
+it('un-eliminates target when reason is missed_rebuy_pick', async () => {
+	// target.eliminatedReason = 'missed_rebuy_pick', target.status = 'eliminated'
+	// after successful pick: db.update called on gamePlayer with status: 'alive', eliminatedReason: null
+	// response body.unEliminated === true
+})
+
+it('does not un-eliminate when reason is something else', async () => {
+	// target.eliminatedReason = 'loss'
+	// after pick: no db.update for gamePlayer; response body.unEliminated === false
+})
+```
+
+- [ ] **Step 5: Run tests — verify new tests PASS**
+
+Run: `pnpm exec vitest run src/app/api/picks/[gameId]/[roundId]/route.test.ts`
+Expected: all tests pass.
+
+- [ ] **Step 6: Typecheck + full test run**
+
+Run: `pnpm exec tsc --noEmit && pnpm exec vitest run`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/app/api/picks/[gameId]/[roundId]/
+git commit -m "feat(api): support actingAs in pick route with rule-1 un-elimination"
+```
+
+---
+
+## Part D — Engine rules 2 and 3
+
+### Task 6: `processDeadlineLock` orchestrator
+
+**Files:**
+- Create: `src/lib/game/no-pick-handler.ts`
+- Create: `src/lib/game/no-pick-handler.test.ts`
+
+Orchestrator that scans for no-pick players in newly-live rounds and applies rule 2 (classic, round ≥ 3) or rule 3 (turbo/cup).
+
+- [ ] **Step 1: Implement `no-pick-handler.ts`**
+
+```typescript
+// src/lib/game/no-pick-handler.ts
+import { and, eq, inArray, isNull, ne } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { fixture, round, team } from '@/lib/schema/competition'
+import { game, gamePlayer, pick } from '@/lib/schema/game'
+import { payment } from '@/lib/schema/payment'
+import { pickLowestRankedUnusedTeam } from './auto-pick'
+
+export async function processDeadlineLock(roundIds: string[]): Promise<{
+	autoPicksInserted: number
+	playersEliminated: number
+	paymentsRefunded: number
+}> {
+	let autoPicksInserted = 0
+	let playersEliminated = 0
+	let paymentsRefunded = 0
+
+	for (const roundId of roundIds) {
+		const roundRow = await db.query.round.findFirst({ where: eq(round.id, roundId) })
+		if (!roundRow) continue
+
+		const games = await db.query.game.findMany({
+			where: and(eq(game.currentRoundId, roundId), ne(game.status, 'completed')),
+			with: { players: true },
+		})
+
+		for (const g of games) {
+			const activePlayers = g.players.filter((p) => p.status === 'alive')
+			for (const player of activePlayers) {
+				const existingPick = await db.query.pick.findFirst({
+					where: and(eq(pick.gamePlayerId, player.id), eq(pick.roundId, roundId)),
+				})
+				if (existingPick) continue
+
+				if (g.gameMode === 'classic' && roundRow.number >= 3) {
+					const result = await applyRule2Classic(g.id, player, roundId)
+					if (result === 'auto-pick-inserted') autoPicksInserted++
+					else if (result === 'eliminated-no-fallback') playersEliminated++
+				} else if (g.gameMode === 'turbo' || g.gameMode === 'cup') {
+					const result = await applyRule3TurboOrCup(g.id, player, roundRow.number)
+					playersEliminated++
+					if (result.refunded) paymentsRefunded++
+				}
+			}
+		}
+	}
+
+	return { autoPicksInserted, playersEliminated, paymentsRefunded }
+}
+
+async function applyRule2Classic(
+	gameId: string,
+	player: typeof gamePlayer.$inferSelect,
+	roundId: string,
+): Promise<'auto-pick-inserted' | 'eliminated-no-fallback'> {
+	const fixtures = await db.query.fixture.findMany({
+		where: eq(fixture.roundId, roundId),
+		with: { homeTeam: true, awayTeam: true },
+	})
+	const usedPicks = await db.query.pick.findMany({
+		where: and(eq(pick.gameId, gameId), eq(pick.gamePlayerId, player.id)),
+	})
+	const usedTeamIds = new Set(usedPicks.flatMap((p) => (p.teamId ? [p.teamId] : [])))
+
+	const allTeamIds = new Set<string>()
+	for (const fx of fixtures) {
+		allTeamIds.add(fx.homeTeamId)
+		allTeamIds.add(fx.awayTeamId)
+	}
+	const teamRows = allTeamIds.size
+		? await db.query.team.findMany({ where: inArray(team.id, Array.from(allTeamIds)) })
+		: []
+	const teamPositions = new Map(
+		teamRows.map((t) => [t.id, t.leaguePosition ?? Number.POSITIVE_INFINITY] as const),
+	)
+
+	const teamId = pickLowestRankedUnusedTeam({
+		fixtures: fixtures.map((fx) => ({
+			id: fx.id,
+			homeTeamId: fx.homeTeamId,
+			awayTeamId: fx.awayTeamId,
+		})),
+		usedTeamIds,
+		teamPositions,
+	})
+
+	if (!teamId) {
+		await db
+			.update(gamePlayer)
+			.set({
+				status: 'eliminated',
+				eliminatedReason: 'no_pick_no_fallback',
+				eliminatedRoundNumber: undefined,
+			})
+			.where(eq(gamePlayer.id, player.id))
+		return 'eliminated-no-fallback'
+	}
+
+	const chosenFixture = fixtures.find(
+		(fx) => fx.homeTeamId === teamId || fx.awayTeamId === teamId,
+	)
+	if (!chosenFixture) {
+		// Defensive — should not happen since teamId came from fixtures.
+		return 'eliminated-no-fallback'
+	}
+	const predictedResult = chosenFixture.homeTeamId === teamId ? 'home_win' : 'away_win'
+	await db.insert(pick).values({
+		gameId,
+		roundId,
+		gamePlayerId: player.id,
+		fixtureId: chosenFixture.id,
+		teamId,
+		predictedResult,
+		confidenceRank: null,
+		isAuto: true,
+	})
+	return 'auto-pick-inserted'
+}
+
+async function applyRule3TurboOrCup(
+	gameId: string,
+	player: typeof gamePlayer.$inferSelect,
+	roundNumber: number,
+): Promise<{ refunded: boolean }> {
+	await db
+		.update(gamePlayer)
+		.set({
+			status: 'eliminated',
+			eliminatedReason: 'no_pick_no_fallback',
+			eliminatedRoundNumber: roundNumber,
+		})
+		.where(eq(gamePlayer.id, player.id))
+
+	const refundCandidate = await db.query.payment.findFirst({
+		where: and(
+			eq(payment.gameId, gameId),
+			eq(payment.userId, player.userId),
+			inArray(payment.status, ['paid', 'claimed']),
+		),
+		orderBy: (p, { desc }) => desc(p.createdAt),
+	})
+	if (!refundCandidate) return { refunded: false }
+
+	await db
+		.update(payment)
+		.set({ status: 'refunded', refundedAt: new Date() })
+		.where(eq(payment.id, refundCandidate.id))
+	return { refunded: true }
+}
+```
+
+- [ ] **Step 2: Write test scaffolding (minimal — full integration tests in Task 7)**
+
+```typescript
+// src/lib/game/no-pick-handler.test.ts
+import { describe, expect, it, vi } from 'vitest'
+import { processDeadlineLock } from './no-pick-handler'
+
+vi.mock('@/lib/db', () => ({
+	db: {
+		query: {
+			round: { findFirst: vi.fn() },
+			game: { findMany: vi.fn().mockResolvedValue([]) },
+			pick: { findFirst: vi.fn(), findMany: vi.fn() },
+			fixture: { findMany: vi.fn() },
+			team: { findMany: vi.fn() },
+			payment: { findFirst: vi.fn() },
+		},
+		insert: vi.fn(),
+		update: vi.fn(),
+	},
+}))
+
+describe('processDeadlineLock', () => {
+	it('no-ops when no games use the round', async () => {
+		const result = await processDeadlineLock(['r1'])
+		expect(result).toEqual({ autoPicksInserted: 0, playersEliminated: 0, paymentsRefunded: 0 })
+	})
+})
+```
+
+- [ ] **Step 3: Run — verify PASS**
+
+Run: `pnpm exec vitest run src/lib/game/no-pick-handler.test.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/game/no-pick-handler.ts src/lib/game/no-pick-handler.test.ts
+git commit -m "feat(game): add processDeadlineLock orchestrator for rules 2/3"
+```
+
+---
+
+### Task 7: Persist `league_position` during competition sync
+
+**Files:**
+- Modify: `src/lib/game/bootstrap-competitions.ts`
+
+When `bootstrap-competitions.ts` syncs competition data, it should also persist the latest standings into `team.league_position`. Use the existing `fetchStandings` adapter method.
+
+- [ ] **Step 1: Read existing bootstrap**
+
+Run: `cat src/lib/game/bootstrap-competitions.ts | head -80`
+
+Locate the team-upsert loop.
+
+- [ ] **Step 2: After team upsert, fetch standings and persist positions**
+
+After the existing team sync, add:
+
+```typescript
+const standings = await adapter.fetchStandings()
+for (const row of standings) {
+	await db
+		.update(team)
+		.set({ leaguePosition: row.position })
+		.where(
+			and(
+				eq(team.competitionId, competitionId),
+				eq(team.externalId, row.teamExternalId),
+			),
+		)
+}
+```
+
+(Adjust exact imports/variables to match the file's existing style.)
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 4: Update existing test to assert position persistence**
+
+If `bootstrap-competitions.test.ts` exists and mocks the adapter, add an assertion that `db.update` is called for each standings row with `leaguePosition`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/game/bootstrap-competitions.ts src/lib/game/bootstrap-competitions.test.ts
+git commit -m "feat(sync): persist league_position during competition sync"
+```
+
+---
+
+### Task 8: Wire `processDeadlineLock` into daily-sync
+
+**Files:**
+- Modify: `src/app/api/cron/daily-sync/route.ts`
+
+After the existing competition sync completes, collect the set of round IDs that transitioned to `live` in this run and hand them to `processDeadlineLock`.
+
+- [ ] **Step 1: Read current daily-sync**
+
+Run: `cat src/app/api/cron/daily-sync/route.ts`
+
+Identify where round-transition detection happens (Phase 4b added this for auto-submits).
+
+- [ ] **Step 2: Collect transitioned round ids and invoke handler**
+
+At the end of the POST handler, after the existing sync work:
+
+```typescript
+import { processDeadlineLock } from '@/lib/game/no-pick-handler'
+
+// ... after collecting the list of rounds that moved to `live` ...
+const deadlineLockedRoundIds: string[] = /* the existing collection */
+if (deadlineLockedRoundIds.length > 0) {
+	await processDeadlineLock(deadlineLockedRoundIds)
+}
+```
+
+(The existing Phase 4b code that detects `transitioningToOpen` for auto-submits already iterates the right set — reuse that collection or extract if needed.)
+
+- [ ] **Step 3: Extend existing daily-sync tests**
+
+Add a test case where a round transitions; assert `processDeadlineLock` was called with the round id.
+
+- [ ] **Step 4: Typecheck + full tests**
+
+Run: `pnpm exec tsc --noEmit && pnpm exec vitest run`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/api/cron/daily-sync/
+git commit -m "feat(sync): invoke processDeadlineLock on round transitions"
+```
+
+---
+
+## Part E — UI components
+
+### Task 9: `<AdminPanel>` component
+
+**Files:**
+- Create: `src/components/game/admin-panel.tsx`
+
+Always-visible-to-admin card below standings. Two buttons: "+ Add player" (primary), "Split pot (N alive)" (neutral). Clicking opens the corresponding modal.
+
+- [ ] **Step 1: Implement**
+
+```typescript
+// src/components/game/admin-panel.tsx
+'use client'
+import { useState } from 'react'
+import { AddPlayerModal } from './add-player-modal'
+import { SplitPotModal } from './split-pot-modal'
+
+interface AdminPanelProps {
+	gameId: string
+	aliveCount: number
+	potTotal: string
+}
+
+export function AdminPanel({ gameId, aliveCount, potTotal }: AdminPanelProps) {
+	const [openModal, setOpenModal] = useState<'add' | 'split' | null>(null)
+
+	return (
+		<>
+			<div className="rounded-xl border border-border bg-card p-4">
+				<div className="mb-3 flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-muted-foreground">
+					<span className="rounded-sm bg-primary px-1.5 py-0.5 text-[9px] text-primary-foreground">
+						Admin
+					</span>
+					Game actions
+				</div>
+				<div className="flex flex-wrap gap-2">
+					<button
+						type="button"
+						onClick={() => setOpenModal('add')}
+						className="rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground hover:opacity-90"
+					>
+						+ Add player
+					</button>
+					<button
+						type="button"
+						onClick={() => setOpenModal('split')}
+						disabled={aliveCount < 2}
+						className="rounded-md border border-border bg-background px-3 py-1.5 text-xs font-semibold text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+					>
+						Split pot ({aliveCount} alive)
+					</button>
+				</div>
+			</div>
+			{openModal === 'add' && (
+				<AddPlayerModal gameId={gameId} onClose={() => setOpenModal(null)} />
+			)}
+			{openModal === 'split' && (
+				<SplitPotModal
+					gameId={gameId}
+					aliveCount={aliveCount}
+					potTotal={potTotal}
+					onClose={() => setOpenModal(null)}
+				/>
+			)}
+		</>
+	)
+}
+```
+
+- [ ] **Step 2: Typecheck (will fail — modal components don't exist yet)**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: tsc fails with "cannot find module ./add-player-modal". Acceptable — Tasks 10 and 11 add those.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/game/admin-panel.tsx
+git commit -m "feat(game): add AdminPanel component shell"
+```
+
+---
+
+### Task 10: `<AddPlayerModal>` component
+
+**Files:**
+- Create: `src/components/game/add-player-modal.tsx`
+
+Modal with search → results → select → submit. Post-submit success state chains to `/game/[id]/pick?actingAs=<newGamePlayerId>`.
+
+- [ ] **Step 1: Implement**
+
+```typescript
+// src/components/game/add-player-modal.tsx
+'use client'
+import { useRouter } from 'next/navigation'
+import { useEffect, useRef, useState } from 'react'
+import { cn } from '@/lib/utils'
+
+interface UserRow {
+	id: string
+	name: string
+	email: string
+}
+
+interface AddPlayerModalProps {
+	gameId: string
+	onClose: () => void
+}
+
+interface AddedState {
+	gamePlayerId: string
+	userName: string
+}
+
+export function AddPlayerModal({ gameId, onClose }: AddPlayerModalProps) {
+	const router = useRouter()
+	const [query, setQuery] = useState('')
+	const [results, setResults] = useState<UserRow[]>([])
+	const [selectedId, setSelectedId] = useState<string | null>(null)
+	const [error, setError] = useState<string | null>(null)
+	const [submitting, setSubmitting] = useState(false)
+	const [added, setAdded] = useState<AddedState | null>(null)
+	const inputRef = useRef<HTMLInputElement>(null)
+
+	useEffect(() => {
+		inputRef.current?.focus()
+	}, [])
+
+	useEffect(() => {
+		if (added) return
+		if (query.trim().length === 0) {
+			setResults([])
+			return
+		}
+		const timer = setTimeout(async () => {
+			const res = await fetch(`/api/users/search?q=${encodeURIComponent(query)}`)
+			if (!res.ok) return
+			const body = (await res.json()) as { users: UserRow[] }
+			setResults(body.users)
+		}, 200)
+		return () => clearTimeout(timer)
+	}, [query, added])
+
+	const selected = results.find((u) => u.id === selectedId) ?? null
+
+	async function handleAdd() {
+		if (!selected || submitting) return
+		setSubmitting(true)
+		setError(null)
+		try {
+			const res = await fetch(`/api/games/${gameId}/admin/add-player`, {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ userId: selected.id }),
+			})
+			const body = await res.json()
+			if (!res.ok) {
+				setError(body.error ?? 'failed-to-add')
+				return
+			}
+			setAdded({ gamePlayerId: body.gamePlayer.id, userName: selected.name })
+		} finally {
+			setSubmitting(false)
+		}
+	}
+
+	function handleGoToPick() {
+		if (!added) return
+		router.push(`/game/${gameId}/pick?actingAs=${added.gamePlayerId}`)
+	}
+
+	function handleBackToGame() {
+		onClose()
+		router.refresh()
+	}
+
+	return (
+		<div
+			role="dialog"
+			aria-modal="true"
+			className="fixed inset-0 z-50 flex items-center justify-center bg-black/65"
+			onClick={onClose}
+		>
+			<div
+				onClick={(e) => e.stopPropagation()}
+				className="w-[340px] rounded-lg border border-border bg-background p-5 shadow-2xl"
+			>
+				{added ? (
+					<>
+						<h3 className="text-[15px] font-bold">{added.userName} added</h3>
+						<p className="mb-4 mt-1 text-xs text-muted-foreground">
+							Pick for them now, or come back later.
+						</p>
+						<div className="flex justify-end gap-2">
+							<button
+								type="button"
+								onClick={handleBackToGame}
+								className="rounded-md border border-border bg-transparent px-3 py-1.5 text-xs font-semibold text-muted-foreground"
+							>
+								Back to game
+							</button>
+							<button
+								type="button"
+								onClick={handleGoToPick}
+								className="rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground"
+							>
+								Pick for {added.userName}
+							</button>
+						</div>
+					</>
+				) : (
+					<>
+						<h3 className="text-[15px] font-bold">Add player to this game</h3>
+						<p className="mb-3 mt-1 text-xs text-muted-foreground">
+							Search an existing user by name or email.
+						</p>
+						<input
+							ref={inputRef}
+							value={query}
+							onChange={(e) => setQuery(e.target.value)}
+							placeholder="name or email…"
+							className="w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none"
+						/>
+						<div className="mt-2 max-h-[180px] overflow-y-auto">
+							{results.map((u) => (
+								<button
+									type="button"
+									key={u.id}
+									onClick={() => setSelectedId(u.id)}
+									className={cn(
+										'mb-0.5 flex w-full items-center gap-2 rounded-md border border-transparent px-2 py-1.5 text-left text-sm',
+										selectedId === u.id && 'border-primary bg-primary/10',
+										selectedId !== u.id && 'hover:bg-card hover:border-border',
+									)}
+								>
+									<span className="flex-1">
+										<span className="block font-semibold">{u.name}</span>
+										<span className="block text-[11px] text-muted-foreground">{u.email}</span>
+									</span>
+								</button>
+							))}
+						</div>
+						{error === 'already-in-game' && (
+							<p className="mt-2 text-xs text-amber-600">That user is already in this game.</p>
+						)}
+						{error && error !== 'already-in-game' && (
+							<p className="mt-2 text-xs text-red-500">Couldn't add: {error}</p>
+						)}
+						<p className="mt-3 rounded-l-sm border-l-2 border-primary bg-primary/10 px-2 py-2 text-[11px] text-muted-foreground">
+							Can't find someone? Ask them to sign up first.
+						</p>
+						<div className="mt-4 flex justify-end gap-2">
+							<button
+								type="button"
+								onClick={onClose}
+								className="rounded-md border border-border bg-transparent px-3 py-1.5 text-xs font-semibold text-muted-foreground"
+							>
+								Cancel
+							</button>
+							<button
+								type="button"
+								onClick={handleAdd}
+								disabled={!selected || submitting}
+								className="rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground disabled:opacity-50"
+							>
+								{selected ? `Add ${selected.name}` : 'Add'}
+							</button>
+						</div>
+					</>
+				)}
+			</div>
+		</div>
+	)
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: clean (`admin-panel.tsx`'s import of this module now resolves).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/game/add-player-modal.tsx
+git commit -m "feat(game): add AddPlayerModal with pick-chain success state"
+```
+
+---
+
+### Task 11: `<SplitPotModal>` component
+
+**Files:**
+- Create: `src/components/game/split-pot-modal.tsx`
+
+Confirmation modal. Shows pot.total, per-winner amount, explicit warning, green confirm button. Submits to existing split-pot route.
+
+- [ ] **Step 1: Implement**
+
+```typescript
+// src/components/game/split-pot-modal.tsx
+'use client'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+
+interface SplitPotModalProps {
+	gameId: string
+	aliveCount: number
+	potTotal: string
+	onClose: () => void
+}
+
+export function SplitPotModal({ gameId, aliveCount, potTotal, onClose }: SplitPotModalProps) {
+	const router = useRouter()
+	const [submitting, setSubmitting] = useState(false)
+	const [error, setError] = useState<string | null>(null)
+
+	const totalNum = Number(potTotal)
+	const perWinner = aliveCount > 0 ? (totalNum / aliveCount).toFixed(2) : '0.00'
+
+	async function handleConfirm() {
+		if (submitting) return
+		setSubmitting(true)
+		setError(null)
+		try {
+			const res = await fetch(`/api/games/${gameId}/admin/split-pot`, {
+				method: 'POST',
+			})
+			const body = await res.json()
+			if (!res.ok) {
+				setError(body.error ?? 'failed')
+				return
+			}
+			onClose()
+			router.refresh()
+		} finally {
+			setSubmitting(false)
+		}
+	}
+
+	return (
+		<div
+			role="dialog"
+			aria-modal="true"
+			className="fixed inset-0 z-50 flex items-center justify-center bg-black/65"
+			onClick={onClose}
+		>
+			<div
+				onClick={(e) => e.stopPropagation()}
+				className="w-[360px] rounded-lg border border-border bg-background p-5 shadow-2xl"
+			>
+				<h3 className="text-[15px] font-bold">Split the pot now?</h3>
+				<p className="mb-4 mt-1 text-xs text-muted-foreground">
+					This ends the game immediately. All {aliveCount} alive players are marked as winners.
+					Eliminated players get nothing.
+				</p>
+				<div className="mb-4 rounded-md border border-border bg-card p-3 text-center">
+					<div className="text-xl font-extrabold tabular-nums text-emerald-500">
+						£{perWinner} each
+					</div>
+					<div className="mt-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+						£{potTotal} split {aliveCount} ways
+					</div>
+				</div>
+				<p className="mb-4 rounded-r-sm border-l-2 border-amber-500 bg-amber-500/10 px-2 py-2 text-[11px] text-amber-500">
+					⚠ This can't be undone. Game status becomes "completed".
+				</p>
+				{error && <p className="mb-3 text-xs text-red-500">Couldn't split: {error}</p>}
+				<div className="flex justify-end gap-2">
+					<button
+						type="button"
+						onClick={onClose}
+						disabled={submitting}
+						className="rounded-md border border-border bg-transparent px-3 py-1.5 text-xs font-semibold text-muted-foreground"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						onClick={handleConfirm}
+						disabled={submitting || aliveCount < 2}
+						className="rounded-md bg-emerald-500 px-3 py-1.5 text-xs font-bold text-white disabled:opacity-50"
+					>
+						Split £{potTotal} across {aliveCount} winners
+					</button>
+				</div>
+			</div>
+		</div>
+	)
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/game/split-pot-modal.tsx
+git commit -m "feat(game): add SplitPotModal confirmation"
+```
+
+---
+
+### Task 12: `<ActingAsBanner>` component
+
+**Files:**
+- Create: `src/components/game/acting-as-banner.tsx`
+
+Contained card banner for the pick page's acting-as mode.
+
+- [ ] **Step 1: Implement**
+
+```typescript
+// src/components/game/acting-as-banner.tsx
+'use client'
+import { useRouter } from 'next/navigation'
+
+interface ActingAsBannerProps {
+	gameId: string
+	targetUserName: string
+	targetAvatarInitials: string
+}
+
+export function ActingAsBanner({ gameId, targetUserName, targetAvatarInitials }: ActingAsBannerProps) {
+	const router = useRouter()
+	return (
+		<div className="mx-4 mt-3 flex items-center gap-3 rounded-lg bg-primary px-4 py-3 text-primary-foreground">
+			<span className="flex h-7 w-7 items-center justify-center rounded-full bg-black/25 text-[11px] font-bold">
+				{targetAvatarInitials}
+			</span>
+			<div className="flex flex-col">
+				<span className="text-[10px] font-black uppercase tracking-wider opacity-85">
+					Admin mode
+				</span>
+				<span className="text-sm font-semibold">You're picking for {targetUserName}</span>
+			</div>
+			<button
+				type="button"
+				onClick={() => router.push(`/game/${gameId}`)}
+				className="ml-auto rounded-md bg-black/25 px-2.5 py-1.5 text-[11px] font-semibold text-primary-foreground"
+			>
+				Exit admin mode
+			</button>
+		</div>
+	)
+}
+```
+
+- [ ] **Step 2: Typecheck + commit**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: clean.
+
+```bash
+git add src/components/game/acting-as-banner.tsx
+git commit -m "feat(game): add ActingAsBanner for pick-for-player mode"
+```
+
+---
+
+### Task 13: `<AutoPickBanner>` component
+
+**Files:**
+- Create: `src/components/game/auto-pick-banner.tsx`
+
+One-time dismissible banner. Reads/writes `localStorage.dismissedAutoPicks` (JSON array of pick ids).
+
+- [ ] **Step 1: Implement**
+
+```typescript
+// src/components/game/auto-pick-banner.tsx
+'use client'
+import { useEffect, useState } from 'react'
+
+const STORAGE_KEY = 'dismissedAutoPicks'
+
+interface AutoPickBannerProps {
+	pickId: string
+	teamShortName: string
+	kickoffLabel: string
+}
+
+function getDismissed(): string[] {
+	if (typeof window === 'undefined') return []
+	try {
+		const raw = window.localStorage.getItem(STORAGE_KEY)
+		return raw ? (JSON.parse(raw) as string[]) : []
+	} catch {
+		return []
+	}
+}
+
+function persistDismissed(ids: string[]) {
+	window.localStorage.setItem(STORAGE_KEY, JSON.stringify(ids))
+}
+
+export function AutoPickBanner({ pickId, teamShortName, kickoffLabel }: AutoPickBannerProps) {
+	const [dismissed, setDismissed] = useState(false)
+	const [mounted, setMounted] = useState(false)
+
+	useEffect(() => {
+		setMounted(true)
+		if (getDismissed().includes(pickId)) {
+			setDismissed(true)
+		}
+	}, [pickId])
+
+	if (!mounted || dismissed) return null
+
+	function handleDismiss() {
+		const ids = getDismissed()
+		if (!ids.includes(pickId)) {
+			ids.push(pickId)
+			persistDismissed(ids)
+		}
+		setDismissed(true)
+	}
+
+	return (
+		<div className="mx-4 my-3 flex items-start gap-3 rounded-lg border border-amber-500/50 bg-card p-3">
+			<span className="text-lg text-amber-500">⚠</span>
+			<div className="flex-1">
+				<h4 className="text-xs font-bold">You missed the deadline</h4>
+				<p className="mt-0.5 text-[11px] text-muted-foreground">
+					We auto-picked {teamShortName} for you — the lowest-ranked team you hadn't used.
+					Kickoff is {kickoffLabel}. Message the admin if you want to swap.
+				</p>
+			</div>
+			<button
+				type="button"
+				onClick={handleDismiss}
+				className="text-sm text-muted-foreground"
+				aria-label="Dismiss"
+			>
+				✕
+			</button>
+		</div>
+	)
+}
+```
+
+- [ ] **Step 2: Typecheck + commit**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: clean.
+
+```bash
+git add src/components/game/auto-pick-banner.tsx
+git commit -m "feat(game): add AutoPickBanner one-time notification"
+```
+
+---
+
+### Task 14: Contextual `✎` icon on standings rows
+
+**Files:**
+- Modify: `src/components/standings/progress-grid.tsx`
+- Modify: `src/components/standings/cup-grid.tsx`
+- Modify: `src/components/standings/cup-ladder.tsx`
+- Modify: `src/components/standings/turbo-standings.tsx`
+
+Add an optional `adminPickForPlayerUrl?: (gamePlayerId: string) => string` prop and a `showAdminActions?: boolean` flag. On rows where the player hasn't picked in the current open round, render a small `✎` link button.
+
+- [ ] **Step 1: `progress-grid.tsx`**
+
+Add to props type:
+
+```typescript
+showAdminActions?: boolean
+gameId?: string
+```
+
+At the point where rows are rendered, if `showAdminActions && !player.currentRoundPicked`, append:
+
+```tsx
+<a
+	href={`/game/${gameId}/pick?actingAs=${player.gamePlayerId}`}
+	title={`Pick for ${player.name}`}
+	className="ml-2 inline-flex h-6 w-6 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:border-border hover:bg-muted"
+>
+	✎
+</a>
+```
+
+- [ ] **Step 2: Repeat for `cup-grid.tsx`, `cup-ladder.tsx`, `turbo-standings.tsx`**
+
+Same pattern — accept `showAdminActions?: boolean` + `gameId?: string` props; determine "no pick this round" from each component's existing data; render the `✎` link button.
+
+- [ ] **Step 3: Typecheck + full tests**
+
+Run: `pnpm exec tsc --noEmit && pnpm exec vitest run`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/standings/
+git commit -m "feat(standings): add contextual admin pencil icon for pick-for-player"
+```
+
+---
+
+### Task 15: Auto-pick ribbon on progress-grid pick cells
+
+**Files:**
+- Modify: `src/components/standings/progress-grid.tsx`
+
+Render an amber "AUTO" ribbon on pick cells whose `isAuto === true`. Amber dashed treatment while pending; ribbon persists post-settlement.
+
+- [ ] **Step 1: Extend cell rendering**
+
+Locate the `GridCell` helper (if extracted) or the inline cell rendering. Add:
+
+```tsx
+<span
+	className={cn(
+		/* existing classes */,
+		pick?.isAuto && pick?.result === 'pending' && 'border border-dashed border-amber-500 text-amber-500 bg-amber-500/10',
+	)}
+>
+	{pick?.teamShort ?? '—'}
+	{pick?.isAuto && (
+		<span className="absolute -right-0.5 -top-0.5 rounded-sm bg-amber-500 px-1 py-0 text-[8px] font-black uppercase tracking-wider text-white">
+			AUTO
+		</span>
+	)}
+</span>
+```
+
+- [ ] **Step 2: Update the `pick` prop shape to include `isAuto`**
+
+Ensure the upstream query (`getProgressGridData` or equivalent in `detail-queries.ts`) selects `pick.is_auto`.
+
+- [ ] **Step 3: Typecheck + tests**
+
+Run: `pnpm exec tsc --noEmit && pnpm exec vitest run`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/standings/progress-grid.tsx src/lib/game/detail-queries.ts
+git commit -m "feat(standings): render AUTO ribbon on auto-picked cells"
+```
+
+---
+
+## Part F — Integration
+
+### Task 16: Wire admin-panel + auto-pick-banner into GameDetailView
+
+**Files:**
+- Modify: `src/components/game/game-detail-view.tsx`
+
+Render `<AdminPanel />` below standings when viewer is admin. Render `<AutoPickBanner />` at top of body when the viewer's current-round pick is `isAuto: true`.
+
+- [ ] **Step 1: Read current component**
+
+Run: `cat src/components/game/game-detail-view.tsx | head -80`
+
+- [ ] **Step 2: Add imports and conditional renders**
+
+Near existing imports:
+
+```typescript
+import { AdminPanel } from '@/components/game/admin-panel'
+import { AutoPickBanner } from '@/components/game/auto-pick-banner'
+```
+
+Inside the return, below the standings rendering:
+
+```tsx
+{isAdmin && (
+	<AdminPanel
+		gameId={game.id}
+		aliveCount={game.players.filter((p) => p.status === 'alive').length}
+		potTotal={game.pot.total}
+	/>
+)}
+```
+
+Near the top of the body (just under LiveScoreTicker from 4c1):
+
+```tsx
+{myPickIsAuto && myPick && (
+	<AutoPickBanner
+		pickId={myPick.id}
+		teamShortName={myPick.teamShortName}
+		kickoffLabel={myPick.kickoffLabel}
+	/>
+)}
+```
+
+Derive `myPickIsAuto` from `game.myCurrentRoundPick?.isAuto` (whichever property the existing detail data exposes; extend `getGameDetail` if needed to surface `isAuto` on the viewer's pick).
+
+- [ ] **Step 3: Pass `showAdminActions` and `gameId` to standings renders**
+
+In the same component, update the props being passed to the standings components added in Task 14:
+
+```tsx
+<ProgressGrid data={...} showAdminActions={isAdmin} gameId={game.id} />
+<CupStandings data={...} showAdminActions={isAdmin} gameId={game.id} />
+<TurboStandings data={...} showAdminActions={isAdmin} gameId={game.id} />
+```
+
+(Use whichever component is rendered based on game mode.)
+
+- [ ] **Step 4: Typecheck + full tests**
+
+Run: `pnpm exec tsc --noEmit && pnpm exec vitest run`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/game/game-detail-view.tsx src/lib/game/detail-queries.ts
+git commit -m "feat(game): integrate admin panel and auto-pick banner into game detail"
+```
+
+---
+
+### Task 17: Wire acting-as mode into pick page
+
+**Files:**
+- Modify: `src/app/(app)/game/[id]/page.tsx` (or wherever pick rendering happens — inspect first)
+
+Read `?actingAs=...` URL param. If present AND viewer is admin AND the target is a valid `gamePlayer` in this game, load the target player's pick context (used teams, lives, etc.) instead of the admin's. Render `<ActingAsBanner />` above the pick UI.
+
+- [ ] **Step 1: Read the existing pick-route page**
+
+Run: `cat src/app/\(app\)/game/\[id\]/page.tsx`
+
+Identify where the "current viewer's pick state" is loaded.
+
+- [ ] **Step 2: Extract + override the target gamePlayer**
+
+```typescript
+const actingAsId = typeof searchParams.actingAs === 'string' ? searchParams.actingAs : null
+const isAdmin = gameData.createdBy === session.user.id
+let targetGamePlayerId: string | null = myGamePlayer.id
+let actingAsTarget: { userName: string; initials: string } | null = null
+
+if (actingAsId && isAdmin) {
+	const target = await db.query.gamePlayer.findFirst({
+		where: and(eq(gamePlayer.id, actingAsId), eq(gamePlayer.gameId, gameData.id)),
+		with: { user: true },
+	})
+	if (target) {
+		targetGamePlayerId = target.id
+		const name = target.user.name
+		actingAsTarget = {
+			userName: name,
+			initials: name.split(' ').map((p: string) => p[0]).slice(0, 2).join('').toUpperCase(),
+		}
+	}
+}
+```
+
+Replace references to "my pick history" / "my used teams" with queries keyed off `targetGamePlayerId`.
+
+- [ ] **Step 3: Render the banner**
+
+Near the top of the pick render:
+
+```tsx
+{actingAsTarget && (
+	<ActingAsBanner
+		gameId={gameData.id}
+		targetUserName={actingAsTarget.userName}
+		targetAvatarInitials={actingAsTarget.initials}
+	/>
+)}
+```
+
+Submit button on the pick UI should pass `actingAs: targetGamePlayerId` in the POST body when `actingAsTarget` is non-null. Look for the pick form component (probably `ClassicPick` / `TurboPick` / `CupPick`) and thread a new optional `submitOverride?: { actingAs: string; buttonLabel: string }` prop, OR — simpler — pass a new `actingAs?: string` prop down and let the pick components read it when building their POST body.
+
+- [ ] **Step 4: Update pick components to forward `actingAs` in POST body**
+
+For each of `ClassicPick`, `TurboPick`, `CupPick`: locate the `fetch('/api/picks/…')` call. Add `actingAs` to the JSON body when present:
+
+```typescript
+body: JSON.stringify({ picks: [...], ...(actingAs ? { actingAs } : {}) }),
+```
+
+Also change the submit button label to "Submit as {targetName}" when acting-as is set.
+
+- [ ] **Step 5: Typecheck + full tests**
+
+Run: `pnpm exec tsc --noEmit && pnpm exec vitest run`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/\(app\)/game/\[id\]/page.tsx src/components/picks/
+git commit -m "feat(game): implement actingAs URL param and submit-as-X flow"
+```
+
+---
+
+## Part G — Seed and verification
+
+### Task 18: Dev seed — missed-deadline scenario
+
+**Files:**
+- Modify: `scripts/seed.ts`
+
+Add a seed scenario where one classic-game player has no pick for the current round (round ≥ 3), so rule 2's auto-pick flow can be exercised locally via `just db-reset`.
+
+- [ ] **Step 1: Read current seed**
+
+Run: `tail -60 scripts/seed.ts`
+
+- [ ] **Step 2: Add missed-pick block**
+
+Near the existing classic-game seeding, after players have picked for rounds 1-2, INTENTIONALLY skip inserting a pick for one player in round 3+:
+
+```typescript
+// --- Missed-deadline scenario for 4c2 rule 2 verification -----------------
+// Player "Rachel" has no pick for round 3 of the classic game.
+// Running `processDeadlineLock(['<round-3-id>'])` will auto-assign her the
+// lowest-ranked unused team. Also sets league_position on teams for realism.
+const positions: Record<string, number> = {
+	ARS: 3, CHE: 8, LIV: 2, EVE: 13, MCI: 1, BUR: 20,
+	// fill in remaining teams realistically
+}
+for (const [shortName, pos] of Object.entries(positions)) {
+	await db.update(team)
+		.set({ leaguePosition: pos })
+		.where(and(eq(team.competitionId, plCompetitionId), eq(team.shortName, shortName)))
+}
+```
+
+(Engineer: inspect the existing seed for actual team shortName keys; adjust.)
+
+- [ ] **Step 3: Run seed to verify**
+
+Run: `just db-reset`
+Expected: seed completes; inspecting the DB shows:
+- Rachel's `game_player` row exists for the classic game with `status: 'alive'`.
+- No `pick` row for Rachel in round 3.
+- Teams have non-null `league_position`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/seed.ts
+git commit -m "chore(seed): add missed-deadline scenario for 4c2 verification"
+```
+
+---
+
+### Task 19: Full verification sweep
+
+**Files:** None (may produce a `chore: format` commit).
+
+- [ ] **Step 1: Biome**
+
+Run: `pnpm exec biome check --write .`
+Expected: clean OR formats some files.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Full test suite**
+
+Run: `pnpm exec vitest run`
+Expected: all pass; count is `baseline + ~20` (auto-pick 6 cases, users/search 2 cases, add-player 4 cases, pick route actingAs 4 cases, no-pick-handler 1+, daily-sync extension 1+).
+
+- [ ] **Step 4: Next build**
+
+Run: `pnpm exec next build`
+Expected: compile + TS phases pass. "Collect page data" may fail on missing env; sandbox-only.
+
+- [ ] **Step 5: Manual dev smoke (optional — requires docker)**
+
+```bash
+docker compose up -d
+just db-reset
+just dev
+```
+
+Navigate to the classic game. As admin:
+- Confirm `<AdminPanel />` renders with "+ Add player" and "Split pot" buttons.
+- Confirm Rachel's row shows the `✎` icon (because she has no round-3 pick).
+- Click `✎` → pick page loads with `<ActingAsBanner />`; submit as Rachel → un-elimination fires if applicable.
+- Click "+ Add player" → modal opens; search works; add a user and use the "Pick for X now" chain.
+- Trigger `processDeadlineLock(['round-3-id'])` manually via `tsx scripts/run-deadline-lock.ts` (or hit the daily-sync cron locally) → Rachel gets an auto-assigned pick with `isAuto: true`.
+- Reload game detail as Rachel → `<AutoPickBanner />` appears once; dismiss sticks in localStorage.
+
+- [ ] **Step 6: Commit formatting if any**
+
+If biome made changes:
+
+```bash
+git add -A
+git commit -m "chore: format and smoke-fix for Phase 4c2"
+```
+
+---
+
+## Out-of-scope reminders
+
+- Paid rebuys (4c3). The refund flow laid here (rule 3) is the starting point.
+- Admin kick/remove player with history cleanup.
+- Admin ownership transfer.
+- `paymentId`-keyed admin payment routes (4b follow-up; 4c3 should handle).
+- Email / push notifications on auto-pick.
+- GH Actions secrets (Phase 4.5).
+
+## Risk mitigation
+
+- **Stale `league_position`.** If daily-sync fails the day a deadline falls, auto-pick runs against stale positions. Mitigation: `pickLowestRankedUnusedTeam` treats null positions as "worst" so missing standings still yields a pick; the wrong team may get assigned but the player isn't stuck. Phase 4.5 playbook verifies standings freshness pre-weekend.
+- **Admin un-elimination transaction.** Pick insert + status flip must be atomic — otherwise a crash between the two leaves partial state. Implementation uses `db.transaction(...)` to wrap both.
+- **Concurrent deadline-lock invocations.** Two daily-sync runs in quick succession could both try to auto-pick the same player. The `pick` table has a `(game_player_id, round_id)` uniqueness constraint; second insert fails silently.
+- **Multiple payment rows on refund.** Rule 3 refunds the most recent `paid`/`claimed` row. Documented as "most recent wins" — current semantics until rebuys change the model in 4c3.
+- **URL-param admin mode.** Non-admin hitting `/game/[id]/pick?actingAs=<otherId>` is rejected server-side in the pick route with 403; the page-level check redirects to game detail. No privilege escalation risk.

--- a/docs/superpowers/specs/2026-04-24-phase-4c2-admin-ux-design.md
+++ b/docs/superpowers/specs/2026-04-24-phase-4c2-admin-ux-design.md
@@ -1,0 +1,274 @@
+# Phase 4c2 Design Specification — Admin UX
+
+## Overview
+
+Phase 4c2 adds the admin-side surfaces that make the app usable in practice: letting a game creator add a late-joining player, make a pick on behalf of a player who missed the deadline, and split the pot across surviving players to end a game. It also plugs two long-standing gaps in the no-pick handling engine — a classic-mode auto-assign rule (lowest-ranked unused team) and a turbo/cup refund-and-eliminate rule.
+
+4c2 is the second of five sub-phases in Phase 4c (match-day live, admin UX, paid rebuys, Satori share variants, mobile polish). It's independent of 4c1 and merges dormant onto `main` ahead of the Phase 4.5 launch.
+
+---
+
+## Scope
+
+**In scope:**
+- **Add-player admin action.** Modal opened from a dedicated admin panel on game detail; searches existing users by name/email; adds by `userId`. No new-account creation — admin must ask new users to sign up first.
+- **Pick-for-player admin action.** URL-param-driven "acting as" mode on the existing pick page. Reuses `ClassicPick` / `TurboPick` / `CupPick` interfaces with a banner and "Submit as X" button. Validation runs against the target player's history, not the admin's.
+- **Split-pot UI.** Confirmation modal wrapping the existing `POST /api/games/[id]/admin/split-pot` route (from Phase 2). Shows per-winner payout, alive-player list, irreversibility warning.
+- **Engine rule 1 — admin un-elimination.** When an admin submits a pick for a player whose `eliminatedReason === 'missed_rebuy_pick'`, the server flips them back to `alive` in the same transaction as the pick write.
+- **Engine rule 2 — classic auto-pick on deadline-lock.** When a classic round transitions to `live`, any active player without a pick gets auto-assigned the lowest-ranked team (by current league position) they haven't used yet. Pick is stamped `isAuto: true`.
+- **Engine rule 3 — turbo/cup refund-and-eliminate on deadline-lock.** Same trigger, different outcome: no pick → player eliminated with `eliminatedReason: 'no_pick_no_fallback'`, their `paid`/`claimed` payment marked `refunded`.
+- **Auto-pick visual marker.** Amber dashed treatment on pending cell + persistent "AUTO" ribbon post-settlement on all standings grids (cup-grid, turbo-standings, progress-grid).
+- **Auto-pick one-time player notification.** Dismissible banner on game detail when the viewer's current-round pick is auto-assigned and they haven't dismissed it.
+
+**Out of scope:**
+- Paid rebuys (4c3).
+- Admin remove-player with history cleanup — `admin_removed` enum value reserved but no UI path.
+- Admin ownership transfer.
+- New-account-by-email invite flow.
+- Email / push notifications on auto-pick.
+- Caching layer for league standings beyond the `team.league_position` column update.
+
+---
+
+## Architecture
+
+Single feature branch (`feature/phase-4c2-admin-ux`), merging dormant onto `main` before Phase 4.5. No new framework primitives — just modals, URL-param mode-switching, one new admin-only panel component, and two deadline-hook additions to the existing daily-sync cron (Phase 4a). Database migration adds one flag column (`pick.is_auto`), one enum-shaped text column (`game_player.eliminated_reason`), one integer column (`team.league_position`), and one timestamp column (`payment.refunded_at`).
+
+---
+
+## Components
+
+### New
+
+| Path | Responsibility |
+|---|---|
+| `src/components/game/admin-panel.tsx` | Always-visible-to-admin card below standings. Houses game-wide action buttons (+ Add player, Split pot). Sits next to the 4b payments-panel. |
+| `src/components/game/add-player-modal.tsx` | Modal opened from the admin panel. Search by name/email → live-filtered results (max 10) → select → submit. Post-submit success state offers "Pick for X now" chain into the pick page. |
+| `src/components/game/split-pot-modal.tsx` | Confirmation modal. Shows pot.total, per-winner amount, list of alive players who'll be marked winners, irreversibility warning. Green "Split £X across N winners" confirm. |
+| `src/components/game/acting-as-banner.tsx` | Contained card banner rendered on the pick page when `?actingAs=...` URL param is present and the viewer is the game admin. "Admin mode · Picking for X" + "Exit admin mode" CTA. |
+| `src/components/game/auto-pick-banner.tsx` | One-time dismissible banner shown on game detail when the viewer's own current-round pick has `isAuto=true` and its id is not in `localStorage.dismissedAutoPicks`. |
+| `src/lib/game/auto-pick.ts` | Pure function: `pickLowestRankedUnusedTeam({ fixtures, usedTeamIds, teamPositions }) → teamId \| null`. Fully unit-tested. |
+| `src/lib/game/no-pick-handler.ts` | Orchestrator invoked from the daily-sync deadline-lock path. Loads no-pick players per newly-live round; delegates to engine rules 2 (classic) or 3 (turbo/cup). |
+| `src/app/api/games/[id]/admin/add-player/route.ts` | POST. Admin-gated via `game.createdBy === session.user.id`. Body: `{ userId: string }`. Inserts `gamePlayer`. 409 if duplicate, 404 if user not found, 403 if not admin. |
+| `src/app/api/users/search/route.ts` | GET `?q=<query>`. Auth-gated (any session). Returns up to 10 users matching name or email (case-insensitive prefix match). Response shape: `{ id, name, email }[]`. |
+
+### Modified
+
+| Path | Change |
+|---|---|
+| `src/components/game/game-detail-view.tsx` | Admin-only: render `<AdminPanel />` below standings. Render `<AutoPickBanner />` at top of body when viewer's pick qualifies. |
+| `src/components/standings/progress-grid.tsx` | Add contextual `✎` icon button on rows where player hasn't picked in the current open round (admin-only). Add auto-pick amber-dashed treatment + "AUTO" ribbon on pick cells with `isAuto=true`. |
+| `src/components/standings/cup-grid.tsx` | Same contextual `✎` pattern + `AUTO` ribbon (ribbon unlikely to fire for cup since rule 2 is classic-only, but the prop is threaded through for future parity). |
+| `src/components/standings/cup-ladder.tsx` | Contextual `✎` icon on backer chips where player hasn't picked. |
+| `src/components/standings/turbo-standings.tsx` | Contextual `✎` pattern. |
+| `src/app/api/picks/[gameId]/[roundId]/route.ts` | Accept `actingAs?: string` (gamePlayerId) in the request body. When present, require `session.user.id === game.createdBy` AND that `actingAs` corresponds to an active `gamePlayer` in this game. On successful submit, if target's `eliminatedReason === 'missed_rebuy_pick'`, flip `status` back to `alive` in the same transaction. Response includes `{ unEliminated: boolean }` flag for the UI. |
+| `src/app/(app)/game/[id]/pick/page.tsx` (and any pick sub-routes) | Read `?actingAs` URL param. If present and admin, load the target player's pick history and used-teams — not the admin's. Render `<ActingAsBanner />` at page top. |
+| `src/app/api/cron/daily-sync/route.ts` | After the existing competition sync completes, invoke `processDeadlineLock()` from `src/lib/game/no-pick-handler.ts`. |
+| `src/lib/game/bootstrap-competitions.ts` | When syncing standings, persist each team's latest `league_position`. |
+| `src/lib/schema/game.ts` | Add `pick.isAuto: boolean` (default `false`). Add `gamePlayer.eliminatedReason: text` with documented valid values (`'loss'`, `'missed_rebuy_pick'`, `'no_pick_no_fallback'`, `'admin_removed'`). |
+| `src/lib/schema/competition.ts` | Add `team.leaguePosition: integer` (nullable; 1-20 for PL). |
+| `src/lib/schema/payment.ts` | Add `payment.refundedAt: timestamp` (nullable). `refunded` status already exists in enum from Phase 2. |
+
+---
+
+## Data flow
+
+### Add player
+1. Admin clicks "+ Add player" in the admin panel → modal opens, search input autofocuses.
+2. Admin types → client debounces 200ms → `GET /api/users/search?q=...` → renders up to 10 results.
+3. Users already in this game appear with an "IN GAME" tag and are unselectable.
+4. Admin selects a result and clicks "Add X" → `POST /api/games/[id]/admin/add-player` with `{ userId }`.
+5. Server validates: session user is game admin; target user exists; not already in game. Creates `gamePlayer` with `status: 'alive'`, `livesRemaining: mode.startingLives`, `joinedAt: now()`.
+6. Modal transitions to a success state with two buttons: "Pick for X now" (primary) and "Back to game" (ghost).
+7. "Pick for X now" navigates to `/game/[id]/pick?actingAs=<newGamePlayerId>`. "Back to game" closes the modal and refreshes game detail.
+
+### Pick for player
+1. Admin clicks `✎` on a player row (contextual, only visible on admin view for players who haven't picked) OR arrives via the add-player success chain.
+2. URL: `/game/[id]/pick?actingAs=<gamePlayerId>`.
+3. Pick page reads the param; server-side validates admin + that `actingAs` is an active player in this game; loads the target player's picks/used-teams instead of the admin's.
+4. `<ActingAsBanner>` renders at the top with Exit CTA → `/game/[id]`.
+5. Pick UI renders as normal (classic/turbo/cup) — same validation, same restrictions, just based on the target player's state.
+6. Submit button labelled "Submit as X" → `POST /api/picks/[gameId]/[roundId]` with body `{ ..., actingAs: <gamePlayerId> }`.
+7. Server writes pick with `isAuto: false` on behalf of the target. Returns `{ pick, unEliminated: boolean }`.
+8. If `unEliminated === true`, UI surfaces a toast "X is back in the game".
+
+### Split pot
+1. Admin clicks "Split pot" → modal opens.
+2. Modal computes pot from game detail data (already loaded); shows total, per-winner amount, list of alive players.
+3. Admin confirms → `POST /api/games/[id]/admin/split-pot` (existing Phase 2 route).
+4. Game marked `completed`; `payout` rows inserted; alive players flipped to `winner`.
+5. Modal closes; `router.refresh()` reloads the game detail view.
+
+### Auto-pick notification (player-side)
+1. On game detail mount, client checks `gameData.myPick.isAuto === true` for the current open/live round.
+2. Reads `localStorage.dismissedAutoPicks` (JSON array of pick ids). If the pick's id isn't in the array, render `<AutoPickBanner>` at top.
+3. User dismisses via `✕` → push pick id to localStorage, hide banner. Never shown again for that pick.
+
+---
+
+## Engine rules
+
+### Rule 1 — Admin un-elimination (classic rounds 1-2 no-pick)
+Lives in the pick route on the server. Covers both round 1 (never engaged) and round 2 (declined rebuy) since both land as `eliminatedReason: 'missed_rebuy_pick'`. On successful admin submit for a target player:
+
+```ts
+if (target.eliminatedReason === 'missed_rebuy_pick') {
+  await tx.update(gamePlayer)
+    .set({ status: 'alive', eliminatedReason: null, eliminatedRoundNumber: null })
+    .where(eq(gamePlayer.id, target.id))
+  return { pick, unEliminated: true }
+}
+```
+
+No user-facing decision needed; automatic.
+
+### Rule 2 — Classic auto-pick on deadline-lock
+Triggered in `processDeadlineLock()` called from daily-sync. **Only fires for classic rounds where `round.number >= 3`.** Rounds 1 and 2 retain the existing "no pick = eliminated" behaviour — round 2 is the rebuy window where not picking is an implicit "I'm not rebuying" signal, and round 1 means you never engaged with the game at all. Both are handled by rule 1 admin un-elimination via pick-for-player.
+
+When a classic round with `number >= 3` transitions to `status: 'live'` (deadline locked):
+
+1. For each active `gamePlayer` on a game using this round who has no pick:
+2. Load the player's used-team set (all teams from their prior picks in this game).
+3. Load the round's fixtures with team metadata.
+4. Call `pickLowestRankedUnusedTeam({ fixtures, usedTeamIds, teamPositions })`:
+   - Enumerate all teams appearing in this round's fixtures.
+   - Exclude teams in `usedTeamIds`.
+   - Return the team with the highest `league_position` value (20 = bottom of PL = lowest rank). Ties broken by team id.
+   - Return `null` if no unused team available (shouldn't happen in PL classic but defensively).
+5. Insert a `pick` row with `isAuto: true`, fixture derived from which fixture the assigned team appears in, `predictedResult: 'home_win' | 'away_win'` based on which side.
+6. If `null` was returned: mark player `eliminated` with `eliminatedReason: 'no_pick_no_fallback'`.
+
+Standings data sourced from `team.league_position` (column added by this phase's migration), updated daily by `bootstrap-competitions.ts` during the existing sync loop.
+
+### Rule 3 — Turbo/cup refund-and-eliminate on deadline-lock
+Same trigger, different outcome. For turbo/cup games on the newly-live round with a no-pick active player:
+
+1. Mark player `status: 'eliminated'`, `eliminatedReason: 'no_pick_no_fallback'`, `eliminatedRoundNumber: round.number`.
+2. Locate the `payment` row for this entry (most recent row for `gameId + userId` where `status in ('paid', 'claimed')`).
+3. If found: update to `status: 'refunded'`, stamp `refundedAt: now()`. If not found: no-op (player never paid).
+4. No pick row is written.
+
+---
+
+## Visual design
+
+**Admin panel** — card below standings, admin-only, "Admin · Game actions" header with the chip shown in the 4b payments panel. Two buttons in 4c2: "+ Add player" (primary blue), "Split pot (N alive)" (neutral). Additional admin actions (close game early, kick player) are future-phase scope.
+
+**Contextual row icons** — single `✎` pencil button at the end of a standings row when the player hasn't picked in the current open round. Hover state reveals "Pick for X" tooltip. Only visible to admin. Appears on cup-grid, cup-ladder (backer chips), turbo-standings, and progress-grid.
+
+**Add-player modal** — focused dialogue with backdrop, 340px wide. Autofocused search input, live-filtered results with avatar/name/email, "IN GAME" tag for duplicates, primary "Add X" button reflects selection. Help note explains "Can't find someone? Ask them to sign up first."
+
+**Split-pot modal** — backdrop dialogue. Large green per-winner amount (e.g. "£24.00 each"), split summary ("£120 split 5 ways"), list of alive players with their individual payouts, amber warning that the action is irreversible, green confirm button labelled "Split £X across N winners".
+
+**Acting-as banner** — contained card inside the pick page's normal margins, blue (`#3b82f6`) background, "ADMIN MODE" kicker, avatar + "You're picking for Sam Pepper", "Exit admin mode" CTA on the right. Sits between the page header and the fixture list. Submit button in the pick UI changes text to "Submit as Sam".
+
+**Auto-pick ribbon** — amber dashed border + amber text on pending state; tiny "AUTO" chip (amber bg, white text) top-right of the cell. After settlement the cell flips to its usual win/loss colour, but the "AUTO" chip persists so the provenance is always visible in history.
+
+**Auto-pick banner (player-side)** — one-time dismissible card on the affected player's next visit to game detail. Amber left-border, warning icon, text: "You missed GW12's deadline — we auto-picked West Brom for you. Kickoff is Saturday 15:00. Message the admin if you want to swap."
+
+---
+
+## Schema changes
+
+Single migration:
+
+```sql
+ALTER TABLE pick ADD COLUMN is_auto boolean NOT NULL DEFAULT false;
+ALTER TABLE game_player ADD COLUMN eliminated_reason text;
+ALTER TABLE team ADD COLUMN league_position integer;
+ALTER TABLE payment ADD COLUMN refunded_at timestamp;
+```
+
+`eliminated_reason` is nullable text (enforced valid values: `'loss'`, `'missed_rebuy_pick'`, `'no_pick_no_fallback'`, `'admin_removed'`) — not a Postgres enum because enum value additions require an `ALTER TYPE` statement-breakpoint and we want to remain flexible. TypeScript types enforce the union.
+
+`team.league_position` is nullable; 1-20 for PL, null for cup competitions (pots, not positions).
+
+`payment.refunded_at` is nullable; stamped alongside a `status: 'refunded'` transition.
+
+---
+
+## Error handling
+
+| Condition | Behaviour |
+|---|---|
+| Add-player: target already in game | 409 with `{ error: 'already-in-game' }`. Modal shows inline error; user remains selectable to try another. |
+| Add-player: target user doesn't exist | 404 (shouldn't happen via search flow; defensive). Modal shows "User not found — refresh and retry." |
+| Add-player: non-admin attempts | 403 with `{ error: 'forbidden' }`. Client redirects to game detail. |
+| Pick-for-player: `actingAs` references player not in this game | 404 on server. Pick page redirects back to game detail with a "player not found in this game" toast. |
+| Pick-for-player: non-admin attempts | 403. Redirect to game detail. |
+| Split-pot: game already completed | 400. Modal shows "Game is already completed — nothing to split." |
+| Split-pot: fewer than 2 alive players | 400 (existing Phase 2 behaviour). Button disabled in UI when count < 2. |
+| Auto-pick: no unused team available | Log a warning; eliminate with `eliminatedReason: 'no_pick_no_fallback'`; continue daily-sync run. |
+| Refund: no qualifying payment row | No-op; daily-sync continues. |
+| User-search: empty query | Returns `[]` without hitting the DB. |
+| User-search: unauthenticated | 401. Client redirects to `/login`. |
+
+---
+
+## Testing
+
+**Pure functions (Vitest):**
+- `pickLowestRankedUnusedTeam`: happy path (bottom team returned), all teams used (null), single unused team, position-tie broken by team id, null-position team skipped.
+- Rule 1 applicability: returns `true` only for `eliminatedReason === 'missed_rebuy_pick'`.
+
+**API routes (Vitest + route tests, same pattern as Phase 4b):**
+- `add-player`: 403 non-admin, 409 duplicate, 404 unknown user, 200 happy path inserts row with correct `livesRemaining` default.
+- `users/search`: empty query returns `[]`; long queries cap at 10 results; 401 unauthenticated.
+- `picks/[gameId]/[roundId]` with `actingAs`: 403 non-admin, 404 bad player, 200 happy path writes pick and un-eliminates where applicable.
+
+**Engine tests (Vitest, test DB):**
+- `processDeadlineLock` classic: no-pick player gets auto-assigned, pick row has `isAuto: true`, `league_position` read from teams correctly.
+- `processDeadlineLock` turbo: no-pick player eliminated with correct reason, payment row updated to `refunded`.
+- `processDeadlineLock` cup: same as turbo.
+- `processDeadlineLock` classic with no unused team: player eliminated with `no_pick_no_fallback`.
+
+**UI (optional; deferred to launch-time smoke):**
+- Add-player modal opens, searches, submits, chains to pick page with correct `actingAs` URL param.
+- Acting-as banner visible on pick page; Exit CTA returns to game detail.
+- Split-pot modal confirms and reloads game as completed.
+
+**Baseline tests before 4c2:** ~226 (post-4c1). **Target after:** ~245.
+
+---
+
+## Risk mitigation
+
+- **`team.league_position` freshness.** If daily-sync fails on the day a deadline falls, we could auto-pick against a stale table. Mitigation: `pickLowestRankedUnusedTeam` treats null `league_position` as "worst" so teams with unknown standings rank highest for auto-assignment; this is wrong-but-safe (a top team might get assigned to a no-picker the first time a deadline hits before sync completes). Flag in 4.5 playbook: verify standings are fresh before the first competitive weekend.
+- **Schema changes are additive-only.** No enum extensions, no NOT NULL constraints on existing rows; migration is safe on any Postgres ≥ 12.
+- **Admin un-elimination edge.** An admin un-eliminating a player via a rebuy-week pick must fire in the same transaction as the pick write to avoid a partial state where the pick landed but the status flip didn't. Implementation uses a single `db.transaction`.
+- **Concurrent no-pick-handler runs.** Daily-sync is invoked by a cron; in principle two near-simultaneous runs could both attempt rule 2 for the same player. Mitigation: the pick insert is gated on a uniqueness constraint (`game_player_id + round_id`); the losing insert fails gracefully and is ignored.
+- **Refund on payments with rebuys.** A player might have multiple payment rows (original + rebuy). Rule 3 refunds the latest `paid`/`claimed` row, which is the correct one for the current elimination. Documented as "most recent row wins" semantics.
+- **URL-param admin mode discoverable to non-admins.** A non-admin hitting `/game/[id]/pick?actingAs=<otherId>` triggers a 403 server-side; no privilege escalation risk.
+
+---
+
+## Rollout
+
+4c2 merges dormant onto `main` alongside 4a / 4b / 4c1. No production activity until Phase 4.5. Dev verification is full-fidelity — the seed game can be used to exercise all three modals and the ✎ row actions; the deadline-lock engine rules need simulated time jumps via DB mutation (same pattern as 4b's auto-submit verification).
+
+---
+
+## Dependencies on other sub-phases
+
+- **4c2 depends on 4c1:** `useLiveGame` is not a hard dependency, but `game-detail-view.tsx` edits will need to merge around 4c1's `<LiveProvider>` wrapper. Trivial conflict.
+- **4c3 (paid rebuys) depends on 4c2:** `paymentId`-keyed admin actions (flagged as a 4b follow-up) should land before rebuys; 4c2 doesn't have to fix that but 4c3 must. 4c2's refund flow is the starting point for 4c3's rebuy flow.
+- **4c5 (mobile polish) picks up this work:** admin panel, modals, and the `✎` icon all need narrow-viewport treatment.
+
+---
+
+## Acceptance criteria
+
+A Phase 4c2 PR is ready to merge when:
+
+- [ ] Admin panel renders only for `session.user.id === game.createdBy`; shows three buttons (+ Add player, Split pot, Close game early).
+- [ ] Add-player modal searches users, blocks duplicates, adds selected user with correct default state, and offers the "Pick for X now" chain.
+- [ ] Pick-for-player URL mode renders the acting-as banner, loads the target player's history, and successfully submits a pick on their behalf.
+- [ ] Admin un-elimination (rule 1) fires when the target was eliminated for a missed rebuy pick; confirmed via a DB-state test.
+- [ ] Split-pot modal shows correct pot + per-winner figures and successfully marks the game completed.
+- [ ] Classic auto-pick (rule 2) assigns the lowest-ranked unused team to a no-pick player; pick row has `isAuto: true`.
+- [ ] Turbo/cup refund-eliminate (rule 3) marks player eliminated and stamps the payment `refunded`.
+- [ ] Auto-pick pending cell uses amber dashed treatment and shows "AUTO" ribbon; ribbon persists post-settlement.
+- [ ] Auto-pick player-side banner appears on first visit after auto-assignment and dismisses to localStorage.
+- [ ] `pnpm exec tsc --noEmit`, `pnpm exec biome check`, `pnpm exec vitest run` all clean.
+- [ ] `pnpm exec next build` compile + TS phases pass.
+- [ ] Migration file (`drizzle/NNNN_*.sql`) generated and committed; applies cleanly on local dev DB via `just db-migrate`.

--- a/drizzle/0002_bored_lizard.sql
+++ b/drizzle/0002_bored_lizard.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "team" ADD COLUMN "league_position" integer;--> statement-breakpoint
+ALTER TABLE "game_player" ADD COLUMN "eliminated_reason" text;--> statement-breakpoint
+ALTER TABLE "pick" ADD COLUMN "is_auto" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "payment" ADD COLUMN "refunded_at" timestamp;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1580 @@
+{
+  "id": "7cf25f46-2823-419d-b295-281e241cc426",
+  "prevId": "8cb88f44-8d50-4faf-9d0e-7bc82e3445b2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition": {
+      "name": "competition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "competition_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_source": {
+          "name": "data_source",
+          "type": "competition_data_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "season": {
+          "name": "season",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fixture": {
+      "name": "fixture",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_team_id": {
+          "name": "home_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "away_team_id": {
+          "name": "away_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kickoff": {
+          "name": "kickoff",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_score": {
+          "name": "home_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "away_score": {
+          "name": "away_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "fixture_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fixture_round_id_round_id_fk": {
+          "name": "fixture_round_id_round_id_fk",
+          "tableFrom": "fixture",
+          "tableTo": "round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fixture_home_team_id_team_id_fk": {
+          "name": "fixture_home_team_id_team_id_fk",
+          "tableFrom": "fixture",
+          "tableTo": "team",
+          "columnsFrom": [
+            "home_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fixture_away_team_id_team_id_fk": {
+          "name": "fixture_away_team_id_team_id_fk",
+          "tableFrom": "fixture",
+          "tableTo": "team",
+          "columnsFrom": [
+            "away_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.round": {
+      "name": "round",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "round_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upcoming'"
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "round_competition_id_competition_id_fk": {
+          "name": "round_competition_id_competition_id_fk",
+          "tableFrom": "round",
+          "tableTo": "competition",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team": {
+      "name": "team",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_url": {
+          "name": "badge_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_color": {
+          "name": "primary_color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ids": {
+          "name": "external_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "league_position": {
+          "name": "league_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_form": {
+      "name": "team_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recent_results": {
+          "name": "recent_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "home_form": {
+          "name": "home_form",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "away_form": {
+          "name": "away_form",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "league_position": {
+          "name": "league_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_form_team_comp_idx": {
+          "name": "team_form_team_comp_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_form_team_id_team_id_fk": {
+          "name": "team_form_team_id_team_id_fk",
+          "tableFrom": "team_form",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_form_competition_id_competition_id_fk": {
+          "name": "team_form_competition_id_competition_id_fk",
+          "tableFrom": "team_form",
+          "tableTo": "competition",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game": {
+      "name": "game",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "game_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'setup'"
+        },
+        "game_mode": {
+          "name": "game_mode",
+          "type": "game_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode_config": {
+          "name": "mode_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_players": {
+          "name": "max_players",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_round_id": {
+          "name": "current_round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_competition_id_competition_id_fk": {
+          "name": "game_competition_id_competition_id_fk",
+          "tableFrom": "game",
+          "tableTo": "competition",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_current_round_id_round_id_fk": {
+          "name": "game_current_round_id_round_id_fk",
+          "tableFrom": "game",
+          "tableTo": "round",
+          "columnsFrom": [
+            "current_round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "game_invite_code_unique": {
+          "name": "game_invite_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_player": {
+      "name": "game_player",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "player_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'alive'"
+        },
+        "eliminated_round_id": {
+          "name": "eliminated_round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eliminated_reason": {
+          "name": "eliminated_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lives_remaining": {
+          "name": "lives_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_player_unique_idx": {
+          "name": "game_player_unique_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_player_game_id_game_id_fk": {
+          "name": "game_player_game_id_game_id_fk",
+          "tableFrom": "game_player",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_player_eliminated_round_id_round_id_fk": {
+          "name": "game_player_eliminated_round_id_round_id_fk",
+          "tableFrom": "game_player",
+          "tableTo": "round",
+          "columnsFrom": [
+            "eliminated_round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pick": {
+      "name": "pick",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_player_id": {
+          "name": "game_player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fixture_id": {
+          "name": "fixture_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_rank": {
+          "name": "confidence_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "predicted_result": {
+          "name": "predicted_result",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "pick_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "goals_scored": {
+          "name": "goals_scored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_submitted": {
+          "name": "auto_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_auto": {
+          "name": "is_auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pick_player_round_idx": {
+          "name": "pick_player_round_idx",
+          "columns": [
+            {
+              "expression": "game_player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "round_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "confidence_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pick_game_id_game_id_fk": {
+          "name": "pick_game_id_game_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_game_player_id_game_player_id_fk": {
+          "name": "pick_game_player_id_game_player_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "game_player",
+          "columnsFrom": [
+            "game_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_round_id_round_id_fk": {
+          "name": "pick_round_id_round_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_team_id_team_id_fk": {
+          "name": "pick_team_id_team_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_fixture_id_fixture_id_fk": {
+          "name": "pick_fixture_id_fixture_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "fixture",
+          "columnsFrom": [
+            "fixture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planned_pick": {
+      "name": "planned_pick",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_player_id": {
+          "name": "game_player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_submit": {
+          "name": "auto_submit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "planned_pick_unique_idx": {
+          "name": "planned_pick_unique_idx",
+          "columns": [
+            {
+              "expression": "game_player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "round_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "planned_pick_game_player_id_game_player_id_fk": {
+          "name": "planned_pick_game_player_id_game_player_id_fk",
+          "tableFrom": "planned_pick",
+          "tableTo": "game_player",
+          "columnsFrom": [
+            "game_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "planned_pick_round_id_round_id_fk": {
+          "name": "planned_pick_round_id_round_id_fk",
+          "tableFrom": "planned_pick",
+          "tableTo": "round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "planned_pick_team_id_team_id_fk": {
+          "name": "planned_pick_team_id_team_id_fk",
+          "tableFrom": "planned_pick",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment": {
+      "name": "payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payment_game_id_game_id_fk": {
+          "name": "payment_game_id_game_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payout": {
+      "name": "payout",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_split": {
+          "name": "is_split",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "payout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payout_game_id_game_id_fk": {
+          "name": "payout_game_id_game_id_fk",
+          "tableFrom": "payout",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.competition_data_source": {
+      "name": "competition_data_source",
+      "schema": "public",
+      "values": [
+        "fpl",
+        "football_data",
+        "manual"
+      ]
+    },
+    "public.competition_type": {
+      "name": "competition_type",
+      "schema": "public",
+      "values": [
+        "league",
+        "knockout",
+        "group_knockout"
+      ]
+    },
+    "public.fixture_status": {
+      "name": "fixture_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "live",
+        "finished",
+        "postponed"
+      ]
+    },
+    "public.round_status": {
+      "name": "round_status",
+      "schema": "public",
+      "values": [
+        "upcoming",
+        "open",
+        "active",
+        "completed"
+      ]
+    },
+    "public.game_mode": {
+      "name": "game_mode",
+      "schema": "public",
+      "values": [
+        "classic",
+        "turbo",
+        "cup"
+      ]
+    },
+    "public.game_status": {
+      "name": "game_status",
+      "schema": "public",
+      "values": [
+        "setup",
+        "open",
+        "active",
+        "completed"
+      ]
+    },
+    "public.pick_result": {
+      "name": "pick_result",
+      "schema": "public",
+      "values": [
+        "pending",
+        "win",
+        "loss",
+        "draw",
+        "saved_by_life"
+      ]
+    },
+    "public.player_status": {
+      "name": "player_status",
+      "schema": "public",
+      "values": [
+        "alive",
+        "eliminated",
+        "winner"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "manual",
+        "mangopay"
+      ]
+    },
+    "public.payment_status": {
+      "name": "payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "claimed",
+        "paid",
+        "refunded"
+      ]
+    },
+    "public.payout_status": {
+      "name": "payout_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776976690339,
       "tag": "0001_mute_nova",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1777041436570,
+      "tag": "0002_bored_lizard",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -20,45 +20,168 @@ const PL_TEAMS: Array<{
 	primaryColor: string
 	fplCode: number
 	strength: number // higher = stronger side, used to bias results
+	leaguePosition: number
 }> = [
-	{ name: 'Arsenal', shortName: 'ARS', primaryColor: '#EF0107', fplCode: 3, strength: 85 },
-	{ name: 'Aston Villa', shortName: 'AVL', primaryColor: '#670E36', fplCode: 7, strength: 72 },
-	{ name: 'Bournemouth', shortName: 'BOU', primaryColor: '#DA291C', fplCode: 91, strength: 65 },
-	{ name: 'Brentford', shortName: 'BRE', primaryColor: '#e30613', fplCode: 94, strength: 63 },
-	{ name: 'Brighton', shortName: 'BHA', primaryColor: '#0057B8', fplCode: 36, strength: 70 },
-	{ name: 'Burnley', shortName: 'BUR', primaryColor: '#6C1D45', fplCode: 90, strength: 50 },
-	{ name: 'Chelsea', shortName: 'CHE', primaryColor: '#034694', fplCode: 8, strength: 80 },
-	{ name: 'Crystal Palace', shortName: 'CRY', primaryColor: '#1B458F', fplCode: 31, strength: 62 },
-	{ name: 'Everton', shortName: 'EVE', primaryColor: '#003399', fplCode: 11, strength: 58 },
-	{ name: 'Fulham', shortName: 'FUL', primaryColor: '#000000', fplCode: 54, strength: 60 },
-	{ name: 'Leeds United', shortName: 'LEE', primaryColor: '#FFCD00', fplCode: 2, strength: 55 },
-	{ name: 'Liverpool', shortName: 'LIV', primaryColor: '#C8102E', fplCode: 14, strength: 88 },
-	{ name: 'Manchester City', shortName: 'MCI', primaryColor: '#6CABDD', fplCode: 43, strength: 86 },
+	{
+		name: 'Arsenal',
+		shortName: 'ARS',
+		primaryColor: '#EF0107',
+		fplCode: 3,
+		strength: 85,
+		leaguePosition: 2,
+	},
+	{
+		name: 'Aston Villa',
+		shortName: 'AVL',
+		primaryColor: '#670E36',
+		fplCode: 7,
+		strength: 72,
+		leaguePosition: 4,
+	},
+	{
+		name: 'Bournemouth',
+		shortName: 'BOU',
+		primaryColor: '#DA291C',
+		fplCode: 91,
+		strength: 65,
+		leaguePosition: 10,
+	},
+	{
+		name: 'Brentford',
+		shortName: 'BRE',
+		primaryColor: '#e30613',
+		fplCode: 94,
+		strength: 63,
+		leaguePosition: 9,
+	},
+	{
+		name: 'Brighton',
+		shortName: 'BHA',
+		primaryColor: '#0057B8',
+		fplCode: 36,
+		strength: 70,
+		leaguePosition: 6,
+	},
+	{
+		name: 'Burnley',
+		shortName: 'BUR',
+		primaryColor: '#6C1D45',
+		fplCode: 90,
+		strength: 50,
+		leaguePosition: 17,
+	},
+	{
+		name: 'Chelsea',
+		shortName: 'CHE',
+		primaryColor: '#034694',
+		fplCode: 8,
+		strength: 80,
+		leaguePosition: 3,
+	},
+	{
+		name: 'Crystal Palace',
+		shortName: 'CRY',
+		primaryColor: '#1B458F',
+		fplCode: 31,
+		strength: 62,
+		leaguePosition: 11,
+	},
+	{
+		name: 'Everton',
+		shortName: 'EVE',
+		primaryColor: '#003399',
+		fplCode: 11,
+		strength: 58,
+		leaguePosition: 14,
+	},
+	{
+		name: 'Fulham',
+		shortName: 'FUL',
+		primaryColor: '#000000',
+		fplCode: 54,
+		strength: 60,
+		leaguePosition: 8,
+	},
+	{
+		name: 'Leeds United',
+		shortName: 'LEE',
+		primaryColor: '#FFCD00',
+		fplCode: 2,
+		strength: 55,
+		leaguePosition: 16,
+	},
+	{
+		name: 'Liverpool',
+		shortName: 'LIV',
+		primaryColor: '#C8102E',
+		fplCode: 14,
+		strength: 88,
+		leaguePosition: 1,
+	},
+	{
+		name: 'Manchester City',
+		shortName: 'MCI',
+		primaryColor: '#6CABDD',
+		fplCode: 43,
+		strength: 86,
+		leaguePosition: 5,
+	},
 	{
 		name: 'Manchester United',
 		shortName: 'MUN',
 		primaryColor: '#DA291C',
 		fplCode: 1,
 		strength: 75,
+		leaguePosition: 7,
 	},
-	{ name: 'Newcastle United', shortName: 'NEW', primaryColor: '#241F20', fplCode: 4, strength: 76 },
+	{
+		name: 'Newcastle United',
+		shortName: 'NEW',
+		primaryColor: '#241F20',
+		fplCode: 4,
+		strength: 76,
+		leaguePosition: 12,
+	},
 	{
 		name: 'Nottingham Forest',
 		shortName: 'NFO',
 		primaryColor: '#DD0000',
 		fplCode: 17,
 		strength: 68,
+		leaguePosition: 13,
 	},
-	{ name: 'Sunderland', shortName: 'SUN', primaryColor: '#EB172B', fplCode: 56, strength: 48 },
+	{
+		name: 'Sunderland',
+		shortName: 'SUN',
+		primaryColor: '#EB172B',
+		fplCode: 56,
+		strength: 48,
+		leaguePosition: 19,
+	},
 	{
 		name: 'Tottenham Hotspur',
 		shortName: 'TOT',
 		primaryColor: '#132257',
 		fplCode: 6,
 		strength: 74,
+		leaguePosition: 15,
 	},
-	{ name: 'West Ham United', shortName: 'WHU', primaryColor: '#7A263A', fplCode: 21, strength: 64 },
-	{ name: 'Wolverhampton', shortName: 'WOL', primaryColor: '#FDB913', fplCode: 39, strength: 55 },
+	{
+		name: 'West Ham United',
+		shortName: 'WHU',
+		primaryColor: '#7A263A',
+		fplCode: 21,
+		strength: 64,
+		leaguePosition: 18,
+	},
+	{
+		name: 'Wolverhampton',
+		shortName: 'WOL',
+		primaryColor: '#FDB913',
+		fplCode: 39,
+		strength: 55,
+		leaguePosition: 20,
+	},
 ]
 
 function fplBadgeUrl(code: number): string {
@@ -73,6 +196,7 @@ const DEV_USERS = [
 	{ email: 'sarah@example.com', name: 'Sarah', password: 'password123' },
 	{ email: 'tom@example.com', name: 'Tom', password: 'password123' },
 	{ email: 'james@example.com', name: 'James', password: 'password123' },
+	{ email: 'rachel@example.com', name: 'Rachel', password: 'password123' },
 ]
 
 type RoundRow = typeof roundTable.$inferSelect
@@ -146,7 +270,7 @@ async function seed() {
 		.returning()
 	console.log(`Created competition: ${pl.name}`)
 
-	// --- Teams (with FPL badge URLs) ---
+	// --- Teams (with FPL badge URLs and league positions) ---
 	const teams = await db
 		.insert(teamTable)
 		.values(
@@ -156,6 +280,7 @@ async function seed() {
 				primaryColor: t.primaryColor,
 				badgeUrl: fplBadgeUrl(t.fplCode),
 				externalIds: { fpl: t.fplCode },
+				leaguePosition: t.leaguePosition,
 			})),
 		)
 		.returning()
@@ -332,6 +457,9 @@ async function seed() {
 		// Turbo-specific: whether to seed picks for all players (completed game) or
 		// leave most of them unsubmitted so the pick interface is testable
 		turboState?: 'live' | 'completed'
+		// Missed deadline scenario: skip inserting a pick for this player in a specific round
+		missedDeadlinePlayer?: string
+		missedDeadlineRound?: number
 	}
 
 	const gameSeeds: GameSeed[] = [
@@ -347,10 +475,13 @@ async function seed() {
 				'sarah@example.com',
 				'tom@example.com',
 				'james@example.com',
+				'rachel@example.com',
 			],
 			entryFee: '10.00',
 			creatorSubmittedCurrentPick: false,
 			plannedEliminations: { 'tom@example.com': 4, 'james@example.com': 2 },
+			missedDeadlinePlayer: 'rachel@example.com',
+			missedDeadlineRound: 3,
 		},
 		{
 			name: 'Work Classic',
@@ -473,9 +604,21 @@ async function seed() {
 				let eliminatedAt: number | null = null
 
 				const plannedElim = seed.plannedEliminations?.[email] ?? null
+				const isMissedDeadlinePlayer = email === seed.missedDeadlinePlayer
+				const missedDeadlineRound = seed.missedDeadlineRound ?? null
 
 				for (const r of completedRounds) {
 					if (eliminatedAt !== null) break
+
+					// Skip inserting a pick if this is the missed deadline player/round
+					if (
+						isMissedDeadlinePlayer &&
+						missedDeadlineRound !== null &&
+						r.number === missedDeadlineRound
+					) {
+						continue
+					}
+
 					const roundFixtures = fixturesByRound.get(r.id) ?? []
 					const available = roundFixtures.filter(
 						(f) => !usedTeamIds.has(f.homeTeamId) && !usedTeamIds.has(f.awayTeamId),

--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -176,6 +176,7 @@ export default async function GameDetailPage({ params }: { params: Promise<{ id:
 				myPayment: game.myPayment,
 				otherPayments: game.otherPayments,
 				adminPayments: game.adminPayments,
+				myCurrentRoundPick: game.myCurrentRoundPick,
 			}}
 			pickSection={pickSection}
 			classicGrid={classicGrid}

--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -1,10 +1,13 @@
-import { notFound } from 'next/navigation'
+import { and, eq } from 'drizzle-orm'
+import { notFound, redirect } from 'next/navigation'
+import { ActingAsBanner } from '@/components/game/acting-as-banner'
 import { GameDetailView } from '@/components/game/game-detail-view'
 import { ClassicPick } from '@/components/picks/classic-pick'
 import type { CupPickFixture, CupPickSlot } from '@/components/picks/cup-pick'
 import { CupPickForm } from '@/components/picks/cup-pick-form'
 import { TurboPick } from '@/components/picks/turbo-pick'
 import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
 import { getCupLadderData } from '@/lib/game/cup-standings-queries'
 import {
 	getClassicPickData,
@@ -15,10 +18,31 @@ import {
 	getTurboStandingsData,
 } from '@/lib/game/detail-queries'
 import { computeTierDifference } from '@/lib/game-logic/cup-tier'
+import { user } from '@/lib/schema/auth'
+import { gamePlayer } from '@/lib/schema/game'
 
-export default async function GameDetailPage({ params }: { params: Promise<{ id: string }> }) {
+function initialsFromName(name: string): string {
+	return (
+		name
+			.split(' ')
+			.map((p) => p[0] ?? '')
+			.filter(Boolean)
+			.slice(0, 2)
+			.join('')
+			.toUpperCase() || '??'
+	)
+}
+
+export default async function GameDetailPage({
+	params,
+	searchParams,
+}: {
+	params: Promise<{ id: string }>
+	searchParams: Promise<{ actingAs?: string }>
+}) {
 	const session = await requireSession()
 	const { id } = await params
+	const resolvedSearchParams = await searchParams
 	const game = await getGameDetail(id, session.user.id)
 	if (!game) notFound()
 
@@ -31,19 +55,62 @@ export default async function GameDetailPage({ params }: { params: Promise<{ id:
 		)
 	}
 
+	// Resolve actingAs: admin-only override of whose pick context we render.
+	// Runs before any pick-data loading so non-admins can't leak target picks.
+	const actingAsId = resolvedSearchParams.actingAs ?? null
+	let actingAsTarget: {
+		gamePlayerId: string
+		userName: string
+		initials: string
+		livesRemaining: number
+	} | null = null
+
+	if (actingAsId) {
+		if (!game.isAdmin) {
+			// Non-admin attempting to use actingAs — strip the param and redirect.
+			redirect(`/game/${id}`)
+		}
+		const [targetRow] = await db
+			.select({
+				gamePlayerId: gamePlayer.id,
+				userName: user.name,
+				livesRemaining: gamePlayer.livesRemaining,
+			})
+			.from(gamePlayer)
+			.innerJoin(user, eq(user.id, gamePlayer.userId))
+			.where(and(eq(gamePlayer.id, actingAsId), eq(gamePlayer.gameId, game.id)))
+			.limit(1)
+		if (!targetRow) {
+			// Invalid actingAs target — redirect back to the game page.
+			redirect(`/game/${id}`)
+		}
+		actingAsTarget = {
+			gamePlayerId: targetRow.gamePlayerId,
+			userName: targetRow.userName,
+			initials: initialsFromName(targetRow.userName),
+			livesRemaining: targetRow.livesRemaining,
+		}
+	}
+
+	// Choose the gamePlayer whose pick context we're loading. Admin acting-as mode
+	// targets another player; otherwise the viewer's own membership.
+	const targetGamePlayerId = actingAsTarget?.gamePlayerId ?? game.myMembership?.id
+	const targetLivesRemaining =
+		actingAsTarget?.livesRemaining ?? game.myMembership?.livesRemaining ?? 0
+
 	const classicPickData =
-		game.currentRound && game.myMembership && game.gameMode === 'classic'
-			? await getClassicPickData(game.id, game.currentRound.id, game.myMembership.id)
+		game.currentRound && targetGamePlayerId && game.gameMode === 'classic'
+			? await getClassicPickData(game.id, game.currentRound.id, targetGamePlayerId)
 			: null
 
 	const classicPlannerData =
-		game.myMembership && game.gameMode === 'classic'
-			? await getClassicPlannerData(game.id, game.myMembership.id, game.currentRound?.id ?? null)
+		targetGamePlayerId && game.gameMode === 'classic'
+			? await getClassicPlannerData(game.id, targetGamePlayerId, game.currentRound?.id ?? null)
 			: null
 
 	const turboPickData =
-		game.currentRound && game.myMembership && game.gameMode === 'turbo'
-			? await getTurboPickData(game.id, game.currentRound.id, game.myMembership.id)
+		game.currentRound && targetGamePlayerId && game.gameMode === 'turbo'
+			? await getTurboPickData(game.id, game.currentRound.id, targetGamePlayerId)
 			: null
 
 	const numberOfPicks = game.modeConfig?.numberOfPicks ?? 10
@@ -56,7 +123,13 @@ export default async function GameDetailPage({ params }: { params: Promise<{ id:
 	const cupStandingsData =
 		game.gameMode === 'cup' ? await getCupLadderData(game.id, session.user.id) : null
 
-	const isAlive = game.myMembership?.status === 'alive'
+	// Alive check is on the TARGET player (acting-as) or the viewer's own membership.
+	const targetPlayerStatus = actingAsTarget
+		? game.players.find((p) => p.id === actingAsTarget.gamePlayerId)?.status
+		: game.myMembership?.status
+	const isAlive = targetPlayerStatus === 'alive' || !!actingAsTarget
+	// NB: in acting-as mode we always render the pick UI even for "eliminated"
+	// players so admins can rebuy-via-pick (see maybeUnEliminate in the POST route).
 	const aliveCount = game.players.filter((p) => p.status === 'alive').length
 
 	// Target = entryFee × playerCount (what the pot would be if everyone paid).
@@ -68,11 +141,11 @@ export default async function GameDetailPage({ params }: { params: Promise<{ id:
 	const target = targetNum.toFixed(2)
 	const unpaid = unpaidNum.toFixed(2)
 
-	// Build cup pick props inline from the data already fetched by getGameDetail.
-	// (Kept here rather than in detail-queries.ts because all source fields are already loaded.)
+	// Build cup pick props. Source picks from the TARGET player so admin acting-as
+	// sees the target's existing slot state, not their own.
 	let cupFixtures: CupPickFixture[] = []
 	let cupInitialSlots: CupPickSlot[] = []
-	if (game.gameMode === 'cup' && game.currentRound && game.myMembership) {
+	if (game.gameMode === 'cup' && game.currentRound && targetGamePlayerId) {
 		cupFixtures = game.currentRound.fixtures.map((f) => ({
 			id: f.id,
 			homeTeamId: f.homeTeamId,
@@ -89,11 +162,10 @@ export default async function GameDetailPage({ params }: { params: Promise<{ id:
 			tierDifference: computeTierDifference(f.homeTeam, f.awayTeam, game.competition.type),
 		}))
 
-		const myPlayerId = game.myMembership.id
 		cupInitialSlots = game.picks
 			.filter(
 				(p) =>
-					p.gamePlayerId === myPlayerId &&
+					p.gamePlayerId === targetGamePlayerId &&
 					p.roundId === game.currentRound?.id &&
 					p.fixtureId != null &&
 					p.confidenceRank != null,
@@ -104,6 +176,10 @@ export default async function GameDetailPage({ params }: { params: Promise<{ id:
 				pickedSide: (p.predictedResult === 'away_win' ? 'away' : 'home') as 'home' | 'away',
 			}))
 	}
+
+	const actingAsForPickUI = actingAsTarget
+		? { gamePlayerId: actingAsTarget.gamePlayerId, userName: actingAsTarget.userName }
+		: undefined
 
 	const pickSection =
 		game.currentRound && isAlive ? (
@@ -118,6 +194,7 @@ export default async function GameDetailPage({ params }: { params: Promise<{ id:
 					existingPickTeamId={classicPickData.existingPickTeamId}
 					chain={classicPlannerData?.chain}
 					futureRounds={classicPlannerData?.futureRounds}
+					actingAs={actingAsForPickUI}
 				/>
 			) : game.gameMode === 'turbo' && turboPickData ? (
 				<TurboPick
@@ -128,18 +205,20 @@ export default async function GameDetailPage({ params }: { params: Promise<{ id:
 					fixtures={turboPickData.fixtures}
 					existingPicks={turboPickData.existingPicks}
 					numberOfPicks={numberOfPicks}
+					actingAs={actingAsForPickUI}
 				/>
-			) : game.gameMode === 'cup' && game.myMembership ? (
+			) : game.gameMode === 'cup' && targetGamePlayerId ? (
 				<CupPickForm
 					gameId={game.id}
 					roundId={game.currentRound.id}
 					fixtures={cupFixtures}
 					numberOfPicks={numberOfPicks}
-					livesRemaining={game.myMembership.livesRemaining}
+					livesRemaining={targetLivesRemaining}
 					maxLives={startingLives}
 					initialSlots={cupInitialSlots}
 					deadline={game.currentRound.deadline}
 					readonly={game.status !== 'open'}
+					actingAs={actingAsForPickUI}
 				/>
 			) : (
 				<div className="p-4 rounded-lg border border-border bg-card text-sm text-muted-foreground">
@@ -178,7 +257,18 @@ export default async function GameDetailPage({ params }: { params: Promise<{ id:
 				adminPayments: game.adminPayments,
 				myCurrentRoundPick: game.myCurrentRoundPick,
 			}}
-			pickSection={pickSection}
+			pickSection={
+				<>
+					{actingAsTarget && (
+						<ActingAsBanner
+							gameId={game.id}
+							targetUserName={actingAsTarget.userName}
+							targetAvatarInitials={actingAsTarget.initials}
+						/>
+					)}
+					{pickSection}
+				</>
+			}
 			classicGrid={classicGrid}
 			turboStandings={
 				turboStandingsData ? { rounds: turboStandingsData.rounds, numberOfPicks } : null

--- a/src/app/api/cron/daily-sync/route.test.ts
+++ b/src/app/api/cron/daily-sync/route.test.ts
@@ -5,11 +5,18 @@ vi.mock('@/lib/db', () => ({
 }))
 
 vi.mock('@/lib/game/bootstrap-competitions', () => ({
-	syncCompetition: vi.fn().mockResolvedValue({ rounds: 0, fixtures: 0 }),
+	syncCompetition: vi.fn().mockResolvedValue({ rounds: 0, fixtures: 0, transitionedRoundIds: [] }),
+}))
+
+vi.mock('@/lib/game/no-pick-handler', () => ({
+	processDeadlineLock: vi
+		.fn()
+		.mockResolvedValue({ autoPicksInserted: 0, playersEliminated: 0, paymentsRefunded: 0 }),
 }))
 
 import { db } from '@/lib/db'
 import { syncCompetition } from '@/lib/game/bootstrap-competitions'
+import { processDeadlineLock } from '@/lib/game/no-pick-handler'
 import { POST } from './route'
 
 describe('daily-sync route', () => {
@@ -28,6 +35,11 @@ describe('daily-sync route', () => {
 			{ id: 'c1' },
 			{ id: 'c2' },
 		] as never)
+		vi.mocked(syncCompetition).mockResolvedValue({
+			rounds: 0,
+			fixtures: 0,
+			transitionedRoundIds: [],
+		})
 		await POST(
 			new Request('http://x', {
 				method: 'POST',
@@ -35,5 +47,47 @@ describe('daily-sync route', () => {
 			}),
 		)
 		expect(syncCompetition).toHaveBeenCalledTimes(2)
+	})
+
+	it('does not call processDeadlineLock when no rounds transitioned', async () => {
+		vi.mocked(db.query.competition.findMany).mockResolvedValue([{ id: 'c1' }] as never)
+		vi.mocked(syncCompetition).mockResolvedValue({
+			rounds: 1,
+			fixtures: 10,
+			transitionedRoundIds: [],
+		})
+		await POST(
+			new Request('http://x', {
+				method: 'POST',
+				headers: { authorization: 'Bearer test-secret' },
+			}),
+		)
+		expect(processDeadlineLock).not.toHaveBeenCalled()
+	})
+
+	it('invokes processDeadlineLock once with all transitioned round ids across competitions', async () => {
+		vi.mocked(db.query.competition.findMany).mockResolvedValue([
+			{ id: 'c1' },
+			{ id: 'c2' },
+		] as never)
+		vi.mocked(syncCompetition)
+			.mockResolvedValueOnce({ rounds: 2, fixtures: 20, transitionedRoundIds: ['r1', 'r2'] })
+			.mockResolvedValueOnce({ rounds: 1, fixtures: 10, transitionedRoundIds: ['r3'] })
+
+		const res = await POST(
+			new Request('http://x', {
+				method: 'POST',
+				headers: { authorization: 'Bearer test-secret' },
+			}),
+		)
+
+		expect(processDeadlineLock).toHaveBeenCalledTimes(1)
+		expect(processDeadlineLock).toHaveBeenCalledWith(['r1', 'r2', 'r3'])
+		const body = (await res.json()) as { deadlineLock: unknown }
+		expect(body.deadlineLock).toEqual({
+			autoPicksInserted: 0,
+			playersEliminated: 0,
+			paymentsRefunded: 0,
+		})
 	})
 })

--- a/src/app/api/cron/daily-sync/route.ts
+++ b/src/app/api/cron/daily-sync/route.ts
@@ -2,6 +2,7 @@ import { eq } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import { db } from '@/lib/db'
 import { syncCompetition } from '@/lib/game/bootstrap-competitions'
+import { processDeadlineLock } from '@/lib/game/no-pick-handler'
 import { competition } from '@/lib/schema/competition'
 
 export async function POST(request: Request) {
@@ -17,9 +18,25 @@ export async function POST(request: Request) {
 		where: eq(competition.status, 'active'),
 	})
 	const results = []
+	const deadlineLockedRoundIds: string[] = []
 	for (const c of comps) {
 		const summary = await syncCompetition(c, { footballDataApiKey: apiKey })
-		results.push({ competitionId: c.id, ...summary })
+		results.push({
+			competitionId: c.id,
+			rounds: summary.rounds,
+			fixtures: summary.fixtures,
+		})
+		if (summary.transitionedRoundIds?.length) {
+			deadlineLockedRoundIds.push(...summary.transitionedRoundIds)
+		}
 	}
-	return NextResponse.json({ competitions: results })
+	let deadlineLock: {
+		autoPicksInserted: number
+		playersEliminated: number
+		paymentsRefunded: number
+	} | null = null
+	if (deadlineLockedRoundIds.length > 0) {
+		deadlineLock = await processDeadlineLock(deadlineLockedRoundIds)
+	}
+	return NextResponse.json({ competitions: results, deadlineLock })
 }

--- a/src/app/api/games/[id]/admin/add-player/route.test.ts
+++ b/src/app/api/games/[id]/admin/add-player/route.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/auth-helpers', () => ({
+	requireSession: vi.fn(),
+}))
+vi.mock('@/lib/db', () => ({
+	db: {
+		query: {
+			game: { findFirst: vi.fn() },
+			user: { findFirst: vi.fn() },
+			gamePlayer: { findFirst: vi.fn() },
+		},
+		insert: vi.fn(),
+	},
+}))
+
+import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { POST } from './route'
+
+function makeReq(body: unknown) {
+	return new Request('http://localhost/api/games/g1/admin/add-player', {
+		method: 'POST',
+		body: JSON.stringify(body),
+	})
+}
+
+const params = { params: Promise.resolve({ id: 'g1' }) }
+
+describe('POST /api/games/[id]/admin/add-player', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.mocked(requireSession).mockResolvedValue({ user: { id: 'u-admin' } } as never)
+	})
+
+	it('returns 403 for non-admin', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({
+			id: 'g1',
+			createdBy: 'u-other',
+			modeConfig: { startingLives: 3 },
+			gameMode: 'classic',
+		} as never)
+		const res = await POST(makeReq({ userId: 'u-new' }), params)
+		expect(res.status).toBe(403)
+	})
+
+	it('returns 404 when target user not found', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({
+			id: 'g1',
+			createdBy: 'u-admin',
+			modeConfig: { startingLives: 3 },
+			gameMode: 'classic',
+		} as never)
+		vi.mocked(db.query.user.findFirst).mockResolvedValue(undefined as never)
+		const res = await POST(makeReq({ userId: 'u-new' }), params)
+		expect(res.status).toBe(404)
+	})
+
+	it('returns 409 when user already in game', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({
+			id: 'g1',
+			createdBy: 'u-admin',
+			modeConfig: { startingLives: 3 },
+			gameMode: 'classic',
+		} as never)
+		vi.mocked(db.query.user.findFirst).mockResolvedValue({ id: 'u-new' } as never)
+		vi.mocked(db.query.gamePlayer.findFirst).mockResolvedValue({
+			id: 'gp-exist',
+			userId: 'u-new',
+		} as never)
+		const res = await POST(makeReq({ userId: 'u-new' }), params)
+		expect(res.status).toBe(409)
+	})
+
+	it('inserts gamePlayer and returns 200', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({
+			id: 'g1',
+			createdBy: 'u-admin',
+			modeConfig: { startingLives: 3 },
+			gameMode: 'classic',
+		} as never)
+		vi.mocked(db.query.user.findFirst).mockResolvedValue({ id: 'u-new' } as never)
+		vi.mocked(db.query.gamePlayer.findFirst).mockResolvedValue(undefined as never)
+		const insertChain = {
+			values: vi.fn().mockReturnValue({
+				returning: vi.fn().mockResolvedValue([{ id: 'gp-new', userId: 'u-new' }]),
+			}),
+		}
+		vi.mocked(db.insert).mockReturnValue(insertChain as never)
+
+		const res = await POST(makeReq({ userId: 'u-new' }), params)
+		expect(res.status).toBe(200)
+		const body = await res.json()
+		expect(body.gamePlayer.id).toBe('gp-new')
+	})
+})

--- a/src/app/api/games/[id]/admin/add-player/route.ts
+++ b/src/app/api/games/[id]/admin/add-player/route.ts
@@ -1,0 +1,53 @@
+import { and, eq } from 'drizzle-orm'
+import { NextResponse } from 'next/server'
+import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { user } from '@/lib/schema/auth'
+import { game, gamePlayer } from '@/lib/schema/game'
+
+export async function POST(
+	request: Request,
+	{ params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+	const session = await requireSession()
+	const { id: gameId } = await params
+	const body = (await request.json()) as { userId?: string }
+
+	if (!body.userId) {
+		return NextResponse.json({ error: 'missing-userId' }, { status: 400 })
+	}
+
+	const gameRow = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+	if (!gameRow) {
+		return NextResponse.json({ error: 'not-found' }, { status: 404 })
+	}
+	if (gameRow.createdBy !== session.user.id) {
+		return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+	}
+
+	const targetUser = await db.query.user.findFirst({ where: eq(user.id, body.userId) })
+	if (!targetUser) {
+		return NextResponse.json({ error: 'user-not-found' }, { status: 404 })
+	}
+
+	const existing = await db.query.gamePlayer.findFirst({
+		where: and(eq(gamePlayer.gameId, gameId), eq(gamePlayer.userId, body.userId)),
+	})
+	if (existing) {
+		return NextResponse.json({ error: 'already-in-game' }, { status: 409 })
+	}
+
+	const startingLives =
+		(gameRow.modeConfig as { startingLives?: number } | null)?.startingLives ?? 1
+	const [inserted] = await db
+		.insert(gamePlayer)
+		.values({
+			gameId,
+			userId: body.userId,
+			status: 'alive',
+			livesRemaining: startingLives,
+		})
+		.returning()
+
+	return NextResponse.json({ gamePlayer: inserted })
+}

--- a/src/app/api/picks/[gameId]/[roundId]/route.test.ts
+++ b/src/app/api/picks/[gameId]/[roundId]/route.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/auth-helpers', () => ({
+	requireSession: vi.fn(),
+}))
+vi.mock('@/lib/db', () => ({
+	db: {
+		query: {
+			game: { findFirst: vi.fn() },
+			gamePlayer: { findFirst: vi.fn() },
+			round: { findFirst: vi.fn() },
+			pick: { findMany: vi.fn() },
+		},
+		insert: vi.fn(),
+		delete: vi.fn(),
+		update: vi.fn(),
+	},
+}))
+
+import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { POST } from './route'
+
+function makeReq(body: unknown) {
+	return new Request('http://localhost/api/picks/g1/r1', {
+		method: 'POST',
+		body: JSON.stringify(body),
+	})
+}
+
+const params = { params: Promise.resolve({ gameId: 'g1', roundId: 'r1' }) }
+
+// --- Shared stubs --------------------------------------------------------
+
+const OPEN_ROUND_FAR_FUTURE = {
+	id: 'r1',
+	number: 5,
+	status: 'open' as const,
+	deadline: new Date('2099-01-01T00:00:00Z'),
+	fixtures: [
+		{
+			id: 'fx1',
+			roundId: 'r1',
+			homeTeamId: 't-home',
+			awayTeamId: 't-away',
+			homeScore: null,
+			awayScore: null,
+			status: 'scheduled',
+			homeTeam: { id: 't-home', leaguePosition: 1 },
+			awayTeam: { id: 't-away', leaguePosition: 2 },
+		},
+	],
+}
+
+const CLASSIC_GAME_ADMIN = {
+	id: 'g1',
+	createdBy: 'u-admin',
+	gameMode: 'classic' as const,
+	modeConfig: {},
+	competitionId: 'c1',
+	competition: { id: 'c1', type: 'league' },
+}
+
+function mockDeleteChain() {
+	const chain = { where: vi.fn().mockResolvedValue(undefined) }
+	vi.mocked(db.delete).mockReturnValue(chain as never)
+	return chain
+}
+
+function mockUpdateChain() {
+	const setChain = { where: vi.fn().mockResolvedValue(undefined) }
+	const chain = { set: vi.fn().mockReturnValue(setChain) }
+	vi.mocked(db.update).mockReturnValue(chain as never)
+	return { chain, setChain }
+}
+
+function mockInsertReturning(returned: unknown[]) {
+	const insertChain = {
+		values: vi.fn().mockReturnValue({
+			returning: vi.fn().mockResolvedValue(returned),
+		}),
+	}
+	vi.mocked(db.insert).mockReturnValue(insertChain as never)
+	return insertChain
+}
+
+// --- Tests ---------------------------------------------------------------
+
+describe('POST /api/picks/[gameId]/[roundId] — actingAs + un-elimination', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.mocked(requireSession).mockResolvedValue({ user: { id: 'u-admin' } } as never)
+	})
+
+	it('rejects actingAs from non-admin with 403', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({
+			...CLASSIC_GAME_ADMIN,
+			createdBy: 'u-other', // session user is NOT the admin
+		} as never)
+		// Session user has their own gamePlayer, but the actingAs check runs first.
+		vi.mocked(db.query.gamePlayer.findFirst).mockResolvedValueOnce({
+			id: 'gp-self',
+			userId: 'u-admin',
+			status: 'alive',
+		} as never)
+
+		const res = await POST(makeReq({ teamId: 't-home', actingAs: 'gp-target' }), params)
+		expect(res.status).toBe(403)
+		const body = await res.json()
+		expect(body.error).toBe('forbidden')
+	})
+
+	it('rejects actingAs referencing a player not in this game with 404', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue(CLASSIC_GAME_ADMIN as never)
+		vi.mocked(db.query.gamePlayer.findFirst)
+			// First call: session user's own gamePlayer
+			.mockResolvedValueOnce({ id: 'gp-self', userId: 'u-admin', status: 'alive' } as never)
+			// Second call: actingAs lookup returns undefined
+			.mockResolvedValueOnce(undefined as never)
+
+		const res = await POST(makeReq({ teamId: 't-home', actingAs: 'gp-target' }), params)
+		expect(res.status).toBe(404)
+		const body = await res.json()
+		expect(body.error).toBe('actingAs-not-in-game')
+	})
+
+	it('un-eliminates target when reason is missed_rebuy_pick and sets unEliminated=true', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue(CLASSIC_GAME_ADMIN as never)
+		vi.mocked(db.query.gamePlayer.findFirst)
+			.mockResolvedValueOnce({ id: 'gp-self', userId: 'u-admin', status: 'alive' } as never)
+			.mockResolvedValueOnce({
+				id: 'gp-target',
+				userId: 'u-target',
+				gameId: 'g1',
+				status: 'alive', // validation needs alive — the admin's pick implicitly rebuys
+				eliminatedReason: 'missed_rebuy_pick',
+				eliminatedRoundId: 'r-prev',
+			} as never)
+		vi.mocked(db.query.round.findFirst).mockResolvedValue(OPEN_ROUND_FAR_FUTURE as never)
+		vi.mocked(db.query.pick.findMany).mockResolvedValue([] as never)
+		mockDeleteChain()
+		mockInsertReturning([{ id: 'p-new', teamId: 't-home' }])
+		const { chain, setChain } = mockUpdateChain()
+
+		const res = await POST(makeReq({ teamId: 't-home', actingAs: 'gp-target' }), params)
+		expect(res.status).toBe(201)
+		const body = await res.json()
+		expect(body.unEliminated).toBe(true)
+		expect(body.id).toBe('p-new')
+		// Verify we wrote the un-elimination update
+		expect(chain.set).toHaveBeenCalledWith({
+			status: 'alive',
+			eliminatedReason: null,
+			eliminatedRoundId: null,
+		})
+		expect(setChain.where).toHaveBeenCalled()
+	})
+
+	it('does not un-eliminate when reason is not missed_rebuy_pick (unEliminated=false)', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue(CLASSIC_GAME_ADMIN as never)
+		vi.mocked(db.query.gamePlayer.findFirst)
+			.mockResolvedValueOnce({ id: 'gp-self', userId: 'u-admin', status: 'alive' } as never)
+			.mockResolvedValueOnce({
+				id: 'gp-target',
+				userId: 'u-target',
+				gameId: 'g1',
+				status: 'alive',
+				eliminatedReason: 'loss',
+			} as never)
+		vi.mocked(db.query.round.findFirst).mockResolvedValue(OPEN_ROUND_FAR_FUTURE as never)
+		vi.mocked(db.query.pick.findMany).mockResolvedValue([] as never)
+		mockDeleteChain()
+		mockInsertReturning([{ id: 'p-new', teamId: 't-home' }])
+
+		const res = await POST(makeReq({ teamId: 't-home', actingAs: 'gp-target' }), params)
+		expect(res.status).toBe(201)
+		const body = await res.json()
+		expect(body.unEliminated).toBe(false)
+		expect(body.id).toBe('p-new')
+		// No un-elimination update should have been invoked
+		expect(db.update).not.toHaveBeenCalled()
+	})
+})

--- a/src/app/api/picks/[gameId]/[roundId]/route.test.ts
+++ b/src/app/api/picks/[gameId]/[roundId]/route.test.ts
@@ -132,7 +132,10 @@ describe('POST /api/picks/[gameId]/[roundId] — actingAs + un-elimination', () 
 				id: 'gp-target',
 				userId: 'u-target',
 				gameId: 'g1',
-				status: 'alive', // validation needs alive — the admin's pick implicitly rebuys
+				// Real post-deadline-lock state: player was eliminated for missing
+				// the rebuy deadline. Admin acting-as with allowEliminatedRebuy
+				// bypasses the "not alive" validator gate so maybeUnEliminate can run.
+				status: 'eliminated',
 				eliminatedReason: 'missed_rebuy_pick',
 				eliminatedRoundId: 'r-prev',
 			} as never)

--- a/src/app/api/picks/[gameId]/[roundId]/route.ts
+++ b/src/app/api/picks/[gameId]/[roundId]/route.ts
@@ -25,7 +25,11 @@ export async function GET(_request: Request, { params }: { params: Params }) {
 export async function POST(request: Request, { params }: { params: Params }) {
 	const session = await requireSession()
 	const { gameId, roundId } = await params
-	const body = await request.json()
+	const body = (await request.json()) as {
+		teamId?: string
+		picks?: unknown[]
+		actingAs?: string
+	}
 
 	// Get game and player
 	const gameData = await db.query.game.findFirst({
@@ -36,10 +40,27 @@ export async function POST(request: Request, { params }: { params: Params }) {
 		return NextResponse.json({ error: 'Game not found' }, { status: 404 })
 	}
 
-	const player = await db.query.gamePlayer.findFirst({
+	// Resolve target player. Default is the session user's own gamePlayer, but
+	// admins can pick on behalf of another player via `actingAs` (Phase 4c2).
+	let targetGamePlayer = await db.query.gamePlayer.findFirst({
 		where: and(eq(gamePlayer.gameId, gameId), eq(gamePlayer.userId, session.user.id)),
 	})
-	if (!player) {
+
+	if (body.actingAs) {
+		// Admin is picking for another player.
+		if (gameData.createdBy !== session.user.id) {
+			return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+		}
+		const actingAsPlayer = await db.query.gamePlayer.findFirst({
+			where: and(eq(gamePlayer.id, body.actingAs), eq(gamePlayer.gameId, gameId)),
+		})
+		if (!actingAsPlayer) {
+			return NextResponse.json({ error: 'actingAs-not-in-game' }, { status: 404 })
+		}
+		targetGamePlayer = actingAsPlayer
+	}
+
+	if (!targetGamePlayer) {
 		return NextResponse.json({ error: 'Not a member of this game' }, { status: 403 })
 	}
 
@@ -54,12 +75,26 @@ export async function POST(request: Request, { params }: { params: Params }) {
 
 	const now = new Date()
 
-	if (gameData.gameMode === 'classic') {
-		const { teamId } = body
+	// Shared helper: after a successful pick write, if the admin was acting-as
+	// a player who was eliminated via `missed_rebuy_pick`, flip them back to
+	// alive (Phase 4c2 rule 1: rebuy is implicit on first admin pick).
+	async function maybeUnEliminate(): Promise<boolean> {
+		if (!body.actingAs) return false
+		if (!targetGamePlayer) return false
+		if (targetGamePlayer.eliminatedReason !== 'missed_rebuy_pick') return false
+		await db
+			.update(gamePlayer)
+			.set({ status: 'alive', eliminatedReason: null, eliminatedRoundId: null })
+			.where(eq(gamePlayer.id, targetGamePlayer.id))
+		return true
+	}
 
-		// Get previously used teams
+	if (gameData.gameMode === 'classic') {
+		const { teamId } = body as { teamId: string }
+
+		// Get previously used teams (for the TARGET player, not the admin)
 		const previousPicks = await db.query.pick.findMany({
-			where: and(eq(pick.gamePlayerId, player.id), eq(pick.gameId, gameId)),
+			where: and(eq(pick.gamePlayerId, targetGamePlayer.id), eq(pick.gameId, gameId)),
 		})
 		const usedTeamIds = previousPicks.filter((p) => p.roundId !== roundId).map((p) => p.teamId)
 
@@ -67,7 +102,7 @@ export async function POST(request: Request, { params }: { params: Params }) {
 
 		const validation = validateClassicPick({
 			teamId,
-			playerStatus: player.status,
+			playerStatus: targetGamePlayer.status,
 			roundStatus: roundData.status,
 			deadline: roundData.deadline,
 			now,
@@ -133,22 +168,28 @@ export async function POST(request: Request, { params }: { params: Params }) {
 			.insert(pick)
 			.values({
 				gameId,
-				gamePlayerId: player.id,
+				gamePlayerId: targetGamePlayer.id,
 				roundId,
 				teamId,
 				fixtureId: teamFixture?.id,
 			})
 			.returning()
 
-		return NextResponse.json(newPick, { status: 201 })
+		const unEliminated = await maybeUnEliminate()
+
+		return NextResponse.json({ ...newPick, unEliminated }, { status: 201 })
 	}
 
 	// Turbo and Cup modes
-	const { picks: pickEntries } = body
+	const pickEntries = (body.picks ?? []) as Array<{
+		fixtureId: string
+		confidenceRank: number
+		predictedResult: 'home_win' | 'draw' | 'away_win'
+	}>
 	const numberOfPicks = (gameData.modeConfig as { numberOfPicks?: number })?.numberOfPicks ?? 10
 
 	const validation = validateTurboPicks({
-		playerStatus: player.status,
+		playerStatus: targetGamePlayer.status,
 		roundStatus: roundData.status,
 		deadline: roundData.deadline,
 		now,
@@ -190,9 +231,9 @@ export async function POST(request: Request, { params }: { params: Params }) {
 		}
 	}
 
-	// Delete existing picks for this round, then insert new ones
+	// Delete existing picks for this round (for the TARGET player), then insert new ones
 	const existingPicks = await db.query.pick.findMany({
-		where: and(eq(pick.gamePlayerId, player.id), eq(pick.roundId, roundId)),
+		where: and(eq(pick.gamePlayerId, targetGamePlayer.id), eq(pick.roundId, roundId)),
 	})
 	if (existingPicks.length > 0) {
 		const existingIds = existingPicks.map((p) => p.id)
@@ -214,7 +255,7 @@ export async function POST(request: Request, { params }: { params: Params }) {
 					const teamId = entry.predictedResult === 'away_win' ? fx.awayTeamId : fx.homeTeamId
 					return {
 						gameId,
-						gamePlayerId: player.id,
+						gamePlayerId: targetGamePlayer!.id,
 						roundId,
 						teamId,
 						fixtureId: entry.fixtureId,
@@ -226,5 +267,7 @@ export async function POST(request: Request, { params }: { params: Params }) {
 		)
 		.returning()
 
-	return NextResponse.json(newPicks, { status: 201 })
+	const unEliminated = await maybeUnEliminate()
+
+	return NextResponse.json({ picks: newPicks, unEliminated }, { status: 201 })
 }

--- a/src/app/api/picks/[gameId]/[roundId]/route.ts
+++ b/src/app/api/picks/[gameId]/[roundId]/route.ts
@@ -100,15 +100,22 @@ export async function POST(request: Request, { params }: { params: Params }) {
 
 		const fixtureTeamIds = roundData.fixtures.flatMap((f) => [f.homeTeamId, f.awayTeamId])
 
-		const validation = validateClassicPick({
-			teamId,
-			playerStatus: targetGamePlayer.status,
-			roundStatus: roundData.status,
-			deadline: roundData.deadline,
-			now,
-			usedTeamIds,
-			fixtureTeamIds,
-		})
+		const allowEliminatedRebuy = Boolean(
+			body.actingAs && targetGamePlayer.eliminatedReason === 'missed_rebuy_pick',
+		)
+
+		const validation = validateClassicPick(
+			{
+				teamId,
+				playerStatus: targetGamePlayer.status,
+				roundStatus: roundData.status,
+				deadline: roundData.deadline,
+				now,
+				usedTeamIds,
+				fixtureTeamIds,
+			},
+			{ allowEliminatedRebuy },
+		)
 
 		if (!validation.valid) {
 			return NextResponse.json({ error: validation.reason }, { status: 400 })
@@ -188,15 +195,22 @@ export async function POST(request: Request, { params }: { params: Params }) {
 	}>
 	const numberOfPicks = (gameData.modeConfig as { numberOfPicks?: number })?.numberOfPicks ?? 10
 
-	const validation = validateTurboPicks({
-		playerStatus: targetGamePlayer.status,
-		roundStatus: roundData.status,
-		deadline: roundData.deadline,
-		now,
-		numberOfPicks,
-		fixtureIds: roundData.fixtures.map((f) => f.id),
-		picks: pickEntries,
-	})
+	const allowEliminatedRebuyMulti = Boolean(
+		body.actingAs && targetGamePlayer.eliminatedReason === 'missed_rebuy_pick',
+	)
+
+	const validation = validateTurboPicks(
+		{
+			playerStatus: targetGamePlayer.status,
+			roundStatus: roundData.status,
+			deadline: roundData.deadline,
+			now,
+			numberOfPicks,
+			fixtureIds: roundData.fixtures.map((f) => f.id),
+			picks: pickEntries,
+		},
+		{ allowEliminatedRebuy: allowEliminatedRebuyMulti },
+	)
 
 	if (!validation.valid) {
 		return NextResponse.json({ error: validation.reason }, { status: 400 })

--- a/src/app/api/users/search/route.test.ts
+++ b/src/app/api/users/search/route.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/auth-helpers', () => ({
+	requireSession: vi.fn(),
+}))
+vi.mock('@/lib/db', () => ({
+	db: {
+		select: vi.fn(),
+	},
+}))
+
+import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { GET } from './route'
+
+describe('GET /api/users/search', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.mocked(requireSession).mockResolvedValue({ user: { id: 'u-me' } } as never)
+	})
+
+	it('returns [] for empty query', async () => {
+		const req = new Request('http://localhost/api/users/search?q=')
+		const res = await GET(req)
+		expect(res.status).toBe(200)
+		expect(await res.json()).toEqual({ users: [] })
+	})
+
+	it('returns matching users limited to 10', async () => {
+		const mockUsers = Array.from({ length: 15 }, (_, i) => ({
+			id: `u-${i}`,
+			name: `User ${i}`,
+			email: `u${i}@example.com`,
+		}))
+		const selectChain = {
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockReturnValue({
+					limit: vi.fn().mockResolvedValue(mockUsers.slice(0, 10)),
+				}),
+			}),
+		}
+		vi.mocked(db.select).mockReturnValue(selectChain as never)
+
+		const req = new Request('http://localhost/api/users/search?q=user')
+		const res = await GET(req)
+		expect(res.status).toBe(200)
+		const body = await res.json()
+		expect(body.users).toHaveLength(10)
+	})
+})

--- a/src/app/api/users/search/route.ts
+++ b/src/app/api/users/search/route.ts
@@ -1,0 +1,24 @@
+import { or, sql } from 'drizzle-orm'
+import { NextResponse } from 'next/server'
+import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { user } from '@/lib/schema/auth'
+
+export async function GET(request: Request): Promise<Response> {
+	await requireSession()
+
+	const { searchParams } = new URL(request.url)
+	const q = (searchParams.get('q') ?? '').trim()
+	if (q.length === 0) {
+		return NextResponse.json({ users: [] })
+	}
+
+	const pattern = `${q.toLowerCase()}%`
+	const results = await db
+		.select({ id: user.id, name: user.name, email: user.email })
+		.from(user)
+		.where(or(sql`lower(${user.name}) like ${pattern}`, sql`lower(${user.email}) like ${pattern}`))
+		.limit(10)
+
+	return NextResponse.json({ users: results })
+}

--- a/src/components/game/acting-as-banner.tsx
+++ b/src/components/game/acting-as-banner.tsx
@@ -1,0 +1,36 @@
+'use client'
+import { useRouter } from 'next/navigation'
+
+interface ActingAsBannerProps {
+	gameId: string
+	targetUserName: string
+	targetAvatarInitials: string
+}
+
+export function ActingAsBanner({
+	gameId,
+	targetUserName,
+	targetAvatarInitials,
+}: ActingAsBannerProps) {
+	const router = useRouter()
+	return (
+		<div className="mx-4 mt-3 flex items-center gap-3 rounded-lg bg-primary px-4 py-3 text-primary-foreground">
+			<span className="flex h-7 w-7 items-center justify-center rounded-full bg-black/25 text-[11px] font-bold">
+				{targetAvatarInitials}
+			</span>
+			<div className="flex flex-col">
+				<span className="text-[10px] font-black uppercase tracking-wider opacity-85">
+					Admin mode
+				</span>
+				<span className="text-sm font-semibold">You're picking for {targetUserName}</span>
+			</div>
+			<button
+				type="button"
+				onClick={() => router.push(`/game/${gameId}`)}
+				className="ml-auto rounded-md bg-black/25 px-2.5 py-1.5 text-[11px] font-semibold text-primary-foreground"
+			>
+				Exit admin mode
+			</button>
+		</div>
+	)
+}

--- a/src/components/game/add-player-modal.tsx
+++ b/src/components/game/add-player-modal.tsx
@@ -1,0 +1,185 @@
+'use client'
+import { useRouter } from 'next/navigation'
+import { useEffect, useRef, useState } from 'react'
+import { cn } from '@/lib/utils'
+
+interface UserRow {
+	id: string
+	name: string
+	email: string
+}
+
+interface AddPlayerModalProps {
+	gameId: string
+	onClose: () => void
+}
+
+interface AddedState {
+	gamePlayerId: string
+	userName: string
+}
+
+export function AddPlayerModal({ gameId, onClose }: AddPlayerModalProps) {
+	const router = useRouter()
+	const [query, setQuery] = useState('')
+	const [results, setResults] = useState<UserRow[]>([])
+	const [selectedId, setSelectedId] = useState<string | null>(null)
+	const [error, setError] = useState<string | null>(null)
+	const [submitting, setSubmitting] = useState(false)
+	const [added, setAdded] = useState<AddedState | null>(null)
+	const inputRef = useRef<HTMLInputElement>(null)
+
+	useEffect(() => {
+		inputRef.current?.focus()
+	}, [])
+
+	useEffect(() => {
+		if (added) return
+		if (query.trim().length === 0) {
+			setResults([])
+			return
+		}
+		const timer = setTimeout(async () => {
+			const res = await fetch(`/api/users/search?q=${encodeURIComponent(query)}`)
+			if (!res.ok) return
+			const body = (await res.json()) as { users: UserRow[] }
+			setResults(body.users)
+		}, 200)
+		return () => clearTimeout(timer)
+	}, [query, added])
+
+	const selected = results.find((u) => u.id === selectedId) ?? null
+
+	async function handleAdd() {
+		if (!selected || submitting) return
+		setSubmitting(true)
+		setError(null)
+		try {
+			const res = await fetch(`/api/games/${gameId}/admin/add-player`, {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ userId: selected.id }),
+			})
+			const body = await res.json()
+			if (!res.ok) {
+				setError(body.error ?? 'failed-to-add')
+				return
+			}
+			setAdded({ gamePlayerId: body.gamePlayer.id, userName: selected.name })
+		} finally {
+			setSubmitting(false)
+		}
+	}
+
+	function handleGoToPick() {
+		if (!added) return
+		router.push(`/game/${gameId}/pick?actingAs=${added.gamePlayerId}`)
+	}
+
+	function handleBackToGame() {
+		onClose()
+		router.refresh()
+	}
+
+	return (
+		// biome-ignore lint/a11y/useKeyWithClickEvents: backdrop click-to-close; Escape handling delegated to dialog close button
+		// biome-ignore lint/a11y/noStaticElementInteractions: backdrop is a dialog scrim, not an interactive control
+		<div
+			role="dialog"
+			aria-modal="true"
+			className="fixed inset-0 z-50 flex items-center justify-center bg-black/65"
+			onClick={onClose}
+		>
+			{/* biome-ignore lint/a11y/useKeyWithClickEvents: stopPropagation on container prevents backdrop-close, not a user-facing interaction */}
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: inner panel is non-interactive — intercepts bubbling clicks only */}
+			<div
+				onClick={(e) => e.stopPropagation()}
+				className="w-[340px] rounded-lg border border-border bg-background p-5 shadow-2xl"
+			>
+				{added ? (
+					<>
+						<h3 className="text-[15px] font-bold">{added.userName} added</h3>
+						<p className="mb-4 mt-1 text-xs text-muted-foreground">
+							Pick for them now, or come back later.
+						</p>
+						<div className="flex justify-end gap-2">
+							<button
+								type="button"
+								onClick={handleBackToGame}
+								className="rounded-md border border-border bg-transparent px-3 py-1.5 text-xs font-semibold text-muted-foreground"
+							>
+								Back to game
+							</button>
+							<button
+								type="button"
+								onClick={handleGoToPick}
+								className="rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground"
+							>
+								Pick for {added.userName}
+							</button>
+						</div>
+					</>
+				) : (
+					<>
+						<h3 className="text-[15px] font-bold">Add player to this game</h3>
+						<p className="mb-3 mt-1 text-xs text-muted-foreground">
+							Search an existing user by name or email.
+						</p>
+						<input
+							ref={inputRef}
+							value={query}
+							onChange={(e) => setQuery(e.target.value)}
+							placeholder="name or email…"
+							className="w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none"
+						/>
+						<div className="mt-2 max-h-[180px] overflow-y-auto">
+							{results.map((u) => (
+								<button
+									type="button"
+									key={u.id}
+									onClick={() => setSelectedId(u.id)}
+									className={cn(
+										'mb-0.5 flex w-full items-center gap-2 rounded-md border border-transparent px-2 py-1.5 text-left text-sm',
+										selectedId === u.id && 'border-primary bg-primary/10',
+										selectedId !== u.id && 'hover:bg-card hover:border-border',
+									)}
+								>
+									<span className="flex-1">
+										<span className="block font-semibold">{u.name}</span>
+										<span className="block text-[11px] text-muted-foreground">{u.email}</span>
+									</span>
+								</button>
+							))}
+						</div>
+						{error === 'already-in-game' && (
+							<p className="mt-2 text-xs text-amber-600">That user is already in this game.</p>
+						)}
+						{error && error !== 'already-in-game' && (
+							<p className="mt-2 text-xs text-red-500">Couldn't add: {error}</p>
+						)}
+						<p className="mt-3 rounded-l-sm border-l-2 border-primary bg-primary/10 px-2 py-2 text-[11px] text-muted-foreground">
+							Can't find someone? Ask them to sign up first.
+						</p>
+						<div className="mt-4 flex justify-end gap-2">
+							<button
+								type="button"
+								onClick={onClose}
+								className="rounded-md border border-border bg-transparent px-3 py-1.5 text-xs font-semibold text-muted-foreground"
+							>
+								Cancel
+							</button>
+							<button
+								type="button"
+								onClick={handleAdd}
+								disabled={!selected || submitting}
+								className="rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground disabled:opacity-50"
+							>
+								{selected ? `Add ${selected.name}` : 'Add'}
+							</button>
+						</div>
+					</>
+				)}
+			</div>
+		</div>
+	)
+}

--- a/src/components/game/add-player-modal.tsx
+++ b/src/components/game/add-player-modal.tsx
@@ -73,7 +73,7 @@ export function AddPlayerModal({ gameId, onClose }: AddPlayerModalProps) {
 
 	function handleGoToPick() {
 		if (!added) return
-		router.push(`/game/${gameId}/pick?actingAs=${added.gamePlayerId}`)
+		router.push(`/game/${gameId}?actingAs=${added.gamePlayerId}`)
 	}
 
 	function handleBackToGame() {

--- a/src/components/game/admin-panel.tsx
+++ b/src/components/game/admin-panel.tsx
@@ -1,0 +1,53 @@
+'use client'
+import { useState } from 'react'
+import { AddPlayerModal } from './add-player-modal'
+import { SplitPotModal } from './split-pot-modal'
+
+interface AdminPanelProps {
+	gameId: string
+	aliveCount: number
+	potTotal: string
+}
+
+export function AdminPanel({ gameId, aliveCount, potTotal }: AdminPanelProps) {
+	const [openModal, setOpenModal] = useState<'add' | 'split' | null>(null)
+
+	return (
+		<>
+			<div className="rounded-xl border border-border bg-card p-4">
+				<div className="mb-3 flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-muted-foreground">
+					<span className="rounded-sm bg-primary px-1.5 py-0.5 text-[9px] text-primary-foreground">
+						Admin
+					</span>
+					Game actions
+				</div>
+				<div className="flex flex-wrap gap-2">
+					<button
+						type="button"
+						onClick={() => setOpenModal('add')}
+						className="rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground hover:opacity-90"
+					>
+						+ Add player
+					</button>
+					<button
+						type="button"
+						onClick={() => setOpenModal('split')}
+						disabled={aliveCount < 2}
+						className="rounded-md border border-border bg-background px-3 py-1.5 text-xs font-semibold text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+					>
+						Split pot ({aliveCount} alive)
+					</button>
+				</div>
+			</div>
+			{openModal === 'add' && <AddPlayerModal gameId={gameId} onClose={() => setOpenModal(null)} />}
+			{openModal === 'split' && (
+				<SplitPotModal
+					gameId={gameId}
+					aliveCount={aliveCount}
+					potTotal={potTotal}
+					onClose={() => setOpenModal(null)}
+				/>
+			)}
+		</>
+	)
+}

--- a/src/components/game/auto-pick-banner.tsx
+++ b/src/components/game/auto-pick-banner.tsx
@@ -1,0 +1,68 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+const STORAGE_KEY = 'dismissedAutoPicks'
+
+interface AutoPickBannerProps {
+	pickId: string
+	teamShortName: string
+	kickoffLabel: string
+}
+
+function getDismissed(): string[] {
+	if (typeof window === 'undefined') return []
+	try {
+		const raw = window.localStorage.getItem(STORAGE_KEY)
+		return raw ? (JSON.parse(raw) as string[]) : []
+	} catch {
+		return []
+	}
+}
+
+function persistDismissed(ids: string[]) {
+	window.localStorage.setItem(STORAGE_KEY, JSON.stringify(ids))
+}
+
+export function AutoPickBanner({ pickId, teamShortName, kickoffLabel }: AutoPickBannerProps) {
+	const [dismissed, setDismissed] = useState(false)
+	const [mounted, setMounted] = useState(false)
+
+	useEffect(() => {
+		setMounted(true)
+		if (getDismissed().includes(pickId)) {
+			setDismissed(true)
+		}
+	}, [pickId])
+
+	if (!mounted || dismissed) return null
+
+	function handleDismiss() {
+		const ids = getDismissed()
+		if (!ids.includes(pickId)) {
+			ids.push(pickId)
+			persistDismissed(ids)
+		}
+		setDismissed(true)
+	}
+
+	return (
+		<div className="mx-4 my-3 flex items-start gap-3 rounded-lg border border-amber-500/50 bg-card p-3">
+			<span className="text-lg text-amber-500">⚠</span>
+			<div className="flex-1">
+				<h4 className="text-xs font-bold">You missed the deadline</h4>
+				<p className="mt-0.5 text-[11px] text-muted-foreground">
+					We auto-picked {teamShortName} for you — the lowest-ranked team you hadn't used. Kickoff
+					is {kickoffLabel}. Message the admin if you want to swap.
+				</p>
+			</div>
+			<button
+				type="button"
+				onClick={handleDismiss}
+				className="text-sm text-muted-foreground"
+				aria-label="Dismiss"
+			>
+				✕
+			</button>
+		</div>
+	)
+}

--- a/src/components/game/game-detail-view.tsx
+++ b/src/components/game/game-detail-view.tsx
@@ -2,6 +2,8 @@
 
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
+import { AdminPanel } from '@/components/game/admin-panel'
+import { AutoPickBanner } from '@/components/game/auto-pick-banner'
 import { GameHeader } from '@/components/game/game-header'
 import { MyPaymentStrip } from '@/components/game/my-payment-strip'
 import { OtherPlayersPayments } from '@/components/game/other-players-payments'
@@ -35,6 +37,12 @@ interface GameDetailViewProps {
 		myPayment: { status: PaymentStatus; amount: string } | null
 		otherPayments: Array<{ userName: string; status: PaymentStatus; isRebuy: boolean }>
 		adminPayments: AdminPayment[] | undefined
+		myCurrentRoundPick: {
+			id: string
+			isAuto: boolean
+			teamShortName: string
+			kickoffLabel: string
+		} | null
 	}
 	pickSection: React.ReactNode
 	classicGrid?: {
@@ -68,6 +76,14 @@ export function GameDetailView({
 		<LiveProvider gameId={game.id}>
 			<div>
 				<LiveScoreTicker />
+
+				{game.myCurrentRoundPick?.isAuto && (
+					<AutoPickBanner
+						pickId={game.myCurrentRoundPick.id}
+						teamShortName={game.myCurrentRoundPick.teamShortName}
+						kickoffLabel={game.myCurrentRoundPick.kickoffLabel}
+					/>
+				)}
 
 				<GameHeader
 					name={game.name}
@@ -134,6 +150,12 @@ export function GameDetailView({
 						showAdminActions={game.isAdmin}
 						gameId={game.id}
 					/>
+				)}
+
+				{game.isAdmin && (
+					<div className="mt-6">
+						<AdminPanel gameId={game.id} aliveCount={game.aliveCount} potTotal={game.pot.total} />
+					</div>
 				)}
 
 				{game.isAdmin && game.adminPayments && game.adminPayments.length > 0 && (

--- a/src/components/game/game-detail-view.tsx
+++ b/src/components/game/game-detail-view.tsx
@@ -113,6 +113,7 @@ export function GameDetailView({
 						pot={classicGrid.pot}
 						gameId={game.id}
 						onShare={() => setShareOpen(true)}
+						showAdminActions={game.isAdmin}
 					/>
 				)}
 
@@ -121,10 +122,19 @@ export function GameDetailView({
 						rounds={turboStandings.rounds}
 						numberOfPicks={turboStandings.numberOfPicks}
 						onShare={() => setShareOpen(true)}
+						showAdminActions={game.isAdmin}
+						gameId={game.id}
 					/>
 				)}
 
-				{cupStandings && <CupStandings data={cupStandings} onShare={() => setShareOpen(true)} />}
+				{cupStandings && (
+					<CupStandings
+						data={cupStandings}
+						onShare={() => setShareOpen(true)}
+						showAdminActions={game.isAdmin}
+						gameId={game.id}
+					/>
+				)}
 
 				{game.isAdmin && game.adminPayments && game.adminPayments.length > 0 && (
 					<div className="mt-6">

--- a/src/components/game/split-pot-modal.tsx
+++ b/src/components/game/split-pot-modal.tsx
@@ -1,0 +1,93 @@
+'use client'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+
+interface SplitPotModalProps {
+	gameId: string
+	aliveCount: number
+	potTotal: string
+	onClose: () => void
+}
+
+export function SplitPotModal({ gameId, aliveCount, potTotal, onClose }: SplitPotModalProps) {
+	const router = useRouter()
+	const [submitting, setSubmitting] = useState(false)
+	const [error, setError] = useState<string | null>(null)
+
+	const totalNum = Number(potTotal)
+	const perWinner = aliveCount > 0 ? (totalNum / aliveCount).toFixed(2) : '0.00'
+
+	async function handleConfirm() {
+		if (submitting) return
+		setSubmitting(true)
+		setError(null)
+		try {
+			const res = await fetch(`/api/games/${gameId}/admin/split-pot`, {
+				method: 'POST',
+			})
+			const body = await res.json()
+			if (!res.ok) {
+				setError(body.error ?? 'failed')
+				return
+			}
+			onClose()
+			router.refresh()
+		} finally {
+			setSubmitting(false)
+		}
+	}
+
+	return (
+		// biome-ignore lint/a11y/useKeyWithClickEvents: backdrop click-to-close; Escape handling delegated to dialog close button
+		// biome-ignore lint/a11y/noStaticElementInteractions: backdrop is a dialog scrim, not an interactive control
+		<div
+			role="dialog"
+			aria-modal="true"
+			className="fixed inset-0 z-50 flex items-center justify-center bg-black/65"
+			onClick={onClose}
+		>
+			{/* biome-ignore lint/a11y/useKeyWithClickEvents: stopPropagation on container prevents backdrop-close, not a user-facing interaction */}
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: inner panel is non-interactive — intercepts bubbling clicks only */}
+			<div
+				onClick={(e) => e.stopPropagation()}
+				className="w-[360px] rounded-lg border border-border bg-background p-5 shadow-2xl"
+			>
+				<h3 className="text-[15px] font-bold">Split the pot now?</h3>
+				<p className="mb-4 mt-1 text-xs text-muted-foreground">
+					This ends the game immediately. All {aliveCount} alive players are marked as winners.
+					Eliminated players get nothing.
+				</p>
+				<div className="mb-4 rounded-md border border-border bg-card p-3 text-center">
+					<div className="text-xl font-extrabold tabular-nums text-emerald-500">
+						£{perWinner} each
+					</div>
+					<div className="mt-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+						£{potTotal} split {aliveCount} ways
+					</div>
+				</div>
+				<p className="mb-4 rounded-r-sm border-l-2 border-amber-500 bg-amber-500/10 px-2 py-2 text-[11px] text-amber-500">
+					⚠ This can't be undone. Game status becomes "completed".
+				</p>
+				{error && <p className="mb-3 text-xs text-red-500">Couldn't split: {error}</p>}
+				<div className="flex justify-end gap-2">
+					<button
+						type="button"
+						onClick={onClose}
+						disabled={submitting}
+						className="rounded-md border border-border bg-transparent px-3 py-1.5 text-xs font-semibold text-muted-foreground"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						onClick={handleConfirm}
+						disabled={submitting || aliveCount < 2}
+						className="rounded-md bg-emerald-500 px-3 py-1.5 text-xs font-bold text-white disabled:opacity-50"
+					>
+						Split £{potTotal} across {aliveCount} winners
+					</button>
+				</div>
+			</div>
+		</div>
+	)
+}

--- a/src/components/picks/classic-pick.tsx
+++ b/src/components/picks/classic-pick.tsx
@@ -35,6 +35,8 @@ interface ClassicPickProps {
 	chain?: { slots: ChainSlot[]; summary: ChainSummary }
 	futureRounds?: PlannerRoundInput[]
 	planHandlers?: ClassicPickPlanHandlers
+	/** When set, the admin is picking on behalf of this player. */
+	actingAs?: { gamePlayerId: string; userName: string }
 }
 
 export function ClassicPick({
@@ -48,6 +50,7 @@ export function ClassicPick({
 	chain,
 	futureRounds,
 	planHandlers,
+	actingAs,
 }: ClassicPickProps) {
 	const router = useRouter()
 	const [selectedTeamId, setSelectedTeamId] = useState<string | null>(existingPickTeamId)
@@ -70,7 +73,10 @@ export function ClassicPick({
 		const res = await fetch(`/api/picks/${gameId}/${roundId}`, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ teamId: selectedTeamId }),
+			body: JSON.stringify({
+				teamId: selectedTeamId,
+				...(actingAs ? { actingAs: actingAs.gamePlayerId } : {}),
+			}),
 		})
 		setLoading(false)
 		if (!res.ok) {
@@ -199,7 +205,13 @@ export function ClassicPick({
 						message={`Picking ${selectedTeam.name} vs ${
 							selectedSide === 'home' ? selectedFixture.away.name : selectedFixture.home.name
 						} (${selectedSide === 'home' ? 'H' : 'A'})`}
-						actionLabel={existingPickTeamId === selectedTeamId ? 'Already locked' : 'Lock in pick'}
+						actionLabel={
+							existingPickTeamId === selectedTeamId
+								? 'Already locked'
+								: actingAs
+									? `Submit as ${actingAs.userName}`
+									: 'Lock in pick'
+						}
 						onConfirm={handleSubmit}
 						disabled={existingPickTeamId === selectedTeamId}
 						loading={loading}

--- a/src/components/picks/cup-pick-form.tsx
+++ b/src/components/picks/cup-pick-form.tsx
@@ -13,6 +13,8 @@ interface CupPickFormProps {
 	initialSlots: CupPickSlot[]
 	deadline: Date | null
 	readonly?: boolean
+	/** When set, the admin is picking on behalf of this player. */
+	actingAs?: { gamePlayerId: string; userName: string }
 }
 
 export function CupPickForm({
@@ -25,6 +27,7 @@ export function CupPickForm({
 	initialSlots,
 	deadline,
 	readonly,
+	actingAs,
 }: CupPickFormProps) {
 	const router = useRouter()
 
@@ -38,6 +41,7 @@ export function CupPickForm({
 					confidenceRank: s.confidenceRank,
 					predictedResult: s.pickedSide === 'home' ? 'home_win' : 'away_win',
 				})),
+				...(actingAs ? { actingAs: actingAs.gamePlayerId } : {}),
 			}),
 		})
 		if (!res.ok) {
@@ -59,6 +63,7 @@ export function CupPickForm({
 			onSubmit={handleSubmit}
 			deadline={deadline}
 			readonly={readonly}
+			submitLabelOverride={actingAs ? `Submit as ${actingAs.userName}` : undefined}
 		/>
 	)
 }

--- a/src/components/picks/cup-pick.tsx
+++ b/src/components/picks/cup-pick.tsx
@@ -43,6 +43,8 @@ interface CupPickProps {
 	onSubmit: (slots: CupPickSlot[]) => Promise<void>
 	deadline?: Date | null
 	readonly?: boolean
+	/** When set (e.g. "Submit as Rachel" for admin acting-as), overrides the default submit label. */
+	submitLabelOverride?: string
 }
 
 function tierForDisplay(fixture: CupPickFixture): { value: number; plusN: number; heart: boolean } {
@@ -121,6 +123,7 @@ export function CupPick({
 	onSubmit,
 	deadline,
 	readonly,
+	submitLabelOverride,
 }: CupPickProps) {
 	// Normalise initial slots into rank order (1..N) — defensive against callers passing gaps.
 	const normalisedInitial = useMemo<CupPickSlot[]>(
@@ -289,7 +292,9 @@ export function CupPick({
 						disabled={readonly || slots.length < minPicks || loading}
 						onClick={handleSubmit}
 					>
-						{loading ? 'Submitting...' : `Submit ${slots.length} of ${numberOfPicks} picks`}
+						{loading
+							? 'Submitting...'
+							: (submitLabelOverride ?? `Submit ${slots.length} of ${numberOfPicks} picks`)}
 					</button>
 					{slots.length > 0 && slots.length < minPicks && (
 						<p className="mt-2 text-xs text-muted-foreground">

--- a/src/components/picks/turbo-pick.tsx
+++ b/src/components/picks/turbo-pick.tsx
@@ -42,6 +42,8 @@ interface TurboPickProps {
 	fixtures: TurboPickFixture[]
 	existingPicks: Array<{ fixtureId: string; confidenceRank: number; predictedResult: Prediction }>
 	numberOfPicks: number
+	/** When set, the admin is picking on behalf of this player. */
+	actingAs?: { gamePlayerId: string; userName: string }
 }
 
 function ordinal(n: number): string {
@@ -58,6 +60,7 @@ export function TurboPick({
 	fixtures,
 	existingPicks,
 	numberOfPicks,
+	actingAs,
 }: TurboPickProps) {
 	const router = useRouter()
 
@@ -162,6 +165,7 @@ export function TurboPick({
 					confidenceRank: r.rank,
 					predictedResult: r.prediction,
 				})),
+				...(actingAs ? { actingAs: actingAs.gamePlayerId } : {}),
 			}),
 		})
 		setLoading(false)
@@ -335,7 +339,13 @@ export function TurboPick({
 							? 'Picks submitted — edit any pick to resubmit'
 							: `${ranked.length} of ${numberOfPicks} predictions ranked${isDirty ? ' · unsaved changes' : ''}`
 					}
-					actionLabel={hasSubmittedPicks ? 'Resubmit picks' : 'Lock in picks'}
+					actionLabel={
+						actingAs
+							? `Submit as ${actingAs.userName}`
+							: hasSubmittedPicks
+								? 'Resubmit picks'
+								: 'Lock in picks'
+					}
 					onConfirm={handleSubmit}
 					disabled={ranked.length !== numberOfPicks || (hasSubmittedPicks && !isDirty)}
 					loading={loading}

--- a/src/components/standings/cup-grid.tsx
+++ b/src/components/standings/cup-grid.tsx
@@ -6,6 +6,8 @@ import { cn } from '@/lib/utils'
 
 interface CupGridProps {
 	data: CupStandingsData
+	showAdminActions?: boolean
+	gameId?: string
 }
 
 const LIVE_RECENT_MS = 1500
@@ -17,7 +19,7 @@ interface LiveRowMeta {
 	recentGoalByFixture: Map<string, { side: 'home' | 'away' }>
 }
 
-export function CupGrid({ data }: CupGridProps) {
+export function CupGrid({ data, showAdminActions, gameId }: CupGridProps) {
 	const liveCtx = useLiveGame()
 	const now = Date.now()
 
@@ -96,6 +98,9 @@ export function CupGrid({ data }: CupGridProps) {
 						roundNumber={data.roundNumber}
 						liveMeta={liveMeta}
 						pickFixtureByRank={pickFixtureByPlayer.get(player.id)}
+						showAdminActions={showAdminActions}
+						gameId={gameId}
+						roundStatus={data.roundStatus}
 					/>
 				))}
 				{out.length > 0 && (
@@ -113,6 +118,9 @@ export function CupGrid({ data }: CupGridProps) {
 								roundNumber={data.roundNumber}
 								liveMeta={liveMeta}
 								pickFixtureByRank={pickFixtureByPlayer.get(player.id)}
+								showAdminActions={showAdminActions}
+								gameId={gameId}
+								roundStatus={data.roundStatus}
 								isOut
 							/>
 						))}
@@ -155,6 +163,9 @@ function PlayerRow({
 	roundNumber,
 	liveMeta,
 	pickFixtureByRank,
+	showAdminActions,
+	gameId,
+	roundStatus,
 	isOut,
 }: {
 	player: CupStandingsData['players'][number]
@@ -164,6 +175,9 @@ function PlayerRow({
 	roundNumber: number
 	liveMeta: LiveRowMeta
 	pickFixtureByRank?: Map<number, string>
+	showAdminActions?: boolean
+	gameId?: string
+	roundStatus: CupStandingsData['roundStatus']
 	isOut?: boolean
 }) {
 	const isViewer = liveMeta.viewerGamePlayerId === player.id
@@ -193,6 +207,15 @@ function PlayerRow({
 				{!player.hasSubmitted && <Badge tone="warn">NO PICKS</Badge>}
 				{isOut && <Badge tone="danger">OUT GW{player.eliminatedRoundNumber ?? '?'}</Badge>}
 				{!isOut && liveEliminated && <Badge tone="danger">OUT GW{roundNumber}</Badge>}
+				{showAdminActions && gameId && !isOut && !player.hasSubmitted && roundStatus === 'open' && (
+					<a
+						href={`/game/${gameId}/pick?actingAs=${player.id}`}
+						title={`Pick for ${player.name}`}
+						className="ml-2 inline-flex h-6 w-6 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:border-border hover:bg-muted"
+					>
+						✎
+					</a>
+				)}
 			</div>
 			<LivesCell remaining={player.livesRemaining} max={maxLives} />
 			<div className="text-center font-bold">{player.streak || '—'}</div>

--- a/src/components/standings/cup-grid.tsx
+++ b/src/components/standings/cup-grid.tsx
@@ -209,7 +209,7 @@ function PlayerRow({
 				{!isOut && liveEliminated && <Badge tone="danger">OUT GW{roundNumber}</Badge>}
 				{showAdminActions && gameId && !isOut && !player.hasSubmitted && roundStatus === 'open' && (
 					<a
-						href={`/game/${gameId}/pick?actingAs=${player.id}`}
+						href={`/game/${gameId}?actingAs=${player.id}`}
 						title={`Pick for ${player.name}`}
 						className="ml-2 inline-flex h-6 w-6 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:border-border hover:bg-muted"
 					>

--- a/src/components/standings/cup-ladder.tsx
+++ b/src/components/standings/cup-ladder.tsx
@@ -17,6 +17,12 @@ import { cn } from '@/lib/utils'
 
 interface CupLadderProps {
 	data: CupLadderData
+	// Admin pick-for-player action is rendered on per-player rows. The ladder
+	// view groups players by fixture/backer, so there's no natural row-level
+	// "this player hasn't picked" surface. Deferred — the cup-grid view already
+	// exposes the same ✎ action for cup games.
+	showAdminActions?: boolean
+	gameId?: string
 }
 
 const LIVE_FLASH_MS = 1500

--- a/src/components/standings/cup-standings.tsx
+++ b/src/components/standings/cup-standings.tsx
@@ -13,9 +13,11 @@ type ViewMode = 'ladder' | 'grid' | 'timeline'
 interface CupStandingsProps {
 	data: CupLadderData
 	onShare?: () => void
+	showAdminActions?: boolean
+	gameId?: string
 }
 
-export function CupStandings({ data, onShare }: CupStandingsProps) {
+export function CupStandings({ data, onShare, showAdminActions, gameId }: CupStandingsProps) {
 	const [view, setView] = useState<ViewMode>('ladder')
 	return (
 		<div className="rounded-xl border border-border bg-card overflow-hidden">
@@ -63,8 +65,12 @@ export function CupStandings({ data, onShare }: CupStandingsProps) {
 				</div>
 			</div>
 			<div className="p-4 md:p-5">
-				{view === 'ladder' && <CupLadder data={data} />}
-				{view === 'grid' && <CupGrid data={data} />}
+				{view === 'ladder' && (
+					<CupLadder data={data} showAdminActions={showAdminActions} gameId={gameId} />
+				)}
+				{view === 'grid' && (
+					<CupGrid data={data} showAdminActions={showAdminActions} gameId={gameId} />
+				)}
 				{view === 'timeline' && <CupTimeline data={data} />}
 			</div>
 		</div>

--- a/src/components/standings/progress-grid.tsx
+++ b/src/components/standings/progress-grid.tsx
@@ -42,6 +42,7 @@ export interface GridCell {
 	opponentShortName?: string
 	homeAway?: 'H' | 'A'
 	score?: string
+	isAuto?: boolean
 }
 
 export interface GridPlayer {
@@ -395,7 +396,13 @@ function GridCellView({
 		pending: 'bg-[var(--accent)] text-white',
 	}
 
-	const colour = colours[cell.result] ?? 'bg-muted text-muted-foreground'
+	// Auto-picked pending cells use amber dashed treatment instead of the
+	// normal pending fill, so the viewer can spot "we auto-picked for you"
+	// at a glance before kickoff.
+	const isAutoPending = cell.isAuto && cell.result === 'pending'
+	const colour = isAutoPending
+		? 'border border-dashed border-amber-500 text-amber-500 bg-amber-500/10'
+		: (colours[cell.result] ?? 'bg-muted text-muted-foreground')
 
 	const pickedLabel = cell.teamShortName ?? '?'
 	const opponentLabel = cell.opponentShortName
@@ -418,8 +425,9 @@ function GridCellView({
 						: cell.result === 'saved'
 							? ' — Saved by life'
 							: ' — Pending'
+	const autoPart = cell.isAuto ? ' (auto-pick)' : ''
 	const tooltipLabel = cell.teamShortName
-		? `${cell.teamShortName}${opponentPart}${scorePart}${resultPart} (GW${roundNumber})`
+		? `${cell.teamShortName}${opponentPart}${scorePart}${resultPart}${autoPart} (GW${roundNumber})`
 		: `GW${roundNumber}`
 
 	return (
@@ -436,6 +444,11 @@ function GridCellView({
 					<span>{pickedLabel}</span>
 					{showOpponents && opponentLabel && (
 						<span className="text-[0.55rem] font-normal opacity-80">{opponentLabel}</span>
+					)}
+					{cell.isAuto && (
+						<span className="absolute -right-0.5 -top-0.5 rounded-sm bg-amber-500 px-1 py-0 text-[8px] font-black uppercase tracking-wider text-white leading-none">
+							AUTO
+						</span>
 					)}
 					{bump && <BumpBadge kind={bump} />}
 				</span>

--- a/src/components/standings/progress-grid.tsx
+++ b/src/components/standings/progress-grid.tsx
@@ -61,6 +61,7 @@ interface ProgressGridProps {
 	defaultFilter?: 'all' | 'last5' | 'last3'
 	gameId?: string
 	onShare?: () => void
+	showAdminActions?: boolean
 }
 
 export function ProgressGrid({
@@ -69,7 +70,9 @@ export function ProgressGrid({
 	aliveCount,
 	eliminatedCount,
 	defaultFilter = 'all',
+	gameId,
 	onShare,
+	showAdminActions,
 }: ProgressGridProps) {
 	const [filter, setFilter] = useState<'all' | 'last5' | 'last3'>(defaultFilter)
 	const [showOpponents, setShowOpponents] = useState(false)
@@ -130,6 +133,8 @@ export function ProgressGrid({
 
 	const visibleRounds =
 		filter === 'all' ? rounds : filter === 'last5' ? rounds.slice(-5) : rounds.slice(-3)
+
+	const currentRoundId = rounds.at(-1)?.id
 
 	const sortedPlayers = [...players].sort((a, b) => {
 		if (a.status === 'alive' && b.status !== 'alive') return -1
@@ -252,6 +257,19 @@ export function ProgressGrid({
 													OUT
 												</span>
 											)}
+											{showAdminActions &&
+												gameId &&
+												currentRoundId &&
+												player.status === 'alive' &&
+												player.cellsByRoundId[currentRoundId]?.result === 'no_pick' && (
+													<a
+														href={`/game/${gameId}/pick?actingAs=${player.id}`}
+														title={`Pick for ${player.name}`}
+														className="ml-2 inline-flex h-6 w-6 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:border-border hover:bg-muted"
+													>
+														✎
+													</a>
+												)}
 										</td>
 										{visibleRounds.map((r) => {
 											const cell = player.cellsByRoundId[r.id] ?? { result: 'empty' }

--- a/src/components/standings/progress-grid.tsx
+++ b/src/components/standings/progress-grid.tsx
@@ -264,7 +264,7 @@ export function ProgressGrid({
 												player.status === 'alive' &&
 												player.cellsByRoundId[currentRoundId]?.result === 'no_pick' && (
 													<a
-														href={`/game/${gameId}/pick?actingAs=${player.id}`}
+														href={`/game/${gameId}?actingAs=${player.id}`}
 														title={`Pick for ${player.name}`}
 														className="ml-2 inline-flex h-6 w-6 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:border-border hover:bg-muted"
 													>

--- a/src/components/standings/turbo-standings.tsx
+++ b/src/components/standings/turbo-standings.tsx
@@ -351,7 +351,7 @@ function GridView({
 											!player.hasSubmitted &&
 											roundStatus === 'open' && (
 												<a
-													href={`/game/${gameId}/pick?actingAs=${player.id}`}
+													href={`/game/${gameId}?actingAs=${player.id}`}
 													title={`Pick for ${player.name}`}
 													className="ml-2 inline-flex h-6 w-6 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:border-border hover:bg-muted"
 												>

--- a/src/components/standings/turbo-standings.tsx
+++ b/src/components/standings/turbo-standings.tsx
@@ -52,13 +52,21 @@ interface TurboStandingsProps {
 	rounds: TurboRoundSummary[]
 	numberOfPicks: number
 	onShare?: () => void
+	showAdminActions?: boolean
+	gameId?: string
 }
 
 const _PRED_ABBREV = { home_win: 'H', draw: 'D', away_win: 'A' } as const
 
 type ViewMode = 'ladder' | 'grid' | 'timeline'
 
-export function TurboStandings({ rounds, numberOfPicks, onShare }: TurboStandingsProps) {
+export function TurboStandings({
+	rounds,
+	numberOfPicks,
+	onShare,
+	showAdminActions,
+	gameId,
+}: TurboStandingsProps) {
 	const initial = rounds[rounds.length - 1]?.id
 	const [roundId, setRoundId] = useState<string>(initial ?? '')
 	const [view, setView] = useState<ViewMode>('ladder')
@@ -178,7 +186,14 @@ export function TurboStandings({ rounds, numberOfPicks, onShare }: TurboStanding
 			)}
 
 			{view === 'grid' && (
-				<GridView sortedPlayers={sortedPlayers} numberOfPicks={numberOfPicks} liveMeta={liveMeta} />
+				<GridView
+					sortedPlayers={sortedPlayers}
+					numberOfPicks={numberOfPicks}
+					liveMeta={liveMeta}
+					showAdminActions={showAdminActions}
+					gameId={gameId}
+					roundStatus={round.status}
+				/>
 			)}
 		</div>
 	)
@@ -245,10 +260,16 @@ function GridView({
 	sortedPlayers,
 	numberOfPicks,
 	liveMeta,
+	showAdminActions,
+	gameId,
+	roundStatus,
 }: {
 	sortedPlayers: TurboPlayerRow[]
 	numberOfPicks: number
 	liveMeta: TurboLiveMeta
+	showAdminActions?: boolean
+	gameId?: string
+	roundStatus: TurboRoundSummary['status']
 }) {
 	return (
 		<TooltipProvider delayDuration={100}>
@@ -325,6 +346,18 @@ function GridView({
 												no picks
 											</span>
 										)}
+										{showAdminActions &&
+											gameId &&
+											!player.hasSubmitted &&
+											roundStatus === 'open' && (
+												<a
+													href={`/game/${gameId}/pick?actingAs=${player.id}`}
+													title={`Pick for ${player.name}`}
+													className="ml-2 inline-flex h-6 w-6 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:border-border hover:bg-muted"
+												>
+													✎
+												</a>
+											)}
 									</td>
 									<td className="text-center px-2 py-2 font-display font-semibold text-lg">
 										{player.streak}

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -2,6 +2,17 @@ export interface CompetitionAdapter {
 	fetchTeams(): Promise<AdapterTeam[]>
 	fetchRounds(): Promise<AdapterRound[]>
 	fetchLiveScores(roundNumber: number): Promise<AdapterFixtureScore[]>
+	fetchStandings?(): Promise<AdapterStanding[]>
+}
+
+export interface AdapterStanding {
+	teamExternalId: string
+	position: number
+	played: number
+	won: number
+	drawn: number
+	lost: number
+	points: number
 }
 
 export interface AdapterTeam {

--- a/src/lib/game/auto-pick.test.ts
+++ b/src/lib/game/auto-pick.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import { pickLowestRankedUnusedTeam } from './auto-pick'
+
+interface TestFixture {
+	id: string
+	homeTeamId: string
+	awayTeamId: string
+}
+
+describe('pickLowestRankedUnusedTeam', () => {
+	const fixtures: TestFixture[] = [
+		{ id: 'fx1', homeTeamId: 't-ars', awayTeamId: 't-che' },
+		{ id: 'fx2', homeTeamId: 't-liv', awayTeamId: 't-eve' },
+		{ id: 'fx3', homeTeamId: 't-mci', awayTeamId: 't-wba' },
+	]
+	const positions = new Map([
+		['t-ars', 3],
+		['t-che', 6],
+		['t-liv', 2],
+		['t-eve', 12],
+		['t-mci', 1],
+		['t-wba', 20],
+	])
+
+	it('returns the team with highest league_position (worst rank) when none used', () => {
+		expect(
+			pickLowestRankedUnusedTeam({ fixtures, usedTeamIds: new Set(), teamPositions: positions }),
+		).toBe('t-wba')
+	})
+
+	it('excludes used teams', () => {
+		expect(
+			pickLowestRankedUnusedTeam({
+				fixtures,
+				usedTeamIds: new Set(['t-wba']),
+				teamPositions: positions,
+			}),
+		).toBe('t-eve')
+	})
+
+	it('returns null when all teams in round are used', () => {
+		expect(
+			pickLowestRankedUnusedTeam({
+				fixtures,
+				usedTeamIds: new Set(['t-ars', 't-che', 't-liv', 't-eve', 't-mci', 't-wba']),
+				teamPositions: positions,
+			}),
+		).toBe(null)
+	})
+
+	it('treats teams with null/missing position as lowest-ranked (safe default)', () => {
+		const positionsWithMissing = new Map([
+			['t-ars', 3],
+			['t-che', 6],
+			['t-liv', 2],
+			['t-eve', 12],
+			['t-mci', 1],
+			// t-wba missing — treated as position Infinity
+		])
+		expect(
+			pickLowestRankedUnusedTeam({
+				fixtures,
+				usedTeamIds: new Set(),
+				teamPositions: positionsWithMissing,
+			}),
+		).toBe('t-wba')
+	})
+
+	it('tie-breaks by team id alphabetically', () => {
+		const tied = new Map([
+			['t-aaa', 20],
+			['t-zzz', 20],
+		])
+		const tiedFixtures: TestFixture[] = [{ id: 'fx1', homeTeamId: 't-aaa', awayTeamId: 't-zzz' }]
+		expect(
+			pickLowestRankedUnusedTeam({
+				fixtures: tiedFixtures,
+				usedTeamIds: new Set(),
+				teamPositions: tied,
+			}),
+		).toBe('t-aaa')
+	})
+
+	it('returns null when fixtures array is empty', () => {
+		expect(
+			pickLowestRankedUnusedTeam({
+				fixtures: [],
+				usedTeamIds: new Set(),
+				teamPositions: positions,
+			}),
+		).toBe(null)
+	})
+})

--- a/src/lib/game/auto-pick.ts
+++ b/src/lib/game/auto-pick.ts
@@ -1,0 +1,39 @@
+interface FixtureRef {
+	id: string
+	homeTeamId: string
+	awayTeamId: string
+}
+
+interface PickLowestRankedInput {
+	fixtures: FixtureRef[]
+	usedTeamIds: Set<string>
+	teamPositions: Map<string, number>
+}
+
+export function pickLowestRankedUnusedTeam({
+	fixtures,
+	usedTeamIds,
+	teamPositions,
+}: PickLowestRankedInput): string | null {
+	const candidates = new Set<string>()
+	for (const fx of fixtures) {
+		if (!usedTeamIds.has(fx.homeTeamId)) candidates.add(fx.homeTeamId)
+		if (!usedTeamIds.has(fx.awayTeamId)) candidates.add(fx.awayTeamId)
+	}
+	if (candidates.size === 0) return null
+
+	let best: { teamId: string; position: number } | null = null
+	for (const teamId of candidates) {
+		const position = teamPositions.get(teamId) ?? Number.POSITIVE_INFINITY
+		if (best === null) {
+			best = { teamId, position }
+			continue
+		}
+		if (position > best.position) {
+			best = { teamId, position }
+		} else if (position === best.position && teamId < best.teamId) {
+			best = { teamId, position }
+		}
+	}
+	return best?.teamId ?? null
+}

--- a/src/lib/game/bootstrap-competitions.test.ts
+++ b/src/lib/game/bootstrap-competitions.test.ts
@@ -10,33 +10,42 @@ const {
 	dbQueryPlannedPickFindMany,
 	dbInsertFn,
 	dbUpdateFn,
+	dbUpdateSet,
 	fplFetchTeams,
 	fplFetchRounds,
+	fplFetchStandings,
 	fdFetchTeams,
 	fdFetchRounds,
+	fdFetchStandings,
 	enqueueAutoSubmitMock,
-} = vi.hoisted(() => ({
-	dbQueryCompetitionFindFirst: vi.fn(),
-	dbQueryTeamFindFirst: vi.fn(),
-	dbQueryTeamFindMany: vi.fn().mockResolvedValue([]),
-	dbQueryRoundFindFirst: vi.fn(),
-	dbQueryRoundFindMany: vi.fn().mockResolvedValue([]),
-	dbQueryFixtureFindFirst: vi.fn(),
-	dbQueryPlannedPickFindMany: vi.fn().mockResolvedValue([]),
-	dbInsertFn: vi.fn(() => ({
-		values: vi.fn(() => ({
-			returning: vi.fn().mockResolvedValue([{ id: 'new', externalId: 'WC' }]),
+} = vi.hoisted(() => {
+	const updateSet = vi.fn((_payload: Record<string, unknown>) => ({
+		where: vi.fn().mockResolvedValue(undefined),
+	}))
+	return {
+		dbQueryCompetitionFindFirst: vi.fn(),
+		dbQueryTeamFindFirst: vi.fn(),
+		dbQueryTeamFindMany: vi.fn().mockResolvedValue([]),
+		dbQueryRoundFindFirst: vi.fn(),
+		dbQueryRoundFindMany: vi.fn().mockResolvedValue([]),
+		dbQueryFixtureFindFirst: vi.fn(),
+		dbQueryPlannedPickFindMany: vi.fn().mockResolvedValue([]),
+		dbInsertFn: vi.fn(() => ({
+			values: vi.fn(() => ({
+				returning: vi.fn().mockResolvedValue([{ id: 'new', externalId: 'WC' }]),
+			})),
 		})),
-	})),
-	dbUpdateFn: vi.fn(() => ({
-		set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
-	})),
-	fplFetchTeams: vi.fn().mockResolvedValue([]),
-	fplFetchRounds: vi.fn().mockResolvedValue([]),
-	fdFetchTeams: vi.fn().mockResolvedValue([]),
-	fdFetchRounds: vi.fn().mockResolvedValue([]),
-	enqueueAutoSubmitMock: vi.fn().mockResolvedValue(undefined),
-}))
+		dbUpdateFn: vi.fn(() => ({ set: updateSet })),
+		dbUpdateSet: updateSet,
+		fplFetchTeams: vi.fn().mockResolvedValue([]),
+		fplFetchRounds: vi.fn().mockResolvedValue([]),
+		fplFetchStandings: vi.fn().mockResolvedValue([]),
+		fdFetchTeams: vi.fn().mockResolvedValue([]),
+		fdFetchRounds: vi.fn().mockResolvedValue([]),
+		fdFetchStandings: vi.fn().mockResolvedValue([]),
+		enqueueAutoSubmitMock: vi.fn().mockResolvedValue(undefined),
+	}
+})
 
 vi.mock('@/lib/db', () => ({
 	db: {
@@ -57,14 +66,22 @@ vi.mock('@/lib/data/qstash', () => ({ enqueueAutoSubmit: enqueueAutoSubmitMock }
 vi.mock('@/lib/data/fpl', () => ({
 	// biome-ignore lint/complexity/useArrowFunction: vi.fn().mockImplementation needs a constructable function for `new FplAdapter()`
 	FplAdapter: vi.fn().mockImplementation(function () {
-		return { fetchTeams: fplFetchTeams, fetchRounds: fplFetchRounds }
+		return {
+			fetchTeams: fplFetchTeams,
+			fetchRounds: fplFetchRounds,
+			fetchStandings: fplFetchStandings,
+		}
 	}),
 }))
 
 vi.mock('@/lib/data/football-data', () => ({
 	// biome-ignore lint/complexity/useArrowFunction: vi.fn().mockImplementation needs a constructable function for `new FootballDataAdapter()`
 	FootballDataAdapter: vi.fn().mockImplementation(function () {
-		return { fetchTeams: fdFetchTeams, fetchRounds: fdFetchRounds }
+		return {
+			fetchTeams: fdFetchTeams,
+			fetchRounds: fdFetchRounds,
+			fetchStandings: fdFetchStandings,
+		}
 	}),
 	resolveFootballDataCode: vi.fn(() => 'PL'),
 }))
@@ -95,6 +112,94 @@ describe('bootstrapCompetitions', () => {
 		await bootstrapCompetitions({ footballDataApiKey: 'fd-key' })
 		// No assertion that insert was NOT called — adapters may still insert teams/rounds.
 		// This test just ensures the function runs without error when comps already exist.
+	})
+})
+
+describe('syncCompetition league-position persistence', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		dbQueryTeamFindMany.mockResolvedValue([])
+		dbQueryRoundFindMany.mockResolvedValue([])
+		dbQueryPlannedPickFindMany.mockResolvedValue([])
+		fplFetchStandings.mockResolvedValue([])
+		fdFetchStandings.mockResolvedValue([])
+	})
+
+	it('persists league_position for each standings row scoped by external id', async () => {
+		fplFetchTeams.mockResolvedValue([])
+		fplFetchRounds.mockResolvedValue([])
+		fplFetchStandings.mockResolvedValue([
+			{
+				teamExternalId: '1',
+				position: 1,
+				played: 10,
+				won: 8,
+				drawn: 1,
+				lost: 1,
+				points: 25,
+			},
+			{
+				teamExternalId: '2',
+				position: 4,
+				played: 10,
+				won: 6,
+				drawn: 2,
+				lost: 2,
+				points: 20,
+			},
+		])
+		dbQueryTeamFindMany.mockResolvedValue([
+			{ id: 'team-1-uuid', externalIds: { fpl: '1' } },
+			{ id: 'team-2-uuid', externalIds: { fpl: '2' } },
+			{ id: 'team-other-uuid', externalIds: { football_data: '99' } },
+		])
+
+		await syncCompetition(
+			{ id: 'comp-1', dataSource: 'fpl', externalId: null, season: '2025/26' } as never,
+			{ footballDataApiKey: 'fd-key' },
+		)
+
+		// Two standings rows → two updates with leaguePosition.
+		const positionSets = dbUpdateSet.mock.calls
+			.map((call) => call[0])
+			.filter((payload) => 'leaguePosition' in payload)
+		expect(positionSets).toHaveLength(2)
+		expect(positionSets).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ leaguePosition: 1 }),
+				expect.objectContaining({ leaguePosition: 4 }),
+			]),
+		)
+	})
+
+	it('ignores standings rows whose teamExternalId is not in the competition data source', async () => {
+		fplFetchTeams.mockResolvedValue([])
+		fplFetchRounds.mockResolvedValue([])
+		fplFetchStandings.mockResolvedValue([
+			{
+				teamExternalId: '999',
+				position: 1,
+				played: 0,
+				won: 0,
+				drawn: 0,
+				lost: 0,
+				points: 0,
+			},
+		])
+		dbQueryTeamFindMany.mockResolvedValue([
+			// Team with different data source key — must not match.
+			{ id: 'team-fd-uuid', externalIds: { football_data: '999' } },
+		])
+
+		await syncCompetition(
+			{ id: 'comp-1', dataSource: 'fpl', externalId: null, season: '2025/26' } as never,
+			{ footballDataApiKey: 'fd-key' },
+		)
+
+		const positionSets = dbUpdateSet.mock.calls
+			.map((call) => call[0])
+			.filter((payload) => 'leaguePosition' in payload)
+		expect(positionSets).toHaveLength(0)
 	})
 })
 

--- a/src/lib/game/bootstrap-competitions.test.ts
+++ b/src/lib/game/bootstrap-competitions.test.ts
@@ -307,3 +307,77 @@ describe('syncCompetition auto-submit enqueue', () => {
 		expect(enqueueAutoSubmitMock).not.toHaveBeenCalled()
 	})
 })
+
+describe('syncCompetition deadline-lock trigger (transitionedRoundIds)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		dbQueryTeamFindMany.mockResolvedValue([])
+		dbQueryRoundFindMany.mockResolvedValue([])
+		dbQueryPlannedPickFindMany.mockResolvedValue([])
+	})
+
+	it('does NOT include the round in transitionedRoundIds on upcoming → open transitions (deadline still in future)', async () => {
+		// Deadline is 24h away — within the 48h OPEN_WINDOW so status flips to `open`,
+		// but the deadline itself has NOT passed yet.
+		const deadline = new Date(Date.now() + 24 * 3600 * 1000)
+		fplFetchTeams.mockResolvedValue([])
+		fplFetchRounds.mockResolvedValue([
+			{ number: 1, name: 'Round 1', deadline, finished: false, fixtures: [] },
+		])
+		dbQueryRoundFindFirst.mockResolvedValue({
+			id: 'round-1',
+			status: 'upcoming',
+			deadline: deadline, // existing round had same deadline, still upcoming
+		})
+
+		const result = await syncCompetition(
+			{ id: 'comp-1', dataSource: 'fpl', externalId: null, season: '2025/26' } as never,
+			{ footballDataApiKey: 'fd-key' },
+		)
+
+		expect(result.transitionedRoundIds).toEqual([])
+	})
+
+	it('DOES include the round in transitionedRoundIds when the deadline has actually passed', async () => {
+		// Existing round is `open` (we previously flipped it at T-48h) with a
+		// deadline in the past — i.e. the actual lock moment has arrived.
+		const pastDeadline = new Date(Date.now() - 3600 * 1000) // 1h ago
+		fplFetchTeams.mockResolvedValue([])
+		fplFetchRounds.mockResolvedValue([
+			{ number: 1, name: 'Round 1', deadline: pastDeadline, finished: false, fixtures: [] },
+		])
+		dbQueryRoundFindFirst.mockResolvedValue({
+			id: 'round-1',
+			status: 'open',
+			deadline: pastDeadline,
+		})
+
+		const result = await syncCompetition(
+			{ id: 'comp-1', dataSource: 'fpl', externalId: null, season: '2025/26' } as never,
+			{ footballDataApiKey: 'fd-key' },
+		)
+
+		expect(result.transitionedRoundIds).toEqual(['round-1'])
+	})
+
+	it('does NOT include the round when it is already completed (finished in adapter)', async () => {
+		const pastDeadline = new Date(Date.now() - 24 * 3600 * 1000)
+		fplFetchTeams.mockResolvedValue([])
+		fplFetchRounds.mockResolvedValue([
+			{ number: 1, name: 'Round 1', deadline: pastDeadline, finished: true, fixtures: [] },
+		])
+		dbQueryRoundFindFirst.mockResolvedValue({
+			id: 'round-1',
+			status: 'completed',
+			deadline: pastDeadline,
+		})
+
+		const result = await syncCompetition(
+			{ id: 'comp-1', dataSource: 'fpl', externalId: null, season: '2025/26' } as never,
+			{ footballDataApiKey: 'fd-key' },
+		)
+
+		// Finished rounds are not open anymore — no re-fire of the deadline lock.
+		expect(result.transitionedRoundIds).toEqual([])
+	})
+})

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -89,6 +89,22 @@ export async function syncCompetition(
 
 	const allTeams = await db.query.team.findMany({})
 
+	// Persist latest league standings into team.leaguePosition when the adapter
+	// supports standings. Scope by externalIds[key] so updates stay within this
+	// competition's data source.
+	if (typeof adapter.fetchStandings === 'function') {
+		const standings = await adapter.fetchStandings()
+		for (const row of standings) {
+			const match = allTeams.find(
+				(t) =>
+					String((t.externalIds as Record<string, string | number> | null)?.[key]) ===
+					row.teamExternalId,
+			)
+			if (!match) continue
+			await db.update(team).set({ leaguePosition: row.position }).where(eq(team.id, match.id))
+		}
+	}
+
 	const adapterRounds = await adapter.fetchRounds()
 	let totalFixtures = 0
 	for (const ar of adapterRounds) {

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -118,8 +118,22 @@ export async function syncCompetition(
 				? 'open'
 				: (existingRound?.status ?? 'upcoming')
 		let roundId: string
+		// T-48h: pre-lock window opens. Used to enqueue the planned-pick auto-submit
+		// job (fires at T-60s). Does NOT signal the deadline has passed.
 		const transitioningToOpen =
 			!!existingRound && existingRound.status !== 'open' && newStatus === 'open'
+		// Actual deadline passed: the round is still `open` in the DB (we have not
+		// transitioned it to `active` yet) AND its deadline is in the past. This is
+		// what drives `processDeadlineLock` (rules 2 and 3) — firing earlier would
+		// elim/auto-pick players who still have time to submit. The handler is
+		// idempotent so it is safe to re-fire on subsequent sync runs until the
+		// round advances to `active`/`completed`.
+		const nowForDeadline = new Date()
+		const deadlineHasPassed =
+			!!existingRound &&
+			existingRound.status === 'open' &&
+			existingRound.deadline != null &&
+			existingRound.deadline.getTime() <= nowForDeadline.getTime()
 		if (existingRound) {
 			roundId = existingRound.id
 			await db
@@ -144,18 +158,19 @@ export async function syncCompetition(
 			roundId = created.id
 		}
 
-		if (transitioningToOpen) {
-			transitionedRoundIds.push(roundId)
-			if (ar.deadline) {
-				const plans = await db.query.plannedPick.findMany({
-					where: eq(plannedPick.roundId, roundId),
-				})
-				const autoPlans = plans.filter((p) => p.autoSubmit)
-				const notBefore = new Date(ar.deadline.getTime() - AUTO_SUBMIT_LEAD_MS)
-				for (const p of autoPlans) {
-					await enqueueAutoSubmit(p.gamePlayerId, p.roundId, p.teamId, notBefore)
-				}
+		if (transitioningToOpen && ar.deadline) {
+			const plans = await db.query.plannedPick.findMany({
+				where: eq(plannedPick.roundId, roundId),
+			})
+			const autoPlans = plans.filter((p) => p.autoSubmit)
+			const notBefore = new Date(ar.deadline.getTime() - AUTO_SUBMIT_LEAD_MS)
+			for (const p of autoPlans) {
+				await enqueueAutoSubmit(p.gamePlayerId, p.roundId, p.teamId, notBefore)
 			}
+		}
+
+		if (deadlineHasPassed) {
+			transitionedRoundIds.push(roundId)
 		}
 
 		for (const af of ar.fixtures) {

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -61,9 +61,9 @@ export async function bootstrapCompetitions(opts: BootstrapOptions): Promise<voi
 export async function syncCompetition(
 	comp: CompetitionRow,
 	opts: BootstrapOptions,
-): Promise<{ rounds: number; fixtures: number }> {
+): Promise<{ rounds: number; fixtures: number; transitionedRoundIds: string[] }> {
 	const adapter = adapterFor(comp, opts)
-	if (!adapter) return { rounds: 0, fixtures: 0 }
+	if (!adapter) return { rounds: 0, fixtures: 0, transitionedRoundIds: [] }
 
 	const key = comp.dataSource === 'fpl' ? 'fpl' : 'football_data'
 	const adapterTeams = await adapter.fetchTeams()
@@ -107,6 +107,7 @@ export async function syncCompetition(
 
 	const adapterRounds = await adapter.fetchRounds()
 	let totalFixtures = 0
+	const transitionedRoundIds: string[] = []
 	for (const ar of adapterRounds) {
 		const existingRound = await db.query.round.findFirst({
 			where: and(eq(round.competitionId, comp.id), eq(round.number, ar.number)),
@@ -143,14 +144,17 @@ export async function syncCompetition(
 			roundId = created.id
 		}
 
-		if (transitioningToOpen && ar.deadline) {
-			const plans = await db.query.plannedPick.findMany({
-				where: eq(plannedPick.roundId, roundId),
-			})
-			const autoPlans = plans.filter((p) => p.autoSubmit)
-			const notBefore = new Date(ar.deadline.getTime() - AUTO_SUBMIT_LEAD_MS)
-			for (const p of autoPlans) {
-				await enqueueAutoSubmit(p.gamePlayerId, p.roundId, p.teamId, notBefore)
+		if (transitioningToOpen) {
+			transitionedRoundIds.push(roundId)
+			if (ar.deadline) {
+				const plans = await db.query.plannedPick.findMany({
+					where: eq(plannedPick.roundId, roundId),
+				})
+				const autoPlans = plans.filter((p) => p.autoSubmit)
+				const notBefore = new Date(ar.deadline.getTime() - AUTO_SUBMIT_LEAD_MS)
+				for (const p of autoPlans) {
+					await enqueueAutoSubmit(p.gamePlayerId, p.roundId, p.teamId, notBefore)
+				}
 			}
 		}
 
@@ -196,7 +200,7 @@ export async function syncCompetition(
 		}
 	}
 
-	return { rounds: adapterRounds.length, fixtures: totalFixtures }
+	return { rounds: adapterRounds.length, fixtures: totalFixtures, transitionedRoundIds }
 }
 
 export async function applyPotAssignments(competitionId: string): Promise<void> {

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -23,7 +23,12 @@ export async function getGameDetail(gameId: string, userId: string) {
 			competition: true,
 			currentRound: { with: { fixtures: { with: { homeTeam: true, awayTeam: true } } } },
 			players: true,
-			picks: true,
+			picks: {
+				with: {
+					team: true,
+					fixture: { with: { homeTeam: true, awayTeam: true } },
+				},
+			},
 		},
 	})
 
@@ -32,6 +37,28 @@ export async function getGameDetail(gameId: string, userId: string) {
 	const myMembership = gameData.players.find((p) => p.userId === userId)
 	const isAdmin = gameData.createdBy === userId
 	const isMember = !!myMembership
+
+	// Viewer's current-round pick (used by AutoPickBanner to detect auto-picks).
+	let myCurrentRoundPick: {
+		id: string
+		isAuto: boolean
+		teamShortName: string
+		kickoffLabel: string
+	} | null = null
+	if (myMembership && gameData.currentRoundId) {
+		const currentPick = gameData.picks.find(
+			(p) => p.gamePlayerId === myMembership.id && p.roundId === gameData.currentRoundId,
+		)
+		if (currentPick) {
+			const kickoff = currentPick.fixture?.kickoff ?? null
+			myCurrentRoundPick = {
+				id: currentPick.id,
+				isAuto: currentPick.isAuto,
+				teamShortName: currentPick.team?.shortName ?? '?',
+				kickoffLabel: kickoff ? formatKickoff(kickoff) : 'TBC',
+			}
+		}
+	}
 
 	const payments = await db.query.payment.findMany({
 		where: eq(payment.gameId, gameId),
@@ -111,6 +138,7 @@ export async function getGameDetail(gameId: string, userId: string) {
 		myPayment,
 		otherPayments,
 		adminPayments,
+		myCurrentRoundPick,
 	}
 }
 

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -651,6 +651,7 @@ export async function getProgressGridData(
 				opponentShortName,
 				homeAway,
 				score,
+				isAuto: thePick.isAuto,
 			}
 		}
 

--- a/src/lib/game/no-pick-handler.test.ts
+++ b/src/lib/game/no-pick-handler.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest'
+import { processDeadlineLock } from './no-pick-handler'
+
+vi.mock('@/lib/db', () => ({
+	db: {
+		query: {
+			round: { findFirst: vi.fn().mockResolvedValue(undefined) },
+			game: { findMany: vi.fn().mockResolvedValue([]) },
+			pick: { findFirst: vi.fn(), findMany: vi.fn() },
+			fixture: { findMany: vi.fn() },
+			team: { findMany: vi.fn() },
+			payment: { findFirst: vi.fn() },
+		},
+		insert: vi.fn(),
+		update: vi.fn(),
+	},
+}))
+
+describe('processDeadlineLock', () => {
+	it('no-ops when no games use the round', async () => {
+		const result = await processDeadlineLock(['r1'])
+		expect(result).toEqual({ autoPicksInserted: 0, playersEliminated: 0, paymentsRefunded: 0 })
+	})
+})

--- a/src/lib/game/no-pick-handler.ts
+++ b/src/lib/game/no-pick-handler.ts
@@ -1,0 +1,146 @@
+import { and, eq, inArray, ne } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { fixture, round, team } from '@/lib/schema/competition'
+import { game, gamePlayer, pick } from '@/lib/schema/game'
+import { payment } from '@/lib/schema/payment'
+import { pickLowestRankedUnusedTeam } from './auto-pick'
+
+export async function processDeadlineLock(roundIds: string[]): Promise<{
+	autoPicksInserted: number
+	playersEliminated: number
+	paymentsRefunded: number
+}> {
+	let autoPicksInserted = 0
+	let playersEliminated = 0
+	let paymentsRefunded = 0
+
+	for (const roundId of roundIds) {
+		const roundRow = await db.query.round.findFirst({ where: eq(round.id, roundId) })
+		if (!roundRow) continue
+
+		const games = await db.query.game.findMany({
+			where: and(eq(game.currentRoundId, roundId), ne(game.status, 'completed')),
+			with: { players: true },
+		})
+
+		for (const g of games) {
+			const activePlayers = g.players.filter((p) => p.status === 'alive')
+			for (const player of activePlayers) {
+				const existingPick = await db.query.pick.findFirst({
+					where: and(eq(pick.gamePlayerId, player.id), eq(pick.roundId, roundId)),
+				})
+				if (existingPick) continue
+
+				if (g.gameMode === 'classic' && roundRow.number >= 3) {
+					const result = await applyRule2Classic(g.id, player, roundId)
+					if (result === 'auto-pick-inserted') autoPicksInserted++
+					else if (result === 'eliminated-no-fallback') playersEliminated++
+				} else if (g.gameMode === 'turbo' || g.gameMode === 'cup') {
+					const result = await applyRule3TurboOrCup(g.id, player, roundId)
+					playersEliminated++
+					if (result.refunded) paymentsRefunded++
+				}
+			}
+		}
+	}
+
+	return { autoPicksInserted, playersEliminated, paymentsRefunded }
+}
+
+async function applyRule2Classic(
+	gameId: string,
+	player: typeof gamePlayer.$inferSelect,
+	roundId: string,
+): Promise<'auto-pick-inserted' | 'eliminated-no-fallback'> {
+	const fixtures = await db.query.fixture.findMany({
+		where: eq(fixture.roundId, roundId),
+		with: { homeTeam: true, awayTeam: true },
+	})
+	const usedPicks = await db.query.pick.findMany({
+		where: and(eq(pick.gameId, gameId), eq(pick.gamePlayerId, player.id)),
+	})
+	const usedTeamIds = new Set(usedPicks.flatMap((p) => (p.teamId ? [p.teamId] : [])))
+
+	const allTeamIds = new Set<string>()
+	for (const fx of fixtures) {
+		allTeamIds.add(fx.homeTeamId)
+		allTeamIds.add(fx.awayTeamId)
+	}
+	const teamRows = allTeamIds.size
+		? await db.query.team.findMany({ where: inArray(team.id, Array.from(allTeamIds)) })
+		: []
+	const teamPositions = new Map(
+		teamRows.map((t) => [t.id, t.leaguePosition ?? Number.POSITIVE_INFINITY] as const),
+	)
+
+	const teamId = pickLowestRankedUnusedTeam({
+		fixtures: fixtures.map((fx) => ({
+			id: fx.id,
+			homeTeamId: fx.homeTeamId,
+			awayTeamId: fx.awayTeamId,
+		})),
+		usedTeamIds,
+		teamPositions,
+	})
+
+	if (!teamId) {
+		await db
+			.update(gamePlayer)
+			.set({
+				status: 'eliminated',
+				eliminatedReason: 'no_pick_no_fallback',
+				eliminatedRoundId: roundId,
+			})
+			.where(eq(gamePlayer.id, player.id))
+		return 'eliminated-no-fallback'
+	}
+
+	const chosenFixture = fixtures.find((fx) => fx.homeTeamId === teamId || fx.awayTeamId === teamId)
+	if (!chosenFixture) {
+		// Defensive — should not happen since teamId came from fixtures.
+		return 'eliminated-no-fallback'
+	}
+	const predictedResult = chosenFixture.homeTeamId === teamId ? 'home_win' : 'away_win'
+	await db.insert(pick).values({
+		gameId,
+		roundId,
+		gamePlayerId: player.id,
+		fixtureId: chosenFixture.id,
+		teamId,
+		predictedResult,
+		confidenceRank: null,
+		isAuto: true,
+	})
+	return 'auto-pick-inserted'
+}
+
+async function applyRule3TurboOrCup(
+	gameId: string,
+	player: typeof gamePlayer.$inferSelect,
+	roundId: string,
+): Promise<{ refunded: boolean }> {
+	await db
+		.update(gamePlayer)
+		.set({
+			status: 'eliminated',
+			eliminatedReason: 'no_pick_no_fallback',
+			eliminatedRoundId: roundId,
+		})
+		.where(eq(gamePlayer.id, player.id))
+
+	const refundCandidate = await db.query.payment.findFirst({
+		where: and(
+			eq(payment.gameId, gameId),
+			eq(payment.userId, player.userId),
+			inArray(payment.status, ['paid', 'claimed']),
+		),
+		orderBy: (p, { desc }) => desc(p.createdAt),
+	})
+	if (!refundCandidate) return { refunded: false }
+
+	await db
+		.update(payment)
+		.set({ status: 'refunded', refundedAt: new Date() })
+		.where(eq(payment.id, refundCandidate.id))
+	return { refunded: true }
+}

--- a/src/lib/picks/validate.ts
+++ b/src/lib/picks/validate.ts
@@ -10,8 +10,12 @@ export interface ClassicPickValidation {
 	fixtureTeamIds: string[]
 }
 
-export function validateClassicPick(input: ClassicPickValidation): ValidationResult {
-	if (input.playerStatus !== 'alive') return { valid: false, reason: 'Player is not alive' }
+export function validateClassicPick(
+	input: ClassicPickValidation,
+	opts: { allowEliminatedRebuy?: boolean } = {},
+): ValidationResult {
+	if (!opts.allowEliminatedRebuy && input.playerStatus !== 'alive')
+		return { valid: false, reason: 'Player is not alive' }
 	if (input.roundStatus !== 'open') return { valid: false, reason: 'Round is not open for picks' }
 	if (input.deadline && input.now > input.deadline)
 		return { valid: false, reason: 'Deadline has passed' }
@@ -60,8 +64,12 @@ export interface CupPicksValidation {
 	picks: CupPickEntry[]
 }
 
-export function validateCupPicks(input: CupPicksValidation): ValidationResult {
-	if (input.playerStatus !== 'alive') return { valid: false, reason: 'Player is not alive' }
+export function validateCupPicks(
+	input: CupPicksValidation,
+	opts: { allowEliminatedRebuy?: boolean } = {},
+): ValidationResult {
+	if (!opts.allowEliminatedRebuy && input.playerStatus !== 'alive')
+		return { valid: false, reason: 'Player is not alive' }
 	if (input.roundStatus !== 'open') return { valid: false, reason: 'Round is not open for picks' }
 	if (input.deadline && input.now > input.deadline)
 		return { valid: false, reason: 'Deadline has passed' }
@@ -99,8 +107,12 @@ export function validateCupPicks(input: CupPicksValidation): ValidationResult {
 	return { valid: true }
 }
 
-export function validateTurboPicks(input: TurboPicksValidation): ValidationResult {
-	if (input.playerStatus !== 'alive') return { valid: false, reason: 'Player is not alive' }
+export function validateTurboPicks(
+	input: TurboPicksValidation,
+	opts: { allowEliminatedRebuy?: boolean } = {},
+): ValidationResult {
+	if (!opts.allowEliminatedRebuy && input.playerStatus !== 'alive')
+		return { valid: false, reason: 'Player is not alive' }
 	if (input.roundStatus !== 'open') return { valid: false, reason: 'Round is not open for picks' }
 	if (input.deadline && input.now > input.deadline)
 		return { valid: false, reason: 'Deadline has passed' }

--- a/src/lib/schema/competition.ts
+++ b/src/lib/schema/competition.ts
@@ -66,6 +66,7 @@ export const team = pgTable('team', {
 	badgeUrl: text('badge_url'),
 	primaryColor: varchar('primary_color', { length: 7 }),
 	externalIds: jsonb('external_ids').$type<Record<string, string | number>>().default({}),
+	leaguePosition: integer('league_position'),
 	createdAt: timestamp('created_at').defaultNow().notNull(),
 })
 

--- a/src/lib/schema/game.ts
+++ b/src/lib/schema/game.ts
@@ -64,6 +64,8 @@ export const gamePlayer = pgTable(
 		userId: text('user_id').notNull(),
 		status: playerStatusEnum('status').notNull().default('alive'),
 		eliminatedRoundId: uuid('eliminated_round_id').references(() => round.id),
+		// Valid values: 'loss' | 'missed_rebuy_pick' | 'no_pick_no_fallback' | 'admin_removed'
+		eliminatedReason: text('eliminated_reason'),
 		livesRemaining: integer('lives_remaining').notNull().default(0),
 		joinedAt: timestamp('joined_at').defaultNow().notNull(),
 	},
@@ -92,6 +94,7 @@ export const pick = pgTable(
 		result: pickResultEnum('result').notNull().default('pending'),
 		goalsScored: integer('goals_scored'),
 		autoSubmitted: boolean('auto_submitted').notNull().default(false),
+		isAuto: boolean('is_auto').notNull().default(false),
 		createdAt: timestamp('created_at').defaultNow().notNull(),
 	},
 	(table) => [

--- a/src/lib/schema/payment.ts
+++ b/src/lib/schema/payment.ts
@@ -28,6 +28,7 @@ export const payment = pgTable('payment', {
 	method: paymentMethodEnum('method').notNull().default('manual'),
 	claimedAt: timestamp('claimed_at'),
 	paidAt: timestamp('paid_at'),
+	refundedAt: timestamp('refunded_at'),
 	createdAt: timestamp('created_at').defaultNow().notNull(),
 })
 


### PR DESCRIPTION
## Summary

Phase 4c2 adds the admin-side surfaces that make the app usable in practice (add late-joiner, pick for a friend who missed the deadline, split the pot to end a game) plus two engine rules that plug long-standing gaps in no-pick handling — classic auto-assign-lowest-ranked-team and turbo/cup refund-and-eliminate.

**What shipped:**
- **Admin panel** on game detail (admin-only): "+ Add player" and "Split pot (N alive)" buttons.
- **Add-player modal** with live user search (`GET /api/users/search`), inserts via `POST /api/games/[id]/admin/add-player`, chains to "Pick for X now" on success.
- **Pick-for-player** via `/game/[id]?actingAs=<gamePlayerId>` — admin check server-side before any data load; target player's history + used teams drive validation; `<ActingAsBanner>` shows "Admin mode · Picking for X" with Exit CTA. All three pick UIs (classic/turbo/cup) forward `actingAs` in the POST body.
- **Split-pot confirmation modal** wrapping the existing Phase 2 split-pot route with per-winner preview and irreversibility warning.
- **Contextual ✎ icons** on progress-grid / cup-grid / turbo-standings for players who haven't picked in the current open round (cup-ladder deferred — grid tab provides the path).
- **Engine rule 1** — admin un-elimination: when admin picks for a player with `eliminatedReason: 'missed_rebuy_pick'`, the pick route flips status back to `alive` + clears the reason.
- **Engine rule 2** — classic auto-pick (rounds ≥ 3): `processDeadlineLock` scans for no-pick players, assigns `pickLowestRankedUnusedTeam` using `team.league_position`, stamps `pick.isAuto = true`.
- **Engine rule 3** — turbo/cup no-pick = eliminate + refund: stamps `eliminatedReason: 'no_pick_no_fallback'` + transitions most-recent `paid`/`claimed` payment to `refunded` with `refundedAt`.
- **AUTO ribbon** on progress-grid pick cells (amber-dashed pending, persistent ribbon post-settlement).
- **AutoPickBanner** — one-time dismissible notification for affected players via localStorage.
- **Schema migration** (`drizzle/0002_bored_lizard.sql`): `pick.is_auto`, `game_player.eliminated_reason`, `team.league_position`, `payment.refunded_at`. All nullable/default-safe, no enum extensions.
- **Bootstrap-competitions** now persists `league_position` alongside the team upsert loop.

**Stats:** 21 commits, 250 tests passing (baseline 226, +24 new), typecheck + Biome + Next compile/TS all clean.

## Review findings — fixed pre-merge

Two Criticals caught by the final review and fixed in `d40b596`:

1. **Rule 1 un-elimination was blocked by the validator.** `validateClassicPick` / `validateTurboPicks` rejected on `playerStatus !== 'alive'` before the pick was written, so the un-elimination code never ran. Fix: added optional `allowEliminatedRebuy` flag to each validator, set by the route when `actingAs && eliminatedReason === 'missed_rebuy_pick'`. Test rewritten to use the real eliminated state.

2. **Rule 2/3 fired 48h too early.** The `transitioningToOpen` trigger detects `upcoming → open`, which happens 48h before deadline (`OPEN_WINDOW_MS` pre-lock window). So auto-pick and refund-eliminate would fire while players still had time to submit. Fix: new `deadlineHasPassed` check (round still `open`, deadline in the past) feeds `processDeadlineLock`. The original `transitioningToOpen` still gates Phase 4b's auto-submit enqueue (different purpose, T-60s lead before deadline — unchanged).

## Known deferrals

- **Migration not applied to local DB** in sandbox (no docker). SQL is committed and applies cleanly on first-run.
- **Integration smoke** (add player → pick chain → split pot → deadline auto-pick) deferred to post-merge with docker running.
- **`maybeUnEliminate` not in a DB transaction** (spec said it should be). Pick insert + status flip are back-to-back writes. Risk = transient failure between the two leaves partial state. Low frequency; follow-up ticket.
- **User search endpoint** allows email enumeration. Flagged as Important by reviewer. Mitigation options: min-length gate, `%`/`_` escaping, or hiding email from search results. Follow-up ticket.
- **`unEliminated: true` response** flag isn't surfaced by the UI as a toast. Admin has to refresh to see the row move. Follow-up ticket.
- **FplAdapter doesn't implement `fetchStandings`**, so PL teams' `league_position` stays null until Phase 4.5. `pickLowestRankedUnusedTeam` falls back to alphabetical tie-break on null-position, so rule 2 still assigns *a* team in the meantime — just not necessarily the "lowest-ranked" one until standings are populated. Flag in Phase 4.5 playbook.
- **Modals lack focus trap / escape-to-close / `aria-labelledby`.** WCAG audit improvements deferred to 4c5 mobile polish.
- **Cup-ladder `✎` icon deferred** — backer-centric layout doesn't have natural per-player rows. Admins use the Grid tab for pick-for-player on cup mode.
- **GH Actions cron secrets** → Phase 4.5 (continuing failures are intentional canary).

## Follow-ups logged

- Wrap rule 1 un-elimination in `db.transaction`.
- Harden user-search against enumeration (min-length + escape `%`/`_` + optional game-scoped filter).
- Surface "X is back in the game" toast from `unEliminated` response flag.
- Add "IN GAME" tag to add-player search results (spec deviation).
- Implement `FplAdapter.fetchStandings` (paid tier or fallback to computed table).
- Modal a11y (focus trap, escape, `aria-labelledby`).

## Test plan

- [ ] `pnpm install` then `just db-reset` to apply migration and seed the missed-deadline scenario.
- [ ] `just dev` — confirm admin panel renders for game creator; non-admins see no admin UI.
- [ ] Click "+ Add player" → modal opens, search works, add a new user; success state offers "Pick for X now"; chain navigates to pick page with `?actingAs=...`.
- [ ] On pick page: `<ActingAsBanner />` renders; submit writes pick under the target's gamePlayerId.
- [ ] Mutate an eliminated player to `eliminatedReason: 'missed_rebuy_pick'`; admin picks for them; confirm `status` flips to `alive` + reason cleared.
- [ ] Click "✎" on a player row without a current-round pick → goes to pick page in acting-as mode.
- [ ] Click "Split pot" → modal shows per-winner amount; confirm ends game.
- [ ] Trigger `processDeadlineLock` (via DB mutation to set a classic round's deadline in the past then run daily-sync): no-pick player gets auto-assigned with `isAuto: true`; progress-grid shows the amber AUTO ribbon; Rachel's next visit surfaces `<AutoPickBanner />`.
- [ ] Same for turbo/cup: no-pick player eliminated + payment refunded.
- [ ] `pnpm exec tsc --noEmit && pnpm exec biome check . && pnpm exec vitest run` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)