### PR TITLE
Phase 4c5: mobile polish + a11y sweep

### DIFF
--- a/docs/superpowers/plans/2026-04-27-phase-4c5-mobile-and-a11y.md
+++ b/docs/superpowers/plans/2026-04-27-phase-4c5-mobile-and-a11y.md
@@ -1,0 +1,1022 @@
+# Phase 4c5 — Mobile Polish + A11y Sweep: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate two custom modals to shadcn `Dialog` for free a11y wins, do a mobile width pass at iPhone 393px, clear ~8 Biome warnings, and finish carry-over deferrals from 4c2/4c3/4c4 (IN GAME tag, share-variant seed games, `/grid` alias removal, free-player rebuy in panel).
+
+**Architecture:** No new patterns. Per-task changes in existing files. Modals migrate from custom `<div role="dialog">` to shadcn `Dialog` primitives (already in `src/components/ui/dialog.tsx`). Mobile fixes are Tailwind utility additions (`flex-col md:flex-row` etc.); no structural rewrites. Free-player surfacing extends the existing admin payment list builder in `getGameDetail` to emit synthetic rows for unpaid `gamePlayer` entries.
+
+**Tech Stack:** Next.js 16 App Router, React 19, shadcn/ui (Radix Dialog), Tailwind CSS, Drizzle, Vitest.
+
+---
+
+## Working context
+
+- Branch: `feature/phase-4c5-mobile-and-a11y`
+- Worktree: `.worktrees/phase-4c5/`
+- Spec: `docs/superpowers/specs/2026-04-27-phase-4c5-mobile-and-a11y-design.md`
+- Test count target: 319 (current) → ~325 after new tests in W1, W5, W8.
+- W9 (user-search email enumeration) **dropped** — verified in spec write-up that `src/app/api/users/search/route.ts` already returns `{users: []}` uniformly; no leak.
+
+**Commands** (run from worktree root):
+- `pnpm test` / `pnpm vitest run <path>` — Vitest
+- `pnpm tsc --noEmit` — typecheck
+- `pnpm exec biome check --write .` — lint + format
+- `just dev` — dev server (for manual smoke; requires `docker compose up -d`)
+- `just db-reset` — rebuild local DB from migrations + seed
+
+After each task: `pnpm test && pnpm tsc --noEmit && pnpm exec biome check .` must all pass before commit.
+
+---
+
+## Task 1: Migrate `add-player-modal` to shadcn `Dialog`
+
+**Context:** Currently `src/components/game/add-player-modal.tsx` rolls its own `<div role="dialog">` with four `biome-ignore lint/a11y/*` lines. Migrate to shadcn `Dialog` (already in `src/components/ui/dialog.tsx`), removing all four suppressions. Free wins: focus trap, Escape-to-close, `aria-labelledby` via `DialogTitle`. Modal becomes a child of `Dialog`/`DialogContent`; the parent component drives `open` state.
+
+**Files:**
+- Modify: `src/components/game/add-player-modal.tsx`
+- Modify: `src/components/game/admin-panel.tsx` (caller; the existing pattern in `admin-panel.tsx` opens the modal on a button click — keep that, but switch from conditional render to `open` prop)
+
+**Read first:**
+- `src/components/ui/dialog.tsx` — shadcn Dialog primitives
+- `src/components/game/share-dialog.tsx` — example of correct shadcn Dialog usage in this codebase
+- `src/components/game/admin-panel.tsx` — how `add-player-modal` is currently mounted
+
+### Step 1: Read the existing files
+
+Run these in your head:
+- Read `src/components/game/add-player-modal.tsx` end-to-end so you know the form, autocomplete, and post-submit behavior.
+- Read `src/components/game/admin-panel.tsx` (around the `setOpenModal` state machine) so you know how the parent triggers the modal.
+- Read `src/components/game/share-dialog.tsx` lines 25-130 for the canonical shadcn Dialog usage pattern.
+
+### Step 2: Add a passing-after-migration test
+
+Create or extend `src/components/game/add-player-modal.test.tsx`. If `@testing-library/react` is set up (check `package.json` devDependencies for `@testing-library/react`), use it. If not, mark this step complete with a `// TODO(4c5): add Escape-closes test once @testing-library/react is wired in` placeholder comment in the file and proceed; do NOT install testing-library as part of this task.
+
+If testing-library IS available:
+
+```tsx
+// src/components/game/add-player-modal.test.tsx
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { AddPlayerModal } from './add-player-modal'
+
+describe('AddPlayerModal', () => {
+  it('Escape closes the modal', () => {
+    const onClose = vi.fn()
+    render(<AddPlayerModal gameId="g1" open={true} onClose={onClose} />)
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders dialog title for screen readers', () => {
+    render(<AddPlayerModal gameId="g1" open={true} onClose={vi.fn()} />)
+    expect(screen.getByRole('dialog', { name: /add player/i })).toBeTruthy()
+  })
+})
+```
+
+If testing-library is NOT available, skip this step and rely on manual smoke + the existing test suite.
+
+### Step 3: Run the test (expect failure)
+
+If you wrote tests, run them — they should fail because the current modal is a custom `<div>` that doesn't intercept Escape and doesn't expose a proper accessible name.
+
+```
+pnpm vitest run src/components/game/add-player-modal.test.tsx
+```
+
+Expected: tests fail (Escape isn't handled; `getByRole('dialog')` may match but without an accessible name).
+
+### Step 4: Migrate the modal
+
+Replace `src/components/game/add-player-modal.tsx` with:
+
+```tsx
+'use client'
+import { useRouter } from 'next/navigation'
+import { useId, useState } from 'react'
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '@/components/ui/dialog'
+
+interface AddedPlayer {
+	gamePlayerId: string
+	userName: string
+}
+
+interface AddPlayerModalProps {
+	gameId: string
+	open: boolean
+	onClose: () => void
+}
+
+interface UserResult {
+	id: string
+	name: string
+	email: string
+	isInGame?: boolean
+}
+
+export function AddPlayerModal({ gameId, open, onClose }: AddPlayerModalProps) {
+	const router = useRouter()
+	const inputId = useId()
+	const [query, setQuery] = useState('')
+	const [results, setResults] = useState<UserResult[]>([])
+	const [searching, setSearching] = useState(false)
+	const [adding, setAdding] = useState(false)
+	const [error, setError] = useState<string | null>(null)
+	const [added, setAdded] = useState<AddedPlayer | null>(null)
+
+	function handleClose() {
+		setQuery('')
+		setResults([])
+		setError(null)
+		setAdded(null)
+		onClose()
+	}
+
+	async function handleSearch(value: string) {
+		setQuery(value)
+		setError(null)
+		if (value.trim().length === 0) {
+			setResults([])
+			return
+		}
+		setSearching(true)
+		try {
+			const res = await fetch(
+				`/api/users/search?q=${encodeURIComponent(value)}&gameId=${encodeURIComponent(gameId)}`,
+			)
+			if (!res.ok) {
+				setError('Search failed')
+				return
+			}
+			const body = (await res.json()) as { users: UserResult[] }
+			setResults(body.users)
+		} finally {
+			setSearching(false)
+		}
+	}
+
+	async function handleAdd(u: UserResult) {
+		if (u.isInGame) return
+		if (adding) return
+		setAdding(true)
+		setError(null)
+		try {
+			const res = await fetch(`/api/games/${gameId}/admin/add-player`, {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ userId: u.id }),
+			})
+			const body = await res.json()
+			if (!res.ok) {
+				setError(body.error ?? 'failed')
+				return
+			}
+			setAdded({ gamePlayerId: body.gamePlayer.id, userName: u.name })
+		} finally {
+			setAdding(false)
+		}
+	}
+
+	function handlePickForThem() {
+		if (!added) return
+		handleClose()
+		router.push(`/game/${gameId}?actingAs=${added.gamePlayerId}`)
+	}
+
+	function handleBackToGame() {
+		handleClose()
+		router.refresh()
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={(v) => !v && handleClose()}>
+			<DialogContent className="sm:max-w-md">
+				{added ? (
+					<>
+						<DialogHeader>
+							<DialogTitle>{added.userName} added</DialogTitle>
+							<DialogDescription>Pick for them now, or come back later.</DialogDescription>
+						</DialogHeader>
+						<DialogFooter>
+							<button
+								type="button"
+								onClick={handleBackToGame}
+								className="rounded-md border border-border bg-transparent px-3 py-1.5 text-xs font-semibold text-muted-foreground"
+							>
+								Back to game
+							</button>
+							<button
+								type="button"
+								onClick={handlePickForThem}
+								className="rounded-md bg-primary px-3 py-1.5 text-xs font-bold text-primary-foreground"
+							>
+								Pick for them
+							</button>
+						</DialogFooter>
+					</>
+				) : (
+					<>
+						<DialogHeader>
+							<DialogTitle>Add player</DialogTitle>
+							<DialogDescription>Search by name or email to add a user to this game.</DialogDescription>
+						</DialogHeader>
+						<div className="space-y-3">
+							<input
+								id={inputId}
+								autoFocus
+								value={query}
+								onChange={(e) => handleSearch(e.target.value)}
+								placeholder="Name or email"
+								className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+							/>
+							{searching && <p className="text-xs text-muted-foreground">Searching…</p>}
+							{!searching && results.length > 0 && (
+								<ul className="max-h-64 space-y-1 overflow-y-auto">
+									{results.map((u) => (
+										<li key={u.id}>
+											<button
+												type="button"
+												onClick={() => handleAdd(u)}
+												disabled={u.isInGame || adding}
+												className="flex w-full items-center justify-between gap-2 rounded-md border border-border bg-card px-3 py-2 text-left text-sm hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
+											>
+												<div className="min-w-0">
+													<div className="truncate font-semibold">{u.name}</div>
+													<div className="truncate text-xs text-muted-foreground">{u.email}</div>
+												</div>
+												{u.isInGame && (
+													<span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-bold uppercase text-muted-foreground">
+														In game
+													</span>
+												)}
+											</button>
+										</li>
+									))}
+								</ul>
+							)}
+							{!searching && query.length > 0 && results.length === 0 && (
+								<p className="text-xs text-muted-foreground">No matching users.</p>
+							)}
+							{error && <p className="text-xs text-red-500">{error}</p>}
+						</div>
+					</>
+				)}
+			</DialogContent>
+		</Dialog>
+	)
+}
+```
+
+(If the existing modal had different props — e.g., it took an `onAdded` callback rather than handling navigation internally — preserve that contract. The above is the most likely shape based on the original; double-check against the parent `admin-panel.tsx` usage and adapt.)
+
+### Step 5: Update `admin-panel.tsx` to pass `open` + `onClose`
+
+The current pattern is:
+
+```tsx
+{openModal === 'add' && <AddPlayerModal gameId={gameId} onClose={() => setOpenModal(null)} />}
+```
+
+Change to:
+
+```tsx
+<AddPlayerModal gameId={gameId} open={openModal === 'add'} onClose={() => setOpenModal(null)} />
+```
+
+(The shadcn Dialog can stay mounted with `open=false`; it just doesn't render the overlay.)
+
+Same for `split-pot-modal` if its mount pattern is similar — but that's Task 2. Leave split-pot alone for this task.
+
+### Step 6: Run tests + typecheck + lint
+
+```
+pnpm vitest run src/components/game/add-player-modal.test.tsx
+pnpm tsc --noEmit
+pnpm exec biome check --write src/components/game/add-player-modal.tsx src/components/game/admin-panel.tsx
+pnpm test
+```
+
+Expected: tests pass; typecheck clean; **no remaining `biome-ignore lint/a11y/*` lines in `add-player-modal.tsx`**.
+
+### Step 7: Commit
+
+```
+git add src/components/game/add-player-modal.tsx src/components/game/admin-panel.tsx src/components/game/add-player-modal.test.tsx
+git commit -m "feat(4c5): migrate add-player-modal to shadcn Dialog"
+```
+
+---
+
+## Task 2: Migrate `split-pot-modal` to shadcn `Dialog`
+
+**Context:** Same pattern as Task 1. `split-pot-modal.tsx` has the same custom-`<div>` pattern with the same four `biome-ignore` lines. The modal's content is a confirmation prompt with a "Split £X across N winners" button.
+
+**Files:**
+- Modify: `src/components/game/split-pot-modal.tsx`
+- Modify: `src/components/game/admin-panel.tsx` (caller — same `open` prop change as Task 1's Step 5, applied to split-pot now)
+
+### Step 1: Optional test (only if testing-library available)
+
+```tsx
+// src/components/game/split-pot-modal.test.tsx
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { SplitPotModal } from './split-pot-modal'
+
+describe('SplitPotModal', () => {
+  it('Escape closes the modal', () => {
+    const onClose = vi.fn()
+    render(<SplitPotModal gameId="g1" aliveCount={3} potTotal="300.00" open={true} onClose={onClose} />)
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+```
+
+Skip if testing-library isn't available. The migration is mechanical and the manual smoke at Step 5 is sufficient.
+
+### Step 2: Migrate the modal
+
+Replace `src/components/game/split-pot-modal.tsx` with:
+
+```tsx
+'use client'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '@/components/ui/dialog'
+
+interface SplitPotModalProps {
+	gameId: string
+	aliveCount: number
+	potTotal: string
+	open: boolean
+	onClose: () => void
+}
+
+export function SplitPotModal({ gameId, aliveCount, potTotal, open, onClose }: SplitPotModalProps) {
+	const router = useRouter()
+	const [submitting, setSubmitting] = useState(false)
+	const [error, setError] = useState<string | null>(null)
+
+	const totalNum = Number(potTotal)
+	const perWinner = aliveCount > 0 ? (totalNum / aliveCount).toFixed(2) : '0.00'
+
+	async function handleConfirm() {
+		if (submitting) return
+		setSubmitting(true)
+		setError(null)
+		try {
+			const res = await fetch(`/api/games/${gameId}/admin/split-pot`, { method: 'POST' })
+			const body = await res.json()
+			if (!res.ok) {
+				setError(body.error ?? 'failed')
+				return
+			}
+			onClose()
+			router.refresh()
+		} finally {
+			setSubmitting(false)
+		}
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+			<DialogContent className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle>Split the pot now?</DialogTitle>
+					<DialogDescription>
+						This ends the game immediately. All {aliveCount} alive players are marked as winners.
+						Eliminated players get nothing.
+					</DialogDescription>
+				</DialogHeader>
+				<div className="rounded-md border border-border bg-card p-3 text-center">
+					<div className="text-xl font-extrabold tabular-nums text-emerald-500">£{perWinner} each</div>
+					<div className="mt-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+						£{potTotal} split {aliveCount} ways
+					</div>
+				</div>
+				<p className="rounded-r-sm border-l-2 border-amber-500 bg-amber-500/10 px-2 py-2 text-[11px] text-amber-500">
+					⚠ This can't be undone. Game status becomes "completed".
+				</p>
+				{error && <p className="text-xs text-red-500">Couldn't split: {error}</p>}
+				<DialogFooter>
+					<button
+						type="button"
+						onClick={onClose}
+						disabled={submitting}
+						className="rounded-md border border-border bg-transparent px-3 py-1.5 text-xs font-semibold text-muted-foreground"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						onClick={handleConfirm}
+						disabled={submitting || aliveCount < 2}
+						className="rounded-md bg-emerald-500 px-3 py-1.5 text-xs font-bold text-white disabled:opacity-50"
+					>
+						Split £{potTotal} across {aliveCount} winners
+					</button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	)
+}
+```
+
+### Step 3: Update `admin-panel.tsx` for split-pot mount
+
+Change the conditional render to pass `open`:
+
+```tsx
+<SplitPotModal
+	gameId={gameId}
+	aliveCount={aliveCount}
+	potTotal={potTotal}
+	open={openModal === 'split'}
+	onClose={() => setOpenModal(null)}
+/>
+```
+
+### Step 4: Run tests + typecheck + lint
+
+```
+pnpm test
+pnpm tsc --noEmit
+pnpm exec biome check --write src/components/game/split-pot-modal.tsx src/components/game/admin-panel.tsx
+```
+
+Expected: full suite green; typecheck clean; no `biome-ignore lint/a11y/*` lines remain in `split-pot-modal.tsx`.
+
+### Step 5: Commit
+
+```
+git add src/components/game/split-pot-modal.tsx src/components/game/admin-panel.tsx src/components/game/split-pot-modal.test.tsx
+git commit -m "feat(4c5): migrate split-pot-modal to shadcn Dialog"
+```
+
+---
+
+## Task 3: "IN GAME" tag on add-player autocomplete
+
+**Context:** The admin add-player modal can attempt to add a user who is already a `game_player` for the current game. The API returns 409 `already-in-game`, but the autocomplete doesn't anticipate it. Surface an "(in game)" badge on result rows that match an existing player.
+
+**Files:**
+- Modify: `src/app/api/users/search/route.ts` (accept `?gameId=` query param; return `isInGame` per result)
+- Modify: `src/app/api/users/search/route.test.ts` (test the new branch)
+- The modal UI (from Task 1) already renders the `isInGame` badge — no changes needed there if Task 1 was done correctly.
+
+### Step 1: Add a failing test
+
+In `src/app/api/users/search/route.test.ts`, add:
+
+```ts
+it('marks results as isInGame when ?gameId= matches an existing game_player', async () => {
+  // Mock setup follows the existing pattern in this test file.
+  // db.select().from().where().limit() returns [{ id: 'u1', name: 'Sean', email: 's@example.com' }]
+  // db.query.gamePlayer.findMany({where: gameId=g1}) returns [{ userId: 'u1' }]
+  // ...read the existing test file to mirror its mocking style and adapt.
+
+  const res = await GET(new Request('http://x?q=sean&gameId=g1'))
+  expect(res.status).toBe(200)
+  const body = await res.json()
+  expect(body.users).toEqual([{ id: 'u1', name: 'Sean', email: 's@example.com', isInGame: true }])
+})
+
+it('omits isInGame (or sets false) when ?gameId= is not provided', async () => {
+  // Mock setup: same db.select returns the same user; gamePlayer query NOT called.
+  const res = await GET(new Request('http://x?q=sean'))
+  expect(res.status).toBe(200)
+  const body = await res.json()
+  // Existing behavior: response shape is {users: [{id, name, email}]}.
+  expect(body.users[0].isInGame).toBeUndefined()
+})
+```
+
+Read `src/app/api/users/search/route.test.ts` first to mirror its mocking style; the snippets above are illustrative.
+
+### Step 2: Run the tests (expect fails)
+
+```
+pnpm vitest run src/app/api/users/search
+```
+
+Expected: new tests fail because the route doesn't read `gameId` or set `isInGame`.
+
+### Step 3: Update the route
+
+Replace `src/app/api/users/search/route.ts` with:
+
+```ts
+import { and, eq, inArray, or, sql } from 'drizzle-orm'
+import { NextResponse } from 'next/server'
+import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { user } from '@/lib/schema/auth'
+import { gamePlayer } from '@/lib/schema/game'
+
+export async function GET(request: Request): Promise<Response> {
+	await requireSession()
+
+	const { searchParams } = new URL(request.url)
+	const q = (searchParams.get('q') ?? '').trim()
+	const gameId = searchParams.get('gameId')
+	if (q.length === 0) {
+		return NextResponse.json({ users: [] })
+	}
+
+	const pattern = `${q.toLowerCase()}%`
+	const results = await db
+		.select({ id: user.id, name: user.name, email: user.email })
+		.from(user)
+		.where(or(sql`lower(${user.name}) like ${pattern}`, sql`lower(${user.email}) like ${pattern}`))
+		.limit(10)
+
+	if (!gameId || results.length === 0) {
+		return NextResponse.json({ users: results })
+	}
+
+	const userIds = results.map((u) => u.id)
+	const existingPlayers = await db
+		.select({ userId: gamePlayer.userId })
+		.from(gamePlayer)
+		.where(and(eq(gamePlayer.gameId, gameId), inArray(gamePlayer.userId, userIds)))
+	const inGameSet = new Set(existingPlayers.map((p) => p.userId))
+
+	const augmented = results.map((u) => ({ ...u, isInGame: inGameSet.has(u.id) }))
+	return NextResponse.json({ users: augmented })
+}
+```
+
+### Step 4: Run tests (expect pass)
+
+```
+pnpm vitest run src/app/api/users/search
+pnpm tsc --noEmit
+```
+
+### Step 5: Commit
+
+```
+git add src/app/api/users/search src/components/game/add-player-modal.tsx
+git commit -m "feat(4c5): mark in-game users in /users/search; render badge in autocomplete"
+```
+
+(The `add-player-modal.tsx` is included because Task 1 already wrote the rendering for `u.isInGame` — but the API's `?gameId=` plumbing is what makes the flag present.)
+
+---
+
+## Task 4: Free-player rebuy in payments panel
+
+**Context:** Admin-added players with `paymentRowCount=0` are rebuy-eligible per `isRebuyEligible` but invisible in the payments panel because the panel iterates only payment rows. Surface them as synthetic rows so the admin Rebuy button is reachable.
+
+**Files:**
+- Modify: `src/lib/game/detail-queries.ts` (extend `allPayments` builder)
+- Modify: `src/components/game/payments-panel.tsx` (widen `AdminPayment.id` to `string | null`, `status` to include `'unpaid'`)
+- Modify: `src/lib/game/detail-queries.test.ts` (or wherever the admin payments builder is tested)
+
+### Step 1: Read existing structure
+
+Read `src/lib/game/detail-queries.ts` around line 140 (the `allPayments = Array.from(paymentsByUser.entries()).flatMap(...)` block). Read `src/components/game/payments-panel.tsx`'s `AdminPayment` interface at line 7.
+
+### Step 2: Widen `AdminPayment` types in `payments-panel.tsx`
+
+Change:
+
+```ts
+export interface AdminPayment {
+	id: string                 // <-- was string
+	userId: string
+	userName: string
+	amount: string
+	status: PaymentStatus       // <-- was PaymentStatus only
+	isRebuy: boolean
+	isRebuyEligible: boolean
+	claimedAt: Date | null
+	paidAt: Date | null
+}
+```
+
+to:
+
+```ts
+export type AdminPaymentStatus = PaymentStatus | 'unpaid'
+
+export interface AdminPayment {
+	id: string | null  // null for synthetic "no payment yet" rows
+	userId: string
+	userName: string
+	amount: string
+	status: AdminPaymentStatus
+	isRebuy: boolean
+	isRebuyEligible: boolean
+	claimedAt: Date | null
+	paidAt: Date | null
+}
+```
+
+In the `Row` rendering, the existing actions only show `Dispute` for `paid` and `Rebuy player` when `isRebuyEligible`. The new `'unpaid'` status falls through to neither — perfect; only the Rebuy button appears.
+
+Also update `PaymentStatusChip` if it doesn't already handle the `'unpaid'` literal. Read `src/components/game/payment-status-chip.tsx`; if it doesn't accept `'unpaid'`, extend its allowed values + add a grey "Unpaid" chip. (One-line extension.)
+
+### Step 3: Extend the builder in `detail-queries.ts`
+
+Around the `allPayments` builder block (~line 140), after building `allPayments` from payment rows, add synthetic rows for `gamePlayer` entries that have NO payment row at all:
+
+```ts
+const playersWithPayments = new Set(allPayments.map((p) => p.userId))
+const playersWithoutPayments = gameData.players.filter(
+	(p) => !playersWithPayments.has(p.userId),
+)
+const syntheticUnpaidRows = playersWithoutPayments.map((p) => ({
+	id: null as string | null,
+	userId: p.userId,
+	userName: userNames.get(p.userId) ?? 'Unknown',
+	amount: gameData.entryFee ?? '0.00',
+	status: 'unpaid' as const,
+	isRebuy: false,
+	isRebuyEligible: eligibilityByUser.get(p.userId) ?? false,
+	claimedAt: null,
+	paidAt: null,
+}))
+const finalAdminPayments = [...allPayments, ...syntheticUnpaidRows]
+```
+
+Replace the downstream consumer (`adminPayments = isAdmin ? allPayments : undefined`) with `adminPayments = isAdmin ? finalAdminPayments : undefined`.
+
+`eligibilityByUser` and `userNames` are already in scope from Phase 4c3's changes.
+
+### Step 4: Add a test
+
+Append to `src/lib/game/detail-queries.test.ts` (if it exists; otherwise add as part of an existing nearby test file or skip if no test infrastructure for `getGameDetail`):
+
+```ts
+it('emits a synthetic unpaid row for admin-added players with no payment', async () => {
+  // Mock setup: gameData.players = [{userId: 'u1', status: 'alive'}], no payments at all
+  // for u1 (the gamePlayer was created via admin-add-player without a payment).
+  // Expect the admin payments list to include a row with id=null, status='unpaid',
+  // userId='u1', isRebuyEligible=true (assuming the predicate fires for round-1
+  // eliminated etc — set up the mock to satisfy that).
+  // ...mirror the mocking style of existing tests in detail-queries.test.ts...
+})
+```
+
+If `detail-queries.test.ts` doesn't exist or doesn't cover `getGameDetail` directly, skip the test and rely on manual verification with the seeded "admin-added free player" fixture from Phase 4c3.
+
+### Step 5: Verify and commit
+
+```
+pnpm test
+pnpm tsc --noEmit
+pnpm exec biome check --write src/lib/game/detail-queries.ts src/components/game/payments-panel.tsx src/components/game/payment-status-chip.tsx
+git add src/lib/game src/components/game
+git commit -m "feat(4c5): surface admin-added free players in payments panel as unpaid rows"
+```
+
+Expected: typecheck clean; full suite green.
+
+---
+
+## Task 5: Seed live + winner + split-pot games for share variant smoke
+
+**Context:** Per spec W6. Three new seeded games in `scripts/seed.ts` so `just db-reset` puts each share variant in a smoke-testable state. Models on the existing 4c3 "Rebuy Lads" pattern (around line 853 of `seed.ts`).
+
+**Files:**
+- Modify: `scripts/seed.ts`
+
+### Step 1: Read the existing seed pattern
+
+Read `scripts/seed.ts` end-to-end if you haven't already, but pay special attention to:
+- The "Rebuy smoke game (Phase 4c3)" section (~line 853) for game-with-state pattern.
+- Any existing pattern for marking fixtures as `live` or `finished` with non-null scores.
+- How users are created/referenced (existing dev users at the top of the file).
+
+### Step 2: Add the three new games
+
+Append, after the rebuy smoke section, three new game seeds:
+
+**5a — Live snapshot (classic):**
+- Game name: `Live Lads (4c5 smoke)`, `gameMode='classic'`, `entryFee='10.00'`, `status='active'`.
+- Round 1: completed, with a fixture that has fixed scores.
+- Round 2: `status='active'`, `currentRoundId` points to it; one fixture in round 2 has `status='live'` with `homeScore=1`, `awayScore=0` (so a player picking the home team is "winning").
+- 3 players, all `alive`, all with paid payments. Each has a pick for round 2 — one for the live fixture's home team, one for the live fixture's away team, one for a different fixture (`scheduled` / KO not yet).
+- Expected: when this game opens in the share dialog, `defaultShareVariant === 'live'`.
+
+**5b — Solo winner (classic):**
+- Game name: `Champion's Cup (4c5 smoke)`, `gameMode='classic'`, `entryFee='20.00'`, `status='completed'`.
+- 4 players, 1 with `status='winner'`, 3 with `status='eliminated'`.
+- All four with paid payments (so pot = £80).
+- Expected: when this game opens in the share dialog, `defaultShareVariant === 'winner'` and the winner block shows a single winner with £80 pot.
+
+**5c — Split-pot winner (cup):**
+- Game name: `Split Cup (4c5 smoke)`, `gameMode='cup'`, `modeConfig={ startingLives: 2, numberOfPicks: 5 }`, `entryFee='20.00'`, `status='completed'`.
+- 5 players, 2 with `status='winner'`, 3 with `status='eliminated'`.
+- All five with paid payments (pot = £100, so split = £50 each).
+- Expected: when this game opens in the share dialog, `defaultShareVariant === 'winner'` and the winner block shows 2 winners with £50 each.
+
+Reuse existing user IDs from the seed file's user creation block. Pick competitions/rounds/fixtures from the existing seed sets — don't create new ones.
+
+### Step 3: Verify the seed runs
+
+```
+docker compose up -d  # if not already running
+just db-reset
+```
+
+Expected: seed completes without error. Optional: open `psql` and confirm the three new games exist with their expected `status` and `currentRoundId`.
+
+```
+docker compose exec -T postgres psql -U postgres -d lps_dev -c "select name, status, game_mode from game where name like '%4c5 smoke%';"
+```
+
+### Step 4: Commit
+
+```
+git add scripts/seed.ts
+git commit -m "chore(seed): add live/winner/split-pot smoke games for 4c5"
+```
+
+---
+
+## Task 6: Remove `/api/share/grid/[gameId]` legacy alias
+
+**Context:** Per spec W7. The alias was kept for one phase as belt-and-braces; ShareDialog points at `/standings` directly now (verified in `src/components/game/share-dialog.tsx`).
+
+**Files:**
+- Delete: `src/app/api/share/grid/` (the whole folder)
+
+### Step 1: Confirm no callers
+
+```
+grep -rn "/api/share/grid" src
+```
+
+Expected: zero results (ShareDialog uses `/api/share/${variant}/${gameId}` where variant is `standings`/`live`/`winner`).
+
+### Step 2: Delete the folder
+
+```
+rm -rf src/app/api/share/grid
+```
+
+### Step 3: Verify and commit
+
+```
+pnpm test
+pnpm tsc --noEmit
+git add -A
+git commit -m "chore(4c5): remove legacy /api/share/grid alias"
+```
+
+Expected: full suite stays green; the alias's tests are deleted with the folder.
+
+---
+
+## Task 7: Mobile width audit pass
+
+**Context:** Per spec W2. Open each in-scope page in DevTools at iPhone 393px (or 360px Android secondary). Catalogue any horizontal-scroll, unreachable-control, or unreadable-text issues. Apply Tailwind utility fixes only (no structural rewrites). Document each fix in commit messages.
+
+**Files (potential — depends on what the audit finds):**
+- `src/app/(app)/page.tsx` — dashboard
+- `src/app/(app)/game/[id]/page.tsx` — game detail
+- `src/app/(app)/game/create/page.tsx` — game creation
+- `src/app/(app)/join/[code]/page.tsx` — join page
+- Any sub-components rendered within those pages
+
+### Step 1: Boot the dev environment with seeded data
+
+```
+docker compose up -d
+just db-reset  # uses the new 4c5 seeded games from Task 5
+just dev
+```
+
+In a separate terminal/tab, open Chrome DevTools → toggle device toolbar → choose iPhone 14 Pro (393×852) → Open `http://localhost:3000`.
+
+### Step 2: Audit each page
+
+For each page in scope, with several seeded games to navigate to:
+
+1. **Dashboard** (`/`) — look at: card grid layout, action buttons, "join game" CTA, padding.
+2. **Game detail (classic)** (`/game/<id>` for the rebuy or live smoke game) — look at: header, admin panel, payments panel, standings grid (including 30-row case if seed has enough), pick UI, share dialog.
+3. **Game detail (cup)** — similar, focus on cup-grid horizontal scroll behavior.
+4. **Game detail (turbo)** — similar, focus on turbo grid + ladder views.
+5. **Game create** (`/game/create`) — look at: form steppers, mode selector cards, switches.
+6. **Join** (`/join/<code>`) — look at: invite preview, accept/decline buttons.
+
+For each issue found:
+- Identify the responsible component(s).
+- Add Tailwind utilities to fix (e.g., `flex-col md:flex-row`, `text-sm md:text-base`, `overflow-x-auto`, `max-w-full`, `min-w-0`, `truncate`).
+- Commit per page with a message describing what was fixed.
+
+### Step 3: Commit pattern
+
+For each page (or batch of related fixes):
+
+```
+git add <files>
+git commit -m "fix(4c5): mobile width fixes on <page>"
+```
+
+Example commit messages:
+- `fix(4c5): mobile width fixes on dashboard — single-column grid below md`
+- `fix(4c5): mobile width fixes on game detail — admin panel actions stack on narrow widths`
+- `fix(4c5): mobile width fixes on cup grid — sticky player column for horizontal scroll`
+
+### Step 4: After all pages audited, full suite check
+
+```
+pnpm test
+pnpm tsc --noEmit
+pnpm exec biome check --write .
+```
+
+Expected: all pass. Mobile fixes shouldn't break anything; if they do, the responsive utility was wrong — adjust.
+
+### Step 5: If a page needs a structural rewrite (out of scope)
+
+Document it in the PR body as "deferred to post-launch" and move on. Don't pad 4c5.
+
+---
+
+## Task 8: Keyboard navigation pass
+
+**Context:** Per spec W3. Walk Tab through each main flow. Document gaps; fix simple ones.
+
+**Files (potential):**
+- Anywhere `<div onClick>` is used without `role="button"` and `tabIndex` — likely 5-10 occurrences across components.
+
+### Step 1: Find candidate sites
+
+```
+grep -rn "onClick" src/components --include="*.tsx" | grep -v "type=" | grep "<div\|<span\|<li" | head -40
+```
+
+This catches `<div onClick>`, `<span onClick>`, `<li onClick>` — the typical keyboard-inaccessible patterns. Many will be fine (e.g., backdrop click handlers); some will be interactive-but-not-buttoned.
+
+### Step 2: For each candidate, decide
+
+- **If it's a real interactive control** (e.g., a clickable card that navigates somewhere): convert to `<button>` (or `<a>` if it's navigation), inheriting Tailwind `cursor-pointer` and tab semantics.
+- **If it's a backdrop / scrim**: already handled by the modal migration (Task 1, 2). Skip.
+- **If it's an interactive element that genuinely shouldn't be a button** (rare): add `role="button"`, `tabIndex={0}`, `onKeyDown` for Enter/Space.
+
+### Step 3: Verify focus-ring visibility
+
+Look at `tailwind.config.ts` (if present) or `app/globals.css` for `focus-visible:` defaults. Confirm interactive elements have visible focus rings. If a button class is missing `focus-visible:ring-*`, add it.
+
+Spot-check by Tab-traversing the dashboard and game detail pages in the browser. Confirm every reachable element has a visible focus indicator.
+
+### Step 4: Commit
+
+Per fix or per file batch:
+
+```
+git add <files>
+git commit -m "fix(4c5): keyboard nav — convert <div onClick> to <button> in <component>"
+```
+
+### Step 5: After all fixes, full suite check
+
+```
+pnpm test
+pnpm tsc --noEmit
+pnpm exec biome check --write .
+```
+
+---
+
+## Task 9: Biome warnings final cleanup
+
+**Context:** Per spec W4. After Tasks 1-8, the count should be lower (modal a11y suppressions gone). Final pass to clear remaining warnings.
+
+**Files (potential):**
+- `scripts/seed.ts` (`noNonNullAssertion`)
+- `src/app/api/picks/[gameId]/[roundId]/route.ts` (`noNonNullAssertion`)
+- `src/lib/game/detail-queries.ts` (`useOptionalChain` — pre-existing in `getShareLiveData`)
+- Whatever else surfaces
+
+### Step 1: Run Biome
+
+```
+pnpm exec biome check .
+```
+
+Note the warnings.
+
+### Step 2: Fix each
+
+For `noNonNullAssertion`:
+- Replace `foo!` with explicit null-check or `?.` chain.
+- If the assertion is genuinely needed (e.g., for a value the type system can't narrow but you've verified is present), leave a `// biome-ignore lint/style/noNonNullAssertion: <reason>` with a real explanation.
+
+For `useOptionalChain`:
+- Apply Biome's suggested fix (replace `a && a.b` with `a?.b`).
+
+### Step 3: Verify zero warnings
+
+```
+pnpm exec biome check .
+```
+
+Expected: `Found 0 warnings` (or just no warning lines).
+
+### Step 4: Commit
+
+```
+git add -A
+git commit -m "chore(4c5): clear remaining Biome warnings"
+```
+
+---
+
+## Task 10: Final sweep + PR
+
+**Files:** none (just verification + push).
+
+### Step 1: Full verification
+
+```
+pnpm test
+pnpm tsc --noEmit
+pnpm exec biome check .
+pnpm build
+```
+
+All four must pass (build succeeds with `.env.local` from `.env.example`; suite green; typecheck clean; zero Biome warnings).
+
+### Step 2: Manual smoke summary
+
+Confirm at iPhone 393px:
+- Dashboard renders, card grid stacks if needed, all CTAs visible.
+- Game detail (classic + cup + turbo) renders without horizontal-scroll page-bleed.
+- Add player + split pot modals open, trap focus, Escape closes.
+- Share dialog renders correctly; dropdown reachable; download works.
+- Rebuy banner stacks correctly when present.
+
+### Step 3: Push + PR
+
+```
+git push -u origin feature/phase-4c5-mobile-and-a11y
+gh pr create --title "Phase 4c5: mobile polish + a11y sweep" --body "$(cat <<'PRBODY'
+## Summary
+
+Polish + a11y sweep across 4a/4b/4c surfaces. Migrates two custom modals to shadcn `Dialog`, runs a mobile width pass at iPhone 393px, clears all Biome warnings, finishes carry-over deferrals from earlier phases.
+
+### What's done
+- `add-player-modal` + `split-pot-modal` migrated to shadcn `Dialog` — focus trap, Escape, `aria-labelledby` for free; four `biome-ignore lint/a11y/*` suppressions removed.
+- "IN GAME" badge on add-player autocomplete via `?gameId=` query param on `/api/users/search`.
+- Free-player rebuy in payments panel: synthetic "unpaid" rows surface admin-added players with no payment row so the Rebuy button is reachable.
+- Three new seeded games for share-variant smoke (live snapshot, solo winner, split-pot winner).
+- Legacy `/api/share/grid/[gameId]` alias deleted.
+- Mobile width audit + fixes across dashboard, game detail (per mode), game create, join. Tailwind utility additions only.
+- Keyboard nav pass: rogue `<div onClick>` interactives converted to `<button>`/`<a>`; focus rings audited.
+- All Biome warnings resolved (0 → 0).
+
+### Out of scope (deferred)
+- WCAG 2.1 AA conformance audit.
+- Screen-reader testing.
+- Mobile-first re-thinks (bottom nav, swipe gestures).
+- User-search email enumeration hardening — verified during plan write-up that the endpoint already returns uniform `{users: []}` shape; not a leak.
+
+### Spec & plan
+- `docs/superpowers/specs/2026-04-27-phase-4c5-mobile-and-a11y-design.md`
+- `docs/superpowers/plans/2026-04-27-phase-4c5-mobile-and-a11y.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+PRBODY
+)"
+```
+
+Done. Phase 4c5 ready for dormant merge.
+
+---
+
+## Self-review summary
+
+- ✅ Spec W1 (modal a11y migration) → Tasks 1, 2.
+- ✅ Spec W2 (mobile width pass) → Task 7.
+- ✅ Spec W3 (keyboard nav pass) → Task 8.
+- ✅ Spec W4 (Biome warnings cleanup) → Task 9.
+- ✅ Spec W5 ("IN GAME" tag) → Task 3.
+- ✅ Spec W6 (seed live/winner/split-pot) → Task 5.
+- ✅ Spec W7 (`/grid` removal) → Task 6.
+- ✅ Spec W8 (free-player rebuy in panel) → Task 4.
+- ⊘ Spec W9 (email enumeration) — dropped: verified during plan write-up that `users/search/route.ts` returns uniform `{users: []}` shape regardless of match. No leak. Documented in plan header.
+
+**Deferred from spec:**
+- None at the spec level. WCAG, screen-reader testing, mobile re-think, color contrast — all explicitly out of scope per spec §"Non-goals".

--- a/docs/superpowers/specs/2026-04-27-phase-4c5-mobile-and-a11y-design.md
+++ b/docs/superpowers/specs/2026-04-27-phase-4c5-mobile-and-a11y-design.md
@@ -1,0 +1,176 @@
+# Phase 4c5 — Mobile Polish + A11y Sweep: Design Specification
+
+**Status:** Approved for planning (2026-04-27)
+**Phase:** 4c5 — fifth and final sub-phase of 4c (match-day live / admin UX / rebuys / Satori / mobile polish)
+**Predecessors:** 4c1, 4c2, 4c3, 4c4 — all merged
+**Successors:** 4.5 (production launch foundation) — terminal phase
+**Ships:** dormant to `main` via PR; no prod deploy (no Vercel project provisioned yet — 4.5's job)
+
+## Overview
+
+A polish-and-cleanup sweep across the existing 4a/4b/4c surfaces. Not a feature phase. Two custom-rolled modals get migrated to shadcn `Dialog` for free a11y wins; mobile width breakages get audited and fixed at iPhone 390px; carry-over deferrals from 4c2/4c3/4c4 get cleared. Eight workstreams, all small enough to land in one branch + PR.
+
+## Goals
+
+1. Modals (`add-player-modal`, `split-pot-modal`) get focus trap + Escape-to-close + `aria-labelledby` via shadcn `Dialog` migration. Biome a11y suppressions go away.
+2. Main flows render cleanly on iPhone Safari at 393px without horizontal scroll or unreachable controls.
+3. All interactive elements are keyboard-reachable; modals trap focus; visible focus rings on every interactive.
+4. ~8 Biome warnings cleared.
+5. Carry-over deferrals from 4c2/4c3/4c4 cleared (concrete list in §"Workstreams").
+
+## Non-goals (explicit)
+
+- Formal WCAG 2.1 AA conformance audit. Deferred post-launch.
+- Screen-reader testing (NVDA/JAWS/VoiceOver). Deferred.
+- Mobile-first re-thinks (bottom navigation, swipe gestures, mobile-only pick UIs). Deferred.
+- Color contrast formal audit. Deferred.
+- New features. Anything that's "improve the design of X" rather than "fix the broken-on-mobile-or-keyboard X" is out.
+- Performance optimization, bundle size, image optimization.
+- Visual regression testing infrastructure (4.5+ concern).
+
+## Mobile target
+
+- **Primary:** iPhone Safari at 393px logical width.
+- **Secondary:** Chrome Android at 360px.
+- Verification: manual smoke in browser DevTools mobile preview. No automated screenshot/visual-regression infrastructure.
+
+## A11y bar
+
+- Keyboard navigation works on all interactive elements (Tab to reach, Enter/Space to activate).
+- Modals trap focus (free with shadcn `Dialog`).
+- Escape closes modals (free with shadcn `Dialog`).
+- Visible focus rings on every interactive (Tailwind `focus-visible:` utilities).
+- No formal WCAG conformance claim. No screen-reader testing.
+
+## Workstreams
+
+### W1: Modal a11y migration (highest signal)
+
+`src/components/game/add-player-modal.tsx` and `src/components/game/split-pot-modal.tsx` currently roll their own `<div role="dialog">` with `biome-ignore lint/a11y/*` lines. Migrate both to shadcn `Dialog` from `@/components/ui/dialog` (already used cleanly in `share-dialog.tsx`).
+
+Wins:
+- Focus trap, Escape-to-close, `aria-labelledby` come for free.
+- All four `biome-ignore lint/a11y/*` suppressions removed.
+- Keyboard navigation works automatically.
+
+Tests: existing component tests stay. Add an integration smoke that asserts Escape closes the modal.
+
+### W2: Mobile width pass
+
+Audit + adjust at iPhone 390px (logical 393px). Pages in scope:
+
+- `/` (dashboard)
+- `/game/[id]` (per mode: classic, cup, turbo)
+- `/game/create` (game creation form)
+- `/join/[code]` (join page)
+
+**Audit method:** During implementation, open each page in dev with `just db-reset` data, view at 393px in DevTools mobile preview, catalogue fixes per page in commit messages.
+
+**Likely fixes:**
+- Collapse multi-column grids to single column at narrow widths (`grid-cols-2 md:grid-cols-3` patterns).
+- Verify horizontal-scroll containers (cup/turbo pick grids in particular) — they should `overflow-x-auto` with sticky player columns.
+- Verify ShareDialog at narrow widths (image renders, dropdown reachable, download button reachable).
+- Verify rebuy banner stacks correctly (call-to-action button below text on narrow widths).
+- Verify game header doesn't truncate game name unreadably.
+
+**Out of scope:** structural rewrites. Fixes are Tailwind utility additions only.
+
+### W3: Keyboard navigation pass
+
+Walk Tab through each main flow. For each interactive element, verify:
+- Reachable via Tab in logical order.
+- Activates with Enter/Space (buttons) or Enter (links).
+- Has a visible focus ring.
+
+**Document any gaps found.** Fix gaps that are simple (`tabIndex`, `<button>` substitution for `<div onClick>`, missing `focus-visible:ring-*`); flag complex ones for follow-up.
+
+**Out of scope:** screen-reader navigation, ARIA landmarks audit.
+
+### W4: Biome warnings cleanup
+
+Current state: ~8 warnings. Mix of:
+- `lint/style/noNonNullAssertion` (in `scripts/seed.ts`, `src/app/api/picks/[gameId]/[roundId]/route.ts`)
+- `lint/complexity/useOptionalChain` (in `src/lib/game/detail-queries.ts`)
+- `lint/suppressions/unused` × 2 (in `add-player-modal`, `split-pot-modal` — go away with W1)
+
+Resolve each. Final state: `pnpm exec biome check .` reports 0 warnings.
+
+### W5: "IN GAME" tag on add-player autocomplete
+
+When admin searches for a user to add via the migrated `add-player-modal`, surface an "(in game)" badge on result rows where the user is already a `game_player` for the current game. Prevents duplicate-add attempts (currently the API returns 409 `already-in-game`, but the UI doesn't anticipate it).
+
+Implementation: `src/app/api/users/search/route.ts` accepts an optional `?gameId=` query param; when present, the response includes `isInGame: boolean` per result. UI renders the badge based on the flag.
+
+### W6: Seed live/winner/split-pot games
+
+Three new seeded games in `scripts/seed.ts` so `just db-reset` puts each share variant in a smoke-testable state:
+
+1. **Live snapshot** — classic game with `currentRound.status='active'` and at least one fixture `status='live'` with non-null `homeScore`/`awayScore`. Triggers `defaultShareVariant='live'`.
+2. **Solo winner** — classic game with `status='completed'` and one player with `status='winner'`. Triggers `defaultShareVariant='winner'` with single-winner block.
+3. **Split-pot winner** — classic or cup game with `status='completed'` and 2-3 players with `status='winner'`. Triggers `defaultShareVariant='winner'` with split-pot block.
+
+### W7: Remove `/api/share/grid/[gameId]` alias
+
+The legacy route was kept one phase as belt-and-braces. ShareDialog points at `/api/share/standings/[gameId]` directly now. Delete `src/app/api/share/grid/[gameId]/route.tsx`.
+
+### W8: Free-player rebuy in payments panel
+
+Admin-added players with `paymentRowCount=0` are rebuy-eligible per the `isRebuyEligible` predicate but don't appear as a row in the payments panel (which iterates payment rows). Surface them as a "no payment yet" row so the admin Rebuy button is reachable.
+
+Implementation:
+- `getGameDetail` in `src/lib/game/detail-queries.ts`: extend the admin payments list builder to also iterate `gamePlayer` rows with no associated payment, emitting a synthetic row with `id: null`, `status: 'unpaid'`, `amount: game.entryFee ?? '0.00'`.
+- `payments-panel.tsx`: render the synthetic row; only the "Rebuy player" button shows (no Dispute/Override actions, since there's no payment to act on).
+- Type widening: `AdminPayment.id` becomes `string | null`; `status` adds `'unpaid'` literal.
+
+### W9 (conditional): User-search email enumeration hardening
+
+Verify `src/app/api/users/search/route.ts` doesn't differentiate response shape between "email matches a user" and "email doesn't match a user". Specifically:
+- HTTP status code identical.
+- Response body structure identical (e.g., `{users: []}` vs `{users: [{...}]}` is fine; `{found: false}` vs `{user: {...}}` is a leak).
+- Response timing roughly equivalent (don't worry about precise constant-time; a non-issue for this app's threat model).
+
+If the endpoint already responds uniformly, drop W9 from the plan. If it leaks, normalize to a uniform `{users: User[]}` shape.
+
+## Edge cases & invariants
+
+- **Modal migration breaking existing tests**: shadcn `Dialog` may use Radix primitives that interact differently with `userEvent`/`fireEvent`. If existing tests break post-migration, update them to assert on shadcn-rendered structure rather than the old custom `<div>`.
+- **Mobile audit reveals deeper issues**: if a page genuinely doesn't work on mobile and would need a structural rewrite, flag it and defer to a future phase. Don't pad 4c5.
+- **Free-player synthetic row + isRebuyEligible**: predicate already returns `true` for `paymentRowCount=0` — synthetic row works.
+- **Removing `/grid` alias breaks deployed clients**: irrelevant — no Vercel project means no deployed clients yet. The deployed dialog code is the in-repo `share-dialog.tsx` which already uses `/standings`.
+
+## Testing
+
+### Per-workstream
+
+- **W1 (modal a11y)**: existing `add-player-modal` and `split-pot-modal` component tests updated for shadcn `Dialog` rendering. Add Escape-closes test to each.
+- **W2 (mobile)**: manual smoke at 393px in DevTools. Per-page commit messages document fixes. No automated visual regression.
+- **W3 (keyboard nav)**: manual smoke. Per-issue commit messages.
+- **W4 (Biome)**: `pnpm exec biome check .` reports 0 warnings.
+- **W5 ("IN GAME" tag)**: extend `users/search/route.test.ts` to test the `?gameId=` branch returns `isInGame: true` for existing players. Add a component test for the autocomplete badge rendering.
+- **W6 (seed)**: `just db-reset` runs without error; manual smoke confirms each seeded game opens its expected default share variant in the dialog.
+- **W7 (`/grid` removal)**: route file deleted; full suite stays green.
+- **W8 (free-player rebuy)**: extend `detail-queries` test to assert a synthetic row is emitted for an admin-added player with no payment. Extend `payments-panel.test.tsx` to assert the row renders with only a Rebuy button.
+- **W9 (email enumeration)**: if the leak exists, add a test asserting both "found" and "not-found" responses are byte-identical.
+
+### Full-suite
+
+`pnpm test && pnpm tsc --noEmit && pnpm exec biome check .` must all pass with 0 errors and 0 warnings.
+
+## Rollout
+
+- **Schema changes:** none.
+- **Data migrations:** none.
+- **Branch:** `feature/phase-4c5-mobile-and-a11y` in `.worktrees/phase-4c5/`.
+- **Single PR (#7).** Ships dormant to `main`. No prod deploy until Phase 4.5.
+- **Test count target:** 319 (current) → ~325 after new tests for W1, W5, W8 (+W9 if applicable).
+
+## Success criteria
+
+1. `pnpm exec biome check .` reports 0 warnings.
+2. Both custom modals migrated to shadcn `Dialog`; no `biome-ignore lint/a11y/*` lines remain in the codebase.
+3. Manual mobile smoke at 393px on the 5 pages in scope shows no horizontal scroll, unreachable controls, or unreadable text.
+4. Tab navigation traverses all interactive elements on the main flows in logical order; modals trap focus; visible focus rings throughout.
+5. `just db-reset` produces seed data exercising all three share variants (standings/live/winner).
+6. Admin-added players with `paymentRowCount=0` are visible in the payments panel with a working Rebuy button.
+7. `/api/share/grid/[gameId]` returns 404 (file deleted).
+8. Test suite passes; typecheck clean.

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -933,7 +933,8 @@ async function seed() {
 		// Player A picks a winning team in GW1
 		const winnerFixtureA = gw1Fixtures.find((f) => fixtureWinnerTeam(f) !== null)
 		if (winnerFixtureA) {
-			const winner = fixtureWinnerTeam(winnerFixtureA)!
+			const winner = fixtureWinnerTeam(winnerFixtureA)
+			if (!winner) throw new Error('Winner team should exist in fixture')
 			await db.insert(pick).values({
 				gameId: rebuyGame.id,
 				gamePlayerId: gpA.id,
@@ -953,7 +954,8 @@ async function seed() {
 			(f) => fixtureLoserTeam(f) !== null && f.id !== winnerFixtureA?.id,
 		)
 		if (loserFixtureB) {
-			const loser = fixtureLoserTeam(loserFixtureB)!
+			const loser = fixtureLoserTeam(loserFixtureB)
+			if (!loser) throw new Error('Loser team should exist in fixture')
 			await db.insert(pick).values({
 				gameId: rebuyGame.id,
 				gamePlayerId: gpB.id,

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -997,6 +997,273 @@ async function seed() {
 		console.log(`Updated 2 fixtures in round 8 to live status for verification`)
 	}
 
+	// --- 4c5 smoke games ---
+	// Three games that each trigger a different defaultShareVariant in the share dialog:
+	//   5a  Live Lads      → variant = 'live'    (active game, current round has live fixture)
+	//   5b  Champion's Cup → variant = 'winner'  (completed game, 1 winner)
+	//   5c  Split Cup      → variant = 'winner'  (completed game, 2 co-winners)
+
+	// Round references
+	const gw1_4c5 = rounds.find((r) => r.number === 1)
+	const gw2_4c5 = rounds.find((r) => r.number === 2)
+	const gw3_4c5 = rounds.find((r) => r.number === 3)
+	const gw9_4c5 = rounds.find((r) => r.number === 9)
+	const gw6_4c5 = rounds.find((r) => r.number === 6)
+	if (!gw1_4c5 || !gw2_4c5 || !gw3_4c5 || !gw9_4c5 || !gw6_4c5) {
+		throw new Error('Required rounds not found for 4c5 smoke games')
+	}
+
+	// ─── 5a: Live Lads ────────────────────────────────────────────────────────
+	// Active game whose current round (GW9) is 'active' and has a live fixture.
+	// This makes defaultShareVariant === 'live'.
+	{
+		// Promote GW9 from 'upcoming' to 'active'
+		await db.update(roundTable).set({ status: 'active' }).where(eq(roundTable.id, gw9_4c5.id))
+
+		// Update the first GW9 fixture to live status with a score
+		const gw9Fixtures = fixturesByRound.get(gw9_4c5.id) ?? []
+		const liveFixture4c5 = gw9Fixtures[0]
+		if (!liveFixture4c5) throw new Error('No fixtures found in GW9 for 4c5 smoke')
+
+		await db
+			.update(fixture)
+			.set({ status: 'live', homeScore: 1, awayScore: 0 })
+			.where(eq(fixture.id, liveFixture4c5.id))
+
+		const [liveLadsGame] = await db
+			.insert(game)
+			.values({
+				name: 'Live Lads (4c5 smoke)',
+				createdBy: userIds['dev@example.com'],
+				competitionId: pl.id,
+				gameMode: 'classic',
+				modeConfig: {},
+				entryFee: '10.00',
+				inviteCode: generateInviteCode(),
+				status: 'active',
+				currentRoundId: gw9_4c5.id,
+			})
+			.returning()
+
+		const livePlayerEmails = ['dev@example.com', 'dave@example.com', 'mike@example.com']
+		const livePlayerRows: Record<string, { id: string }> = {}
+
+		for (const email of livePlayerEmails) {
+			const [gp] = await db
+				.insert(gamePlayer)
+				.values({
+					gameId: liveLadsGame.id,
+					userId: userIds[email],
+					status: 'alive',
+					livesRemaining: 0,
+				})
+				.returning()
+			livePlayerRows[email] = { id: gp.id }
+
+			await db.insert(payment).values({
+				gameId: liveLadsGame.id,
+				userId: userIds[email],
+				amount: '10.00',
+				status: 'paid',
+				paidAt: new Date(),
+			})
+		}
+
+		// Round 1 picks — each player picks a winner from GW1 fixtures
+		const gw1Fixtures4c5 = fixturesByRound.get(gw1_4c5.id) ?? []
+		const winnerFixtures4c5 = gw1Fixtures4c5.filter((f) => fixtureWinnerTeam(f) !== null)
+		for (let i = 0; i < livePlayerEmails.length; i++) {
+			const email = livePlayerEmails[i]
+			const f = winnerFixtures4c5[i % winnerFixtures4c5.length]
+			const winner = fixtureWinnerTeam(f)
+			if (!f || !winner) continue
+			await db.insert(pick).values({
+				gameId: liveLadsGame.id,
+				gamePlayerId: livePlayerRows[email].id,
+				roundId: gw1_4c5.id,
+				teamId: winner.id,
+				fixtureId: f.id,
+				result: 'win',
+				goalsScored: winner.id === f.homeTeamId ? (f.homeScore ?? 0) : (f.awayScore ?? 0),
+			})
+		}
+
+		// Round 9 picks — at least one player picks the home team of the live fixture
+		// dev picks home team of live fixture (so they're "winning" the live game)
+		await db.insert(pick).values({
+			gameId: liveLadsGame.id,
+			gamePlayerId: livePlayerRows['dev@example.com'].id,
+			roundId: gw9_4c5.id,
+			teamId: liveFixture4c5.homeTeamId,
+			fixtureId: liveFixture4c5.id,
+			result: 'pending',
+		})
+		// dave picks away team of the same live fixture
+		if (gw9Fixtures[1]) {
+			await db.insert(pick).values({
+				gameId: liveLadsGame.id,
+				gamePlayerId: livePlayerRows['dave@example.com'].id,
+				roundId: gw9_4c5.id,
+				teamId: gw9Fixtures[1].homeTeamId,
+				fixtureId: gw9Fixtures[1].id,
+				result: 'pending',
+			})
+		}
+		// mike has no round-9 pick yet (pending submission)
+
+		console.log(`Created "Live Lads (4c5 smoke)" — 3 players, GW9 active with live fixture`)
+	}
+
+	// ─── 5b: Champion's Cup (solo winner) ────────────────────────────────────
+	// Completed classic game: 1 winner, 3 eliminated. Pot = 4 × £20 = £80.
+	// defaultShareVariant === 'winner', single-winner block.
+	{
+		const [champGame] = await db
+			.insert(game)
+			.values({
+				name: "Champion's Cup (4c5 smoke)",
+				createdBy: userIds['dev@example.com'],
+				competitionId: pl.id,
+				gameMode: 'classic',
+				modeConfig: {},
+				entryFee: '20.00',
+				inviteCode: generateInviteCode(),
+				status: 'completed',
+				currentRoundId: gw6_4c5.id,
+			})
+			.returning()
+
+		// Winner: dev
+		await db.insert(gamePlayer).values({
+			gameId: champGame.id,
+			userId: userIds['dev@example.com'],
+			status: 'winner',
+			livesRemaining: 0,
+		})
+		// Eliminated: dave (round 2), mike (round 3), rich (round 4)
+		await db.insert(gamePlayer).values({
+			gameId: champGame.id,
+			userId: userIds['dave@example.com'],
+			status: 'eliminated',
+			eliminatedRoundId: gw2_4c5.id,
+			eliminatedReason: 'loss',
+			livesRemaining: 0,
+		})
+		await db.insert(gamePlayer).values({
+			gameId: champGame.id,
+			userId: userIds['mike@example.com'],
+			status: 'eliminated',
+			eliminatedRoundId: gw3_4c5.id,
+			eliminatedReason: 'loss',
+			livesRemaining: 0,
+		})
+		const gw4_4c5 = rounds.find((r) => r.number === 4)
+		await db.insert(gamePlayer).values({
+			gameId: champGame.id,
+			userId: userIds['rich@example.com'],
+			status: 'eliminated',
+			eliminatedRoundId: gw4_4c5?.id ?? gw3_4c5.id,
+			eliminatedReason: 'loss',
+			livesRemaining: 0,
+		})
+
+		// Payments for all 4 players → pot = £80
+		for (const email of [
+			'dev@example.com',
+			'dave@example.com',
+			'mike@example.com',
+			'rich@example.com',
+		]) {
+			await db.insert(payment).values({
+				gameId: champGame.id,
+				userId: userIds[email],
+				amount: '20.00',
+				status: 'paid',
+				paidAt: new Date(),
+			})
+		}
+
+		console.log(`Created "Champion's Cup (4c5 smoke)" — 1 winner + 3 eliminated, pot £80`)
+	}
+
+	// ─── 5c: Split Cup (two co-winners) ───────────────────────────────────────
+	// Completed cup game: 2 winners, 3 eliminated. Pot = 5 × £20 = £100, split = £50 each.
+	// defaultShareVariant === 'winner', split-pot 2-way block.
+	{
+		const [splitGame] = await db
+			.insert(game)
+			.values({
+				name: 'Split Cup (4c5 smoke)',
+				createdBy: userIds['dev@example.com'],
+				competitionId: pl.id,
+				gameMode: 'cup',
+				modeConfig: { startingLives: 2, numberOfPicks: 5 },
+				entryFee: '20.00',
+				inviteCode: generateInviteCode(),
+				status: 'completed',
+				currentRoundId: gw6_4c5.id,
+			})
+			.returning()
+
+		// 2 winners: dev, dave
+		await db.insert(gamePlayer).values({
+			gameId: splitGame.id,
+			userId: userIds['dev@example.com'],
+			status: 'winner',
+			livesRemaining: 0,
+		})
+		await db.insert(gamePlayer).values({
+			gameId: splitGame.id,
+			userId: userIds['dave@example.com'],
+			status: 'winner',
+			livesRemaining: 0,
+		})
+		// 3 eliminated: mike (round 1), rich (round 2), sarah (round 3)
+		await db.insert(gamePlayer).values({
+			gameId: splitGame.id,
+			userId: userIds['mike@example.com'],
+			status: 'eliminated',
+			eliminatedRoundId: gw1_4c5.id,
+			eliminatedReason: 'loss',
+			livesRemaining: 0,
+		})
+		await db.insert(gamePlayer).values({
+			gameId: splitGame.id,
+			userId: userIds['rich@example.com'],
+			status: 'eliminated',
+			eliminatedRoundId: gw2_4c5.id,
+			eliminatedReason: 'loss',
+			livesRemaining: 0,
+		})
+		await db.insert(gamePlayer).values({
+			gameId: splitGame.id,
+			userId: userIds['sarah@example.com'],
+			status: 'eliminated',
+			eliminatedRoundId: gw3_4c5.id,
+			eliminatedReason: 'loss',
+			livesRemaining: 0,
+		})
+
+		// Payments for all 5 players → pot = £100
+		for (const email of [
+			'dev@example.com',
+			'dave@example.com',
+			'mike@example.com',
+			'rich@example.com',
+			'sarah@example.com',
+		]) {
+			await db.insert(payment).values({
+				gameId: splitGame.id,
+				userId: userIds[email],
+				amount: '20.00',
+				status: 'paid',
+				paidAt: new Date(),
+			})
+		}
+
+		console.log(`Created "Split Cup (4c5 smoke)" — 2 winners + 3 eliminated, pot £100`)
+	}
+
 	console.log('\nSeed complete!')
 	console.log('\nLog in with any of these (password: password123):')
 	for (const u of DEV_USERS) console.log(`  ${u.email}`)

--- a/src/app/api/picks/[gameId]/[roundId]/route.ts
+++ b/src/app/api/picks/[gameId]/[roundId]/route.ts
@@ -269,6 +269,9 @@ export async function POST(request: Request, { params }: { params: Params }) {
 
 	let newPicks: (typeof pick.$inferSelect)[] = []
 	let unEliminated = false
+	// Capture the narrowed reference so it's available inside the .map closure
+	// below without TS losing the non-null narrowing through the callback boundary.
+	const player = targetGamePlayer
 
 	await db.transaction(async (tx) => {
 		const insertedPicks = await tx
@@ -281,8 +284,7 @@ export async function POST(request: Request, { params }: { params: Params }) {
 						const teamId = entry.predictedResult === 'away_win' ? fx.awayTeamId : fx.homeTeamId
 						return {
 							gameId,
-							// biome-ignore lint/style/noNonNullAssertion: targetGamePlayer is checked for existence at line 63
-							gamePlayerId: targetGamePlayer!.id,
+							gamePlayerId: player.id,
 							roundId,
 							teamId,
 							fixtureId: entry.fixtureId,

--- a/src/app/api/picks/[gameId]/[roundId]/route.ts
+++ b/src/app/api/picks/[gameId]/[roundId]/route.ts
@@ -281,6 +281,7 @@ export async function POST(request: Request, { params }: { params: Params }) {
 						const teamId = entry.predictedResult === 'away_win' ? fx.awayTeamId : fx.homeTeamId
 						return {
 							gameId,
+							// biome-ignore lint/style/noNonNullAssertion: targetGamePlayer is checked for existence at line 63
 							gamePlayerId: targetGamePlayer!.id,
 							roundId,
 							teamId,

--- a/src/app/api/share/grid/[gameId]/route.tsx
+++ b/src/app/api/share/grid/[gameId]/route.tsx
@@ -1,6 +1,0 @@
-// Legacy alias of /api/share/standings — kept for backwards compatibility with the
-// deployed ShareDialog. Will be removed in 4c5.
-// `runtime` must be declared directly here — Next.js can't statically resolve
-// re-exported route-segment config.
-export const runtime = 'nodejs'
-export { GET } from '../../standings/[gameId]/route'

--- a/src/app/api/users/search/route.test.ts
+++ b/src/app/api/users/search/route.test.ts
@@ -47,4 +47,56 @@ describe('GET /api/users/search', () => {
 		const body = await res.json()
 		expect(body.users).toHaveLength(10)
 	})
+
+	it('marks results as isInGame when ?gameId= matches an existing game_player', async () => {
+		const mockUsers = [
+			{ id: 'u1', name: 'Sean', email: 's@x.com' },
+			{ id: 'u2', name: 'Sarah', email: 'sa@x.com' },
+		]
+		const userSelectChain = {
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockReturnValue({
+					limit: vi.fn().mockResolvedValue(mockUsers),
+				}),
+			}),
+		}
+		const playerSelectChain = {
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue([{ userId: 'u1' }]),
+			}),
+		}
+
+		let callCount = 0
+		vi.mocked(db.select).mockImplementation(() => {
+			callCount++
+			return callCount === 1 ? (userSelectChain as never) : (playerSelectChain as never)
+		})
+
+		const req = new Request('http://localhost/api/users/search?q=s&gameId=g1')
+		const res = await GET(req)
+		expect(res.status).toBe(200)
+		const body = await res.json()
+		expect(body.users).toEqual([
+			{ id: 'u1', name: 'Sean', email: 's@x.com', isInGame: true },
+			{ id: 'u2', name: 'Sarah', email: 'sa@x.com', isInGame: false },
+		])
+	})
+
+	it('returns un-augmented results when ?gameId= is not provided', async () => {
+		const mockUsers = [{ id: 'u1', name: 'Sean', email: 's@x.com' }]
+		const selectChain = {
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockReturnValue({
+					limit: vi.fn().mockResolvedValue(mockUsers),
+				}),
+			}),
+		}
+		vi.mocked(db.select).mockReturnValue(selectChain as never)
+
+		const req = new Request('http://localhost/api/users/search?q=sean')
+		const res = await GET(req)
+		expect(res.status).toBe(200)
+		const body = await res.json()
+		expect(body.users[0].isInGame).toBeUndefined()
+	})
 })

--- a/src/app/api/users/search/route.ts
+++ b/src/app/api/users/search/route.ts
@@ -1,14 +1,16 @@
-import { or, sql } from 'drizzle-orm'
+import { and, eq, inArray, or, sql } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import { requireSession } from '@/lib/auth-helpers'
 import { db } from '@/lib/db'
 import { user } from '@/lib/schema/auth'
+import { gamePlayer } from '@/lib/schema/game'
 
 export async function GET(request: Request): Promise<Response> {
 	await requireSession()
 
 	const { searchParams } = new URL(request.url)
 	const q = (searchParams.get('q') ?? '').trim()
+	const gameId = searchParams.get('gameId')
 	if (q.length === 0) {
 		return NextResponse.json({ users: [] })
 	}
@@ -20,5 +22,17 @@ export async function GET(request: Request): Promise<Response> {
 		.where(or(sql`lower(${user.name}) like ${pattern}`, sql`lower(${user.email}) like ${pattern}`))
 		.limit(10)
 
-	return NextResponse.json({ users: results })
+	if (!gameId || results.length === 0) {
+		return NextResponse.json({ users: results })
+	}
+
+	const userIds = results.map((u) => u.id)
+	const existingPlayers = await db
+		.select({ userId: gamePlayer.userId })
+		.from(gamePlayer)
+		.where(and(eq(gamePlayer.gameId, gameId), inArray(gamePlayer.userId, userIds)))
+	const inGameSet = new Set(existingPlayers.map((p) => p.userId))
+
+	const augmented = results.map((u) => ({ ...u, isInGame: inGameSet.has(u.id) }))
+	return NextResponse.json({ users: augmented })
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -115,4 +115,10 @@
 	h4 {
 		font-family: var(--font-display), Georgia, serif;
 	}
+	/* Global focus-visible baseline: all interactive elements show a ring on keyboard focus.
+	   Components may override this with more specific focus-visible:ring-* utilities. */
+	:focus-visible {
+		outline: 2px solid var(--ring);
+		outline-offset: 2px;
+	}
 }

--- a/src/components/game/acting-as-banner.tsx
+++ b/src/components/game/acting-as-banner.tsx
@@ -27,7 +27,7 @@ export function ActingAsBanner({
 			<button
 				type="button"
 				onClick={() => router.push(`/game/${gameId}`)}
-				className="ml-auto rounded-md bg-black/25 px-2.5 py-1.5 text-[11px] font-semibold text-primary-foreground"
+				className="ml-auto rounded-md bg-black/25 px-2.5 py-1.5 text-[11px] font-semibold text-primary-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
 			>
 				Exit admin mode
 			</button>

--- a/src/components/game/add-player-modal.test.tsx
+++ b/src/components/game/add-player-modal.test.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { AddPlayerModal } from './add-player-modal'
+
+vi.mock('next/navigation', () => ({
+	useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}))
+
+describe('AddPlayerModal', () => {
+	it('Escape closes the modal', () => {
+		const onClose = vi.fn()
+		render(<AddPlayerModal gameId="g1" open={true} onClose={onClose} />)
+		fireEvent.keyDown(document.body, { key: 'Escape' })
+		expect(onClose).toHaveBeenCalledTimes(1)
+	})
+
+	it('renders dialog title for screen readers', () => {
+		render(<AddPlayerModal gameId="g1" open={true} onClose={vi.fn()} />)
+		expect(screen.getByRole('dialog', { name: /add player/i })).toBeTruthy()
+	})
+})

--- a/src/components/game/add-player-modal.tsx
+++ b/src/components/game/add-player-modal.tsx
@@ -1,6 +1,14 @@
 'use client'
 import { useRouter } from 'next/navigation'
 import { useEffect, useRef, useState } from 'react'
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
 
 interface UserRow {
@@ -11,6 +19,7 @@ interface UserRow {
 
 interface AddPlayerModalProps {
 	gameId: string
+	open: boolean
 	onClose: () => void
 }
 
@@ -19,7 +28,7 @@ interface AddedState {
 	userName: string
 }
 
-export function AddPlayerModal({ gameId, onClose }: AddPlayerModalProps) {
+export function AddPlayerModal({ gameId, open, onClose }: AddPlayerModalProps) {
 	const router = useRouter()
 	const [query, setQuery] = useState('')
 	const [results, setResults] = useState<UserRow[]>([])
@@ -29,9 +38,16 @@ export function AddPlayerModal({ gameId, onClose }: AddPlayerModalProps) {
 	const [added, setAdded] = useState<AddedState | null>(null)
 	const inputRef = useRef<HTMLInputElement>(null)
 
+	// Reset state when dialog opens
 	useEffect(() => {
-		inputRef.current?.focus()
-	}, [])
+		if (open) {
+			setQuery('')
+			setResults([])
+			setSelectedId(null)
+			setError(null)
+			setAdded(null)
+		}
+	}, [open])
 
 	useEffect(() => {
 		if (added) return
@@ -73,6 +89,7 @@ export function AddPlayerModal({ gameId, onClose }: AddPlayerModalProps) {
 
 	function handleGoToPick() {
 		if (!added) return
+		onClose()
 		router.push(`/game/${gameId}?actingAs=${added.gamePlayerId}`)
 	}
 
@@ -82,27 +99,15 @@ export function AddPlayerModal({ gameId, onClose }: AddPlayerModalProps) {
 	}
 
 	return (
-		// biome-ignore lint/a11y/useKeyWithClickEvents: backdrop click-to-close; Escape handling delegated to dialog close button
-		// biome-ignore lint/a11y/noStaticElementInteractions: backdrop is a dialog scrim, not an interactive control
-		<div
-			role="dialog"
-			aria-modal="true"
-			className="fixed inset-0 z-50 flex items-center justify-center bg-black/65"
-			onClick={onClose}
-		>
-			{/* biome-ignore lint/a11y/useKeyWithClickEvents: stopPropagation on container prevents backdrop-close, not a user-facing interaction */}
-			{/* biome-ignore lint/a11y/noStaticElementInteractions: inner panel is non-interactive — intercepts bubbling clicks only */}
-			<div
-				onClick={(e) => e.stopPropagation()}
-				className="w-[340px] rounded-lg border border-border bg-background p-5 shadow-2xl"
-			>
+		<Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+			<DialogContent className="sm:max-w-md">
 				{added ? (
 					<>
-						<h3 className="text-[15px] font-bold">{added.userName} added</h3>
-						<p className="mb-4 mt-1 text-xs text-muted-foreground">
-							Pick for them now, or come back later.
-						</p>
-						<div className="flex justify-end gap-2">
+						<DialogHeader>
+							<DialogTitle>{added.userName} added</DialogTitle>
+							<DialogDescription>Pick for them now, or come back later.</DialogDescription>
+						</DialogHeader>
+						<DialogFooter>
 							<button
 								type="button"
 								onClick={handleBackToGame}
@@ -117,50 +122,53 @@ export function AddPlayerModal({ gameId, onClose }: AddPlayerModalProps) {
 							>
 								Pick for {added.userName}
 							</button>
-						</div>
+						</DialogFooter>
 					</>
 				) : (
 					<>
-						<h3 className="text-[15px] font-bold">Add player to this game</h3>
-						<p className="mb-3 mt-1 text-xs text-muted-foreground">
-							Search an existing user by name or email.
-						</p>
-						<input
-							ref={inputRef}
-							value={query}
-							onChange={(e) => setQuery(e.target.value)}
-							placeholder="name or email…"
-							className="w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none"
-						/>
-						<div className="mt-2 max-h-[180px] overflow-y-auto">
-							{results.map((u) => (
-								<button
-									type="button"
-									key={u.id}
-									onClick={() => setSelectedId(u.id)}
-									className={cn(
-										'mb-0.5 flex w-full items-center gap-2 rounded-md border border-transparent px-2 py-1.5 text-left text-sm',
-										selectedId === u.id && 'border-primary bg-primary/10',
-										selectedId !== u.id && 'hover:bg-card hover:border-border',
-									)}
-								>
-									<span className="flex-1">
-										<span className="block font-semibold">{u.name}</span>
-										<span className="block text-[11px] text-muted-foreground">{u.email}</span>
-									</span>
-								</button>
-							))}
+						<DialogHeader>
+							<DialogTitle>Add player to this game</DialogTitle>
+							<DialogDescription>Search an existing user by name or email.</DialogDescription>
+						</DialogHeader>
+						<div className="space-y-3">
+							<input
+								ref={inputRef}
+								autoFocus
+								value={query}
+								onChange={(e) => setQuery(e.target.value)}
+								placeholder="name or email…"
+								className="w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none"
+							/>
+							<div className="max-h-[180px] overflow-y-auto">
+								{results.map((u) => (
+									<button
+										type="button"
+										key={u.id}
+										onClick={() => setSelectedId(u.id)}
+										className={cn(
+											'mb-0.5 flex w-full items-center gap-2 rounded-md border border-transparent px-2 py-1.5 text-left text-sm',
+											selectedId === u.id && 'border-primary bg-primary/10',
+											selectedId !== u.id && 'hover:bg-card hover:border-border',
+										)}
+									>
+										<span className="flex-1">
+											<span className="block font-semibold">{u.name}</span>
+											<span className="block text-[11px] text-muted-foreground">{u.email}</span>
+										</span>
+									</button>
+								))}
+							</div>
+							{error === 'already-in-game' && (
+								<p className="text-xs text-amber-600">That user is already in this game.</p>
+							)}
+							{error && error !== 'already-in-game' && (
+								<p className="text-xs text-red-500">Couldn't add: {error}</p>
+							)}
+							<p className="rounded-l-sm border-l-2 border-primary bg-primary/10 px-2 py-2 text-[11px] text-muted-foreground">
+								Can't find someone? Ask them to sign up first.
+							</p>
 						</div>
-						{error === 'already-in-game' && (
-							<p className="mt-2 text-xs text-amber-600">That user is already in this game.</p>
-						)}
-						{error && error !== 'already-in-game' && (
-							<p className="mt-2 text-xs text-red-500">Couldn't add: {error}</p>
-						)}
-						<p className="mt-3 rounded-l-sm border-l-2 border-primary bg-primary/10 px-2 py-2 text-[11px] text-muted-foreground">
-							Can't find someone? Ask them to sign up first.
-						</p>
-						<div className="mt-4 flex justify-end gap-2">
+						<DialogFooter>
 							<button
 								type="button"
 								onClick={onClose}
@@ -176,10 +184,10 @@ export function AddPlayerModal({ gameId, onClose }: AddPlayerModalProps) {
 							>
 								{selected ? `Add ${selected.name}` : 'Add'}
 							</button>
-						</div>
+						</DialogFooter>
 					</>
 				)}
-			</div>
-		</div>
+			</DialogContent>
+		</Dialog>
 	)
 }

--- a/src/components/game/add-player-modal.tsx
+++ b/src/components/game/add-player-modal.tsx
@@ -116,14 +116,14 @@ export function AddPlayerModal({ gameId, open, onClose }: AddPlayerModalProps) {
 							<button
 								type="button"
 								onClick={handleBackToGame}
-								className="rounded-md border border-border bg-transparent px-3 py-1.5 text-xs font-semibold text-muted-foreground"
+								className="rounded-md border border-border bg-transparent px-3 py-1.5 text-xs font-semibold text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 							>
 								Back to game
 							</button>
 							<button
 								type="button"
 								onClick={handleGoToPick}
-								className="rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground"
+								className="rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 							>
 								Pick for {added.userName}
 							</button>
@@ -151,7 +151,7 @@ export function AddPlayerModal({ gameId, open, onClose }: AddPlayerModalProps) {
 										key={u.id}
 										onClick={() => setSelectedId(u.id)}
 										className={cn(
-											'mb-0.5 flex w-full items-center gap-2 rounded-md border border-transparent px-2 py-1.5 text-left text-sm',
+											'mb-0.5 flex w-full items-center gap-2 rounded-md border border-transparent px-2 py-1.5 text-left text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
 											selectedId === u.id && 'border-primary bg-primary/10',
 											selectedId !== u.id && 'hover:bg-card hover:border-border',
 										)}
@@ -182,7 +182,7 @@ export function AddPlayerModal({ gameId, open, onClose }: AddPlayerModalProps) {
 							<button
 								type="button"
 								onClick={onClose}
-								className="rounded-md border border-border bg-transparent px-3 py-1.5 text-xs font-semibold text-muted-foreground"
+								className="rounded-md border border-border bg-transparent px-3 py-1.5 text-xs font-semibold text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 							>
 								Cancel
 							</button>
@@ -190,7 +190,7 @@ export function AddPlayerModal({ gameId, open, onClose }: AddPlayerModalProps) {
 								type="button"
 								onClick={handleAdd}
 								disabled={!selected || submitting}
-								className="rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground disabled:opacity-50"
+								className="rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 							>
 								{selected ? `Add ${selected.name}` : 'Add'}
 							</button>

--- a/src/components/game/add-player-modal.tsx
+++ b/src/components/game/add-player-modal.tsx
@@ -15,6 +15,7 @@ interface UserRow {
 	id: string
 	name: string
 	email: string
+	isInGame?: boolean
 }
 
 interface AddPlayerModalProps {
@@ -56,13 +57,17 @@ export function AddPlayerModal({ gameId, open, onClose }: AddPlayerModalProps) {
 			return
 		}
 		const timer = setTimeout(async () => {
-			const res = await fetch(`/api/users/search?q=${encodeURIComponent(query)}`)
+			const params = new URLSearchParams({
+				q: query,
+				gameId: gameId,
+			})
+			const res = await fetch(`/api/users/search?${params}`)
 			if (!res.ok) return
 			const body = (await res.json()) as { users: UserRow[] }
 			setResults(body.users)
 		}, 200)
 		return () => clearTimeout(timer)
-	}, [query, added])
+	}, [query, added, gameId])
 
 	const selected = results.find((u) => u.id === selectedId) ?? null
 
@@ -155,6 +160,11 @@ export function AddPlayerModal({ gameId, open, onClose }: AddPlayerModalProps) {
 											<span className="block font-semibold">{u.name}</span>
 											<span className="block text-[11px] text-muted-foreground">{u.email}</span>
 										</span>
+										{u.isInGame && (
+											<span className="rounded-sm bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-900">
+												IN GAME
+											</span>
+										)}
 									</button>
 								))}
 							</div>

--- a/src/components/game/admin-panel.tsx
+++ b/src/components/game/admin-panel.tsx
@@ -44,14 +44,13 @@ export function AdminPanel({ gameId, aliveCount, potTotal }: AdminPanelProps) {
 				open={openModal === 'add'}
 				onClose={() => setOpenModal(null)}
 			/>
-			{openModal === 'split' && (
-				<SplitPotModal
-					gameId={gameId}
-					aliveCount={aliveCount}
-					potTotal={potTotal}
-					onClose={() => setOpenModal(null)}
-				/>
-			)}
+			<SplitPotModal
+				gameId={gameId}
+				aliveCount={aliveCount}
+				potTotal={potTotal}
+				open={openModal === 'split'}
+				onClose={() => setOpenModal(null)}
+			/>
 		</>
 	)
 }

--- a/src/components/game/admin-panel.tsx
+++ b/src/components/game/admin-panel.tsx
@@ -39,7 +39,11 @@ export function AdminPanel({ gameId, aliveCount, potTotal }: AdminPanelProps) {
 					</button>
 				</div>
 			</div>
-			{openModal === 'add' && <AddPlayerModal gameId={gameId} onClose={() => setOpenModal(null)} />}
+			<AddPlayerModal
+				gameId={gameId}
+				open={openModal === 'add'}
+				onClose={() => setOpenModal(null)}
+			/>
 			{openModal === 'split' && (
 				<SplitPotModal
 					gameId={gameId}

--- a/src/components/game/create-game-form.tsx
+++ b/src/components/game/create-game-form.tsx
@@ -126,7 +126,7 @@ export function CreateGameForm({ competitions }: CreateGameFormProps) {
 									type="button"
 									onClick={() => setMode(m)}
 									className={cn(
-										'text-left p-3 rounded-lg border-2 transition-all',
+										'text-left p-3 rounded-lg border-2 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
 										mode === m
 											? 'border-[var(--alive)] bg-[var(--alive-bg)]'
 											: 'border-border hover:border-muted-foreground bg-card',

--- a/src/components/game/game-card.tsx
+++ b/src/components/game/game-card.tsx
@@ -37,7 +37,7 @@ export function GameCard({ game }: GameCardProps) {
 				</div>
 
 				{!isCompleted && !isEliminated && (
-					<div className="pt-3 border-t flex justify-between items-center">
+					<div className="pt-3 border-t flex flex-wrap justify-between items-center gap-1.5">
 						{needsPick ? (
 							<span className="text-xs font-semibold px-2.5 py-1 rounded-md bg-[var(--draw-bg)] text-[var(--draw)]">
 								⚡ Make your pick — {game.currentRoundName}

--- a/src/components/game/game-header.tsx
+++ b/src/components/game/game-header.tsx
@@ -51,7 +51,7 @@ export function GameHeader({
 					</div>
 				</div>
 
-				<div className="flex items-center gap-3">
+				<div className="flex items-center gap-3 shrink-0">
 					<div className="text-right">
 						<div className="text-[0.65rem] uppercase tracking-wider text-muted-foreground font-semibold">
 							Pot (confirmed)
@@ -59,8 +59,8 @@ export function GameHeader({
 						<div className="font-display text-3xl md:text-4xl font-bold leading-none">
 							£{potBreakdown.confirmed}
 						</div>
-						<div className="text-[0.7rem] text-muted-foreground mt-1">
-							{hasPending && <span>£{potBreakdown.pending} awaiting confirmation · </span>}
+						<div className="text-[0.7rem] text-muted-foreground mt-1 max-w-[200px] leading-relaxed">
+							{hasPending && <span>£{potBreakdown.pending} pending · </span>}
 							{hasUnpaid && <span>£{unpaid} unpaid · </span>}
 							<span>£{target} target</span>
 						</div>

--- a/src/components/game/my-payment-strip.tsx
+++ b/src/components/game/my-payment-strip.tsx
@@ -54,7 +54,7 @@ export function MyPaymentStrip({
 				{status === 'pending' && (
 					<button
 						type="button"
-						className="rounded bg-foreground px-3 py-1.5 text-xs font-semibold text-background disabled:opacity-60"
+						className="rounded bg-foreground px-3 py-1.5 text-xs font-semibold text-background disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 						disabled={pending}
 						onClick={handleClaim}
 					>

--- a/src/components/game/my-payment-strip.tsx
+++ b/src/components/game/my-payment-strip.tsx
@@ -42,7 +42,7 @@ export function MyPaymentStrip({
 	}
 
 	return (
-		<div className="flex items-center justify-between rounded-lg border border-dashed border-border bg-muted/40 px-3.5 py-2.5">
+		<div className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-dashed border-border bg-muted/40 px-3.5 py-2.5">
 			<div className="flex items-center gap-3">
 				<span className="text-sm text-muted-foreground">Your entry fee</span>
 				<PaymentStatusChip status={status} />

--- a/src/components/game/payment-status-chip.tsx
+++ b/src/components/game/payment-status-chip.tsx
@@ -1,15 +1,18 @@
 import { cn } from '@/lib/utils'
 
 export type PaymentStatus = 'pending' | 'claimed' | 'paid' | 'refunded'
+export type AdminPaymentStatus = PaymentStatus | 'unpaid'
 
-const STYLES: Record<PaymentStatus, string> = {
+const STYLES: Record<AdminPaymentStatus, string> = {
+	unpaid: 'bg-slate-100 text-slate-500',
 	pending: 'bg-muted text-foreground/70',
 	claimed: 'bg-amber-100 text-amber-900',
 	paid: 'bg-emerald-100 text-emerald-900',
 	refunded: 'bg-muted text-foreground/70',
 }
 
-const LABELS: Record<PaymentStatus, string> = {
+const LABELS: Record<AdminPaymentStatus, string> = {
+	unpaid: 'UNPAID',
 	pending: 'UNPAID',
 	claimed: '⏱ AWAITING CONFIRMATION',
 	paid: '✓ PAID',
@@ -20,7 +23,7 @@ export function PaymentStatusChip({
 	status,
 	className,
 }: {
-	status: PaymentStatus
+	status: AdminPaymentStatus
 	className?: string
 }) {
 	return (

--- a/src/components/game/payments-panel.tsx
+++ b/src/components/game/payments-panel.tsx
@@ -73,7 +73,7 @@ export function PaymentsPanel(props: PaymentsPanelProps) {
 				</div>
 			</div>
 
-			<div>
+			<div className="overflow-x-auto">
 				<div className="mb-1.5 text-[10px] font-semibold uppercase text-muted-foreground">
 					All payments
 				</div>

--- a/src/components/game/payments-panel.tsx
+++ b/src/components/game/payments-panel.tsx
@@ -2,14 +2,14 @@
 
 import { toast } from 'sonner'
 import { PaymentReminderButton } from './payment-reminder'
-import { type PaymentStatus, PaymentStatusChip } from './payment-status-chip'
+import { type AdminPaymentStatus, PaymentStatusChip } from './payment-status-chip'
 
 export interface AdminPayment {
-	id: string
+	id: string | null
 	userId: string
 	userName: string
 	amount: string
-	status: PaymentStatus
+	status: AdminPaymentStatus
 	isRebuy: boolean
 	isRebuyEligible: boolean
 	claimedAt: Date | null
@@ -27,7 +27,7 @@ interface PaymentsPanelProps {
 
 export function PaymentsPanel(props: PaymentsPanelProps) {
 	const all = props.payments
-	const unpaidCount = all.filter((p) => p.status === 'pending').length
+	const unpaidCount = all.filter((p) => p.status === 'pending' || p.status === 'unpaid').length
 
 	async function callAction(p: AdminPayment, action: 'dispute' | 'admin-rebuy') {
 		if (action === 'admin-rebuy') {
@@ -43,6 +43,7 @@ export function PaymentsPanel(props: PaymentsPanelProps) {
 			return
 		}
 		// 'dispute' branch — POSTs to .../{paymentId}/reject
+		if (!p.id) return
 		const res = await fetch(`/api/games/${props.gameId}/payments/${p.id}/reject`, {
 			method: 'POST',
 		})
@@ -91,7 +92,7 @@ export function PaymentsPanel(props: PaymentsPanelProps) {
 										Rebuy player
 									</button>
 								)}
-								{p.status === 'paid' ? (
+								{p.id !== null && p.status === 'paid' ? (
 									<button
 										type="button"
 										onClick={() => callAction(p, 'dispute')}
@@ -99,7 +100,7 @@ export function PaymentsPanel(props: PaymentsPanelProps) {
 									>
 										Dispute
 									</button>
-								) : p.status === 'pending' ? (
+								) : p.id !== null && p.status === 'pending' ? (
 									<PaymentReminderButton
 										gameName={props.gameName}
 										amount={p.amount}

--- a/src/components/game/payments-panel.tsx
+++ b/src/components/game/payments-panel.tsx
@@ -87,7 +87,7 @@ export function PaymentsPanel(props: PaymentsPanelProps) {
 									<button
 										type="button"
 										onClick={() => callAction(p, 'admin-rebuy')}
-										className="rounded bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground"
+										className="rounded bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 									>
 										Rebuy player
 									</button>
@@ -96,7 +96,7 @@ export function PaymentsPanel(props: PaymentsPanelProps) {
 									<button
 										type="button"
 										onClick={() => callAction(p, 'dispute')}
-										className="rounded border border-red-300 px-3 py-1.5 text-xs font-semibold text-red-700"
+										className="rounded border border-red-300 px-3 py-1.5 text-xs font-semibold text-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/50"
 									>
 										Dispute
 									</button>

--- a/src/components/game/rebuy-banner.tsx
+++ b/src/components/game/rebuy-banner.tsx
@@ -71,7 +71,7 @@ export function RebuyBanner({
 					type="button"
 					onClick={() => claimPaid(pendingPayment.id)}
 					disabled={loading}
-					className="mt-2 rounded bg-amber-900 px-3 py-1.5 text-xs font-semibold text-amber-50 disabled:opacity-50"
+					className="mt-2 rounded bg-amber-900 px-3 py-1.5 text-xs font-semibold text-amber-50 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 				>
 					{loading ? 'Working…' : 'Claim paid'}
 				</button>
@@ -91,7 +91,7 @@ export function RebuyBanner({
 				type="button"
 				onClick={startRebuy}
 				disabled={loading}
-				className="mt-2 rounded bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground disabled:opacity-50"
+				className="mt-2 rounded bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 			>
 				{loading ? 'Working…' : `Rebuy £${entryFee}`}
 			</button>

--- a/src/components/game/share-dialog.tsx
+++ b/src/components/game/share-dialog.tsx
@@ -115,7 +115,7 @@ export function ShareDialog({
 					</div>
 
 					<div>
-						<div className="flex items-center justify-between mb-2">
+						<div className="flex flex-wrap items-center justify-between gap-2 mb-2">
 							<div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
 								Game state image
 							</div>

--- a/src/components/game/split-pot-modal.test.tsx
+++ b/src/components/game/split-pot-modal.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { SplitPotModal } from './split-pot-modal'
+
+vi.mock('next/navigation', () => ({
+	useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}))
+
+describe('SplitPotModal', () => {
+	it('Escape closes the modal', () => {
+		const onClose = vi.fn()
+		render(
+			<SplitPotModal gameId="g1" aliveCount={3} potTotal="300.00" open={true} onClose={onClose} />,
+		)
+		fireEvent.keyDown(document.body, { key: 'Escape' })
+		expect(onClose).toHaveBeenCalledTimes(1)
+	})
+
+	it('renders dialog title for screen readers', () => {
+		render(
+			<SplitPotModal gameId="g1" aliveCount={3} potTotal="300.00" open={true} onClose={vi.fn()} />,
+		)
+		expect(screen.getByRole('dialog', { name: /split the pot/i })).toBeTruthy()
+	})
+})

--- a/src/components/game/split-pot-modal.tsx
+++ b/src/components/game/split-pot-modal.tsx
@@ -1,15 +1,24 @@
 'use client'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '@/components/ui/dialog'
 
 interface SplitPotModalProps {
 	gameId: string
 	aliveCount: number
 	potTotal: string
+	open: boolean
 	onClose: () => void
 }
 
-export function SplitPotModal({ gameId, aliveCount, potTotal, onClose }: SplitPotModalProps) {
+export function SplitPotModal({ gameId, aliveCount, potTotal, open, onClose }: SplitPotModalProps) {
 	const router = useRouter()
 	const [submitting, setSubmitting] = useState(false)
 	const [error, setError] = useState<string | null>(null)
@@ -38,26 +47,16 @@ export function SplitPotModal({ gameId, aliveCount, potTotal, onClose }: SplitPo
 	}
 
 	return (
-		// biome-ignore lint/a11y/useKeyWithClickEvents: backdrop click-to-close; Escape handling delegated to dialog close button
-		// biome-ignore lint/a11y/noStaticElementInteractions: backdrop is a dialog scrim, not an interactive control
-		<div
-			role="dialog"
-			aria-modal="true"
-			className="fixed inset-0 z-50 flex items-center justify-center bg-black/65"
-			onClick={onClose}
-		>
-			{/* biome-ignore lint/a11y/useKeyWithClickEvents: stopPropagation on container prevents backdrop-close, not a user-facing interaction */}
-			{/* biome-ignore lint/a11y/noStaticElementInteractions: inner panel is non-interactive — intercepts bubbling clicks only */}
-			<div
-				onClick={(e) => e.stopPropagation()}
-				className="w-[360px] rounded-lg border border-border bg-background p-5 shadow-2xl"
-			>
-				<h3 className="text-[15px] font-bold">Split the pot now?</h3>
-				<p className="mb-4 mt-1 text-xs text-muted-foreground">
-					This ends the game immediately. All {aliveCount} alive players are marked as winners.
-					Eliminated players get nothing.
-				</p>
-				<div className="mb-4 rounded-md border border-border bg-card p-3 text-center">
+		<Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+			<DialogContent className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle>Split the pot now?</DialogTitle>
+					<DialogDescription>
+						This ends the game immediately. All {aliveCount} alive players are marked as winners.
+						Eliminated players get nothing.
+					</DialogDescription>
+				</DialogHeader>
+				<div className="rounded-md border border-border bg-card p-3 text-center">
 					<div className="text-xl font-extrabold tabular-nums text-emerald-500">
 						£{perWinner} each
 					</div>
@@ -65,11 +64,11 @@ export function SplitPotModal({ gameId, aliveCount, potTotal, onClose }: SplitPo
 						£{potTotal} split {aliveCount} ways
 					</div>
 				</div>
-				<p className="mb-4 rounded-r-sm border-l-2 border-amber-500 bg-amber-500/10 px-2 py-2 text-[11px] text-amber-500">
+				<p className="rounded-r-sm border-l-2 border-amber-500 bg-amber-500/10 px-2 py-2 text-[11px] text-amber-500">
 					⚠ This can't be undone. Game status becomes "completed".
 				</p>
-				{error && <p className="mb-3 text-xs text-red-500">Couldn't split: {error}</p>}
-				<div className="flex justify-end gap-2">
+				{error && <p className="text-xs text-red-500">Couldn't split: {error}</p>}
+				<DialogFooter>
 					<button
 						type="button"
 						onClick={onClose}
@@ -86,8 +85,8 @@ export function SplitPotModal({ gameId, aliveCount, potTotal, onClose }: SplitPo
 					>
 						Split £{potTotal} across {aliveCount} winners
 					</button>
-				</div>
-			</div>
-		</div>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
 	)
 }

--- a/src/components/game/split-pot-modal.tsx
+++ b/src/components/game/split-pot-modal.tsx
@@ -73,7 +73,7 @@ export function SplitPotModal({ gameId, aliveCount, potTotal, open, onClose }: S
 						type="button"
 						onClick={onClose}
 						disabled={submitting}
-						className="rounded-md border border-border bg-transparent px-3 py-1.5 text-xs font-semibold text-muted-foreground"
+						className="rounded-md border border-border bg-transparent px-3 py-1.5 text-xs font-semibold text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 					>
 						Cancel
 					</button>
@@ -81,7 +81,7 @@ export function SplitPotModal({ gameId, aliveCount, potTotal, open, onClose }: S
 						type="button"
 						onClick={handleConfirm}
 						disabled={submitting || aliveCount < 2}
-						className="rounded-md bg-emerald-500 px-3 py-1.5 text-xs font-bold text-white disabled:opacity-50"
+						className="rounded-md bg-emerald-500 px-3 py-1.5 text-xs font-bold text-white disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 					>
 						Split £{potTotal} across {aliveCount} winners
 					</button>

--- a/src/components/picks/classic-pick.tsx
+++ b/src/components/picks/classic-pick.tsx
@@ -139,7 +139,7 @@ export function ClassicPick({
 						<button
 							type="button"
 							onClick={() => setExpanded(true)}
-							className="text-xs font-semibold px-3 py-1.5 rounded-md border border-border bg-card hover:bg-muted flex items-center gap-1"
+							className="text-xs font-semibold px-3 py-1.5 rounded-md border border-border bg-card hover:bg-muted flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 						>
 							Change pick <ChevronDown className="h-3 w-3" />
 						</button>
@@ -160,7 +160,7 @@ export function ClassicPick({
 							<button
 								type="button"
 								onClick={() => setExpanded(false)}
-								className="text-xs font-medium px-2 py-1 rounded-md border border-border hover:bg-muted flex items-center gap-1"
+								className="text-xs font-medium px-2 py-1 rounded-md border border-border hover:bg-muted flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 							>
 								Collapse <ChevronUp className="h-3 w-3" />
 							</button>
@@ -333,7 +333,7 @@ function PlannerSection({
 				type="button"
 				onClick={toggle}
 				aria-expanded={open}
-				className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-muted/40 rounded-xl"
+				className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-muted/40 rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 			>
 				<div>
 					<div className="font-semibold text-sm">Plan ahead</div>

--- a/src/components/picks/cup-pick.tsx
+++ b/src/components/picks/cup-pick.tsx
@@ -288,6 +288,7 @@ export function CupPick({
 						className={cn(
 							'mt-3 w-full rounded bg-foreground text-background py-3 font-semibold',
 							'disabled:opacity-50 disabled:cursor-not-allowed',
+							'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
 						)}
 						disabled={readonly || slots.length < minPicks || loading}
 						onClick={handleSubmit}
@@ -367,7 +368,7 @@ function CupRankedRow({
 				<button
 					type="button"
 					onClick={onRemove}
-					className="ml-auto text-muted-foreground hover:text-[var(--eliminated)] p-1"
+					className="ml-auto text-muted-foreground hover:text-[var(--eliminated)] p-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 					aria-label="Remove"
 				>
 					<X className="h-4 w-4" />
@@ -425,7 +426,7 @@ function CupRankedRow({
 					type="button"
 					onClick={onMoveUp}
 					disabled={isFirst}
-					className="border border-border rounded p-1 disabled:opacity-30 hover:bg-muted"
+					className="border border-border rounded p-1 disabled:opacity-30 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 					aria-label="Move up"
 				>
 					<ChevronUp className="h-3.5 w-3.5" />
@@ -434,7 +435,7 @@ function CupRankedRow({
 					type="button"
 					onClick={onMoveDown}
 					disabled={isLast}
-					className="border border-border rounded p-1 disabled:opacity-30 hover:bg-muted"
+					className="border border-border rounded p-1 disabled:opacity-30 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 					aria-label="Move down"
 				>
 					<ChevronDown className="h-3.5 w-3.5" />
@@ -443,7 +444,7 @@ function CupRankedRow({
 			<button
 				type="button"
 				onClick={onRemove}
-				className="text-muted-foreground hover:text-[var(--eliminated)] p-1 shrink-0"
+				className="text-muted-foreground hover:text-[var(--eliminated)] p-1 shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 				aria-label="Remove"
 			>
 				<X className="h-4 w-4" />

--- a/src/components/picks/fixture-row.tsx
+++ b/src/components/picks/fixture-row.tsx
@@ -162,7 +162,7 @@ function TeamPickButton({
 			onClick={clickable ? onClick : undefined}
 			disabled={!clickable}
 			className={cn(
-				'flex items-center gap-3 px-4 py-3 flex-1 min-w-0 transition-all',
+				'flex items-center gap-3 px-4 py-3 flex-1 min-w-0 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-inset',
 				isHome ? 'flex-row-reverse' : 'flex-row',
 				clickable && 'hover:bg-muted/50 cursor-pointer',
 				selected && 'bg-[var(--alive-bg)] ring-2 ring-[var(--alive)] ring-inset',

--- a/src/components/picks/planner-round.tsx
+++ b/src/components/picks/planner-round.tsx
@@ -151,7 +151,7 @@ export function PlannerRound(props: PlannerRoundProps) {
 			{props.plannedTeamId && (
 				<button
 					type="button"
-					className="mt-2 text-[11px] text-muted-foreground underline"
+					className="mt-2 text-[11px] text-muted-foreground underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 rounded"
 					onClick={() => props.onRemove(props.roundId)}
 				>
 					Clear plan

--- a/src/components/picks/prediction-buttons.tsx
+++ b/src/components/picks/prediction-buttons.tsx
@@ -32,7 +32,7 @@ export function PredictionButtons({ value, onChange, size = 'md' }: PredictionBu
 					type="button"
 					onClick={() => onChange(pred)}
 					className={cn(
-						'flex-1 rounded-md border font-semibold transition-colors',
+						'flex-1 rounded-md border font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
 						sizeClass,
 						value === pred
 							? COLOURS[pred]

--- a/src/components/picks/ranked-item.tsx
+++ b/src/components/picks/ranked-item.tsx
@@ -64,7 +64,7 @@ export function RankedItem({
 				type="button"
 				{...attributes}
 				{...listeners}
-				className="text-muted-foreground p-1 cursor-grab touch-none"
+				className="text-muted-foreground p-1 cursor-grab touch-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 rounded"
 				style={{ touchAction: 'none' }}
 				aria-label="Drag to reorder"
 			>
@@ -99,7 +99,7 @@ export function RankedItem({
 				type="button"
 				onClick={onChangePrediction}
 				className={cn(
-					'text-xs font-bold px-2.5 py-1 rounded shrink-0',
+					'text-xs font-bold px-2.5 py-1 rounded shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
 					PRED_COLOUR[pick.prediction],
 				)}
 			>
@@ -110,7 +110,7 @@ export function RankedItem({
 					type="button"
 					onClick={onMoveUp}
 					disabled={isFirst}
-					className="border border-border rounded p-1 disabled:opacity-30 hover:bg-muted"
+					className="border border-border rounded p-1 disabled:opacity-30 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 					aria-label="Move up"
 				>
 					<ChevronUp className="h-3.5 w-3.5" />
@@ -119,7 +119,7 @@ export function RankedItem({
 					type="button"
 					onClick={onMoveDown}
 					disabled={isLast}
-					className="border border-border rounded p-1 disabled:opacity-30 hover:bg-muted"
+					className="border border-border rounded p-1 disabled:opacity-30 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 					aria-label="Move down"
 				>
 					<ChevronDown className="h-3.5 w-3.5" />
@@ -128,7 +128,7 @@ export function RankedItem({
 			<button
 				type="button"
 				onClick={onRemove}
-				className="text-muted-foreground hover:text-[var(--eliminated)] p-1 shrink-0"
+				className="text-muted-foreground hover:text-[var(--eliminated)] p-1 shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 				aria-label="Remove"
 			>
 				<X className="h-4 w-4" />

--- a/src/components/picks/turbo-pick.tsx
+++ b/src/components/picks/turbo-pick.tsx
@@ -315,7 +315,7 @@ export function TurboPick({
 											<button
 												type="button"
 												onClick={() => handleAddToRanked(fix)}
-												className="mt-2.5 text-sm font-semibold text-[var(--accent)] w-full text-center py-1.5 hover:underline"
+												className="mt-2.5 text-sm font-semibold text-[var(--accent)] w-full text-center py-1.5 hover:underline rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 											>
 												↑ Add to predictions as #{ranked.length + 1}
 											</button>

--- a/src/components/standings/cup-standings.tsx
+++ b/src/components/standings/cup-standings.tsx
@@ -40,7 +40,7 @@ export function CupStandings({ data, onShare, showAdminActions, gameId }: CupSta
 								type="button"
 								onClick={() => setView(m)}
 								className={cn(
-									'text-xs font-semibold px-2.5 py-1 rounded flex items-center gap-1',
+									'text-xs font-semibold px-2.5 py-1 rounded flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
 									view === m
 										? 'bg-foreground text-background'
 										: 'text-muted-foreground hover:text-foreground',
@@ -57,7 +57,7 @@ export function CupStandings({ data, onShare, showAdminActions, gameId }: CupSta
 						<button
 							type="button"
 							onClick={onShare}
-							className="text-xs font-semibold px-3 py-1 rounded border border-border"
+							className="text-xs font-semibold px-3 py-1 rounded border border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 						>
 							Share
 						</button>

--- a/src/components/standings/cup-standings.tsx
+++ b/src/components/standings/cup-standings.tsx
@@ -71,7 +71,11 @@ export function CupStandings({ data, onShare, showAdminActions, gameId }: CupSta
 				{view === 'grid' && (
 					<CupGrid data={data} showAdminActions={showAdminActions} gameId={gameId} />
 				)}
-				{view === 'timeline' && <CupTimeline data={data} />}
+				{view === 'timeline' && (
+					<div className="overflow-x-auto">
+						<CupTimeline data={data} />
+					</div>
+				)}
 			</div>
 		</div>
 	)

--- a/src/components/standings/grid-filter.tsx
+++ b/src/components/standings/grid-filter.tsx
@@ -24,7 +24,7 @@ export function GridFilter({ value, onChange }: GridFilterProps) {
 					type="button"
 					onClick={() => onChange(opt.value)}
 					className={cn(
-						'text-xs px-2 py-1 rounded-md border border-border font-medium transition-colors',
+						'text-xs px-2 py-1 rounded-md border border-border font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
 						value === opt.value
 							? 'bg-foreground text-background border-foreground'
 							: 'bg-card text-muted-foreground hover:bg-muted',

--- a/src/components/standings/turbo-standings.tsx
+++ b/src/components/standings/turbo-standings.tsx
@@ -109,7 +109,7 @@ export function TurboStandings({
 							type="button"
 							onClick={() => setView('ladder')}
 							className={cn(
-								'text-xs font-semibold px-2.5 py-1 rounded flex items-center gap-1',
+								'text-xs font-semibold px-2.5 py-1 rounded flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
 								view === 'ladder'
 									? 'bg-foreground text-background'
 									: 'text-muted-foreground hover:text-foreground',
@@ -121,7 +121,7 @@ export function TurboStandings({
 							type="button"
 							onClick={() => setView('timeline')}
 							className={cn(
-								'text-xs font-semibold px-2.5 py-1 rounded flex items-center gap-1',
+								'text-xs font-semibold px-2.5 py-1 rounded flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
 								view === 'timeline'
 									? 'bg-foreground text-background'
 									: 'text-muted-foreground hover:text-foreground',
@@ -133,7 +133,7 @@ export function TurboStandings({
 							type="button"
 							onClick={() => setView('grid')}
 							className={cn(
-								'text-xs font-semibold px-2.5 py-1 rounded flex items-center gap-1',
+								'text-xs font-semibold px-2.5 py-1 rounded flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
 								view === 'grid'
 									? 'bg-foreground text-background'
 									: 'text-muted-foreground hover:text-foreground',
@@ -150,7 +150,7 @@ export function TurboStandings({
 									type="button"
 									onClick={() => setRoundId(r.id)}
 									className={cn(
-										'text-xs font-semibold px-2.5 py-1 rounded',
+										'text-xs font-semibold px-2.5 py-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
 										r.id === round.id
 											? 'bg-foreground text-background'
 											: 'text-muted-foreground hover:text-foreground',

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -102,8 +102,7 @@ export async function getGameDetail(gameId: string, userId: string) {
 	for (const uid of relevantUserIds) {
 		const userPlayer = gameData.players.find((p) => p.userId === uid)
 		const userPaymentRows = payments.filter((p) => p.userId === uid)
-		// biome-ignore lint/complexity/useOptionalChain: Need to check both round2 existence and deadline separately
-		if (!userPlayer || !round1 || !round2 || !round2.deadline) {
+		if (!userPlayer || !round1 || !round2?.deadline) {
 			eligibilityByUser.set(uid, false)
 			continue
 		}
@@ -200,8 +199,7 @@ export async function getGameDetail(gameId: string, userId: string) {
 		pendingPayment: { id: string; amount: string } | null
 	} | null = null
 
-	// biome-ignore lint/complexity/useOptionalChain: Need to check both round2 existence and deadline separately
-	if (viewerGamePlayer && round1 && round2 && round2.deadline && gameData.entryFee) {
+	if (viewerGamePlayer && round1 && round2?.deadline && gameData.entryFee) {
 		const eligible = isRebuyEligible({
 			game: {
 				gameMode: gameData.gameMode,

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -153,10 +153,41 @@ export async function getGameDetail(gameId: string, userId: string) {
 			paidAt: row.paidAt,
 		}))
 	})
+
+	// Surface admin-added players who have no payment row as synthetic "unpaid" rows
+	// so the admin Rebuy button is reachable for free-entry players.
+	const playersWithPayments = new Set(allPayments.map((p) => p.userId))
+	const syntheticUnpaidRows = gameData.players
+		.filter((p) => !playersWithPayments.has(p.userId))
+		.map((p) => ({
+			id: null as string | null,
+			userId: p.userId,
+			userName: userNames.get(p.userId) ?? 'Unknown',
+			amount: gameData.entryFee ?? '0.00',
+			status: 'unpaid' as const,
+			isRebuy: false,
+			isRebuyEligible: eligibilityByUser.get(p.userId) ?? false,
+			claimedAt: null,
+			paidAt: null,
+		}))
+	// finalAdminPayments unions real payment rows with synthetic free-player rows.
+	// The id field is widened to string | null for synthetic rows.
+	const finalAdminPayments: Array<{
+		id: string | null
+		userId: string
+		userName: string
+		amount: string
+		status: 'pending' | 'claimed' | 'paid' | 'refunded' | 'unpaid'
+		isRebuy: boolean
+		isRebuyEligible: boolean
+		claimedAt: Date | null
+		paidAt: Date | null
+	}> = [...allPayments, ...syntheticUnpaidRows]
+
 	const otherPayments = allPayments
 		.filter((p) => p.userId !== userId)
 		.map((p) => ({ userName: p.userName, status: p.status, isRebuy: p.isRebuy }))
-	const adminPayments = isAdmin ? allPayments : undefined
+	const adminPayments = isAdmin ? finalAdminPayments : undefined
 
 	// Rebuy banner: rounds 1 and 2 were already fetched above for eligibility checks.
 	const viewerGamePlayer = myMembership

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -102,6 +102,7 @@ export async function getGameDetail(gameId: string, userId: string) {
 	for (const uid of relevantUserIds) {
 		const userPlayer = gameData.players.find((p) => p.userId === uid)
 		const userPaymentRows = payments.filter((p) => p.userId === uid)
+		// biome-ignore lint/complexity/useOptionalChain: Need to check both round2 existence and deadline separately
 		if (!userPlayer || !round1 || !round2 || !round2.deadline) {
 			eligibilityByUser.set(uid, false)
 			continue
@@ -199,6 +200,7 @@ export async function getGameDetail(gameId: string, userId: string) {
 		pendingPayment: { id: string; amount: string } | null
 	} | null = null
 
+	// biome-ignore lint/complexity/useOptionalChain: Need to check both round2 existence and deadline separately
 	if (viewerGamePlayer && round1 && round2 && round2.deadline && gameData.entryFee) {
 		const eligible = isRebuyEligible({
 			game: {

--- a/src/lib/share/data.ts
+++ b/src/lib/share/data.ts
@@ -236,8 +236,7 @@ export async function getShareLiveData(
 			players: true,
 		},
 	})
-	// biome-ignore lint/complexity/useOptionalChain: Need to check both gameRow existence and currentRoundId separately
-	if (!gameRow || !gameRow.currentRoundId) return null
+	if (!gameRow?.currentRoundId) return null
 	const currentRound = gameRow.competition.rounds.find((r) => r.id === gameRow.currentRoundId)
 	if (!currentRound) return null
 

--- a/src/lib/share/data.ts
+++ b/src/lib/share/data.ts
@@ -236,6 +236,7 @@ export async function getShareLiveData(
 			players: true,
 		},
 	})
+	// biome-ignore lint/complexity/useOptionalChain: Need to check both gameRow existence and currentRoundId separately
 	if (!gameRow || !gameRow.currentRoundId) return null
 	const currentRound = gameRow.competition.rounds.find((r) => r.id === gameRow.currentRoundId)
 	if (!currentRound) return null


### PR DESCRIPTION
## Summary

Polish + a11y sweep across 4a/4b/4c surfaces. Migrates two custom modals to shadcn `Dialog`, runs a mobile width pass at iPhone 393px, clears all Biome warnings, finishes carry-over deferrals from earlier phases.

### What's done
- **`add-player-modal` + `split-pot-modal` migrated to shadcn `Dialog`** — focus trap, Escape, `aria-labelledby` for free; four `biome-ignore lint/a11y/*` suppressions removed.
- **"IN GAME" badge** on add-player autocomplete via `?gameId=` query param on `/api/users/search`. Prevents duplicate-add attempts.
- **Free-player rebuy in payments panel** — synthetic "unpaid" rows surface admin-added players with no payment row so the Rebuy button is reachable.
- **Three new seeded games** for share-variant smoke testing (live snapshot, solo winner, split-pot winner). `just db-reset` now puts each variant in a smoke-testable state.
- **Legacy `/api/share/grid/[gameId]` alias deleted** (kept for one phase as belt-and-braces; ShareDialog already uses `/standings`).
- **Mobile width audit + fixes** — Tailwind utility additions only across dashboard, game detail (per mode), game create, join. Cup-grid + cup-timeline + payments-panel wrap in `overflow-x-auto`; share-dialog controls + payment strip + game header use `flex-wrap` for narrow widths; game card titles `truncate` long names.
- **Keyboard nav pass** — no `<div onClick>` violations found (everything was already on `<button>`); 17 custom buttons retrofitted with `focus-visible:ring-*` for consistent visible focus indication; added `:focus-visible` baseline to `globals.css`.
- **All Biome warnings resolved** (6 → 0, no new biome-ignore lines).

### Out of scope (deferred)
- WCAG 2.1 AA conformance audit.
- Screen-reader testing.
- Mobile-first re-thinks (bottom nav, swipe gestures, mobile-optimized pick UIs).
- User-search email enumeration hardening — verified during plan write-up that the route already returns uniform `{users: []}` shape; no leak.

### Spec & plan
- `docs/superpowers/specs/2026-04-27-phase-4c5-mobile-and-a11y-design.md`
- `docs/superpowers/plans/2026-04-27-phase-4c5-mobile-and-a11y.md`

## Test plan

- [ ] 325 tests passing locally; typecheck clean; 0 Biome warnings; `pnpm build` succeeds.
- [ ] Open `add-player-modal` and `split-pot-modal` — confirm Escape closes them; tab traps focus.
- [ ] Search for an existing player in `add-player-modal` — confirm "IN GAME" badge appears on already-in-game users.
- [ ] After `just db-reset`, open the rebuy smoke game; admin sees "Mike" (paymentRowCount=0) as an unpaid row with a working Rebuy button.
- [ ] Open the three new seed games; share dialog auto-picks the right variant (live for Live Lads, winner for Champion's Cup + Split Cup).
- [ ] Manual mobile smoke at iPhone 393px: dashboard, game detail (classic/cup/turbo), game create, join — no horizontal scroll, all controls reachable.
- [ ] Tab through dashboard + game detail; visible focus rings on every interactive.
- [ ] `/api/share/grid/[gameId]` returns 404 (alias deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)