### PR TITLE
fix(4.5): document NEXT_PUBLIC_APP_URL — required by auth client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,10 @@ QSTASH_NEXT_SIGNING_KEY=sig_dev_placeholder
 # Auto-populated by Vercel in production builds. Set manually if you want to
 # exercise QStash locally (it's used as the callback base URL).
 VERCEL_URL=http://localhost:3000
+
+# ─── Public app URL ────────────────────────────────────────────────────────
+# Used by the Better Auth client (src/lib/auth-client.ts) as its baseURL.
+# Must be the exact deployed origin in prd/stg so the browser can call
+# /api/auth/* endpoints. NEXT_PUBLIC_* vars are bundled into the client at
+# build time — changing this requires a redeploy.
+NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ Variables:
 - `QSTASH_TOKEN` — Upstash QStash client token.
 - `QSTASH_CURRENT_SIGNING_KEY` and `QSTASH_NEXT_SIGNING_KEY` — QStash webhook signature verification.
 - `VERCEL_URL` — deployment URL used as the QStash callback base. Populated automatically in Vercel builds; set manually in dev if you want to exercise QStash locally.
+- `NEXT_PUBLIC_APP_URL` — public origin of the deployed app. Used by the Better Auth client (`src/lib/auth-client.ts`) as its `baseURL`. **Must match the deployed URL exactly** so the browser can reach `/api/auth/*`. As a `NEXT_PUBLIC_*` var, it's bundled into the client at build time — changing it requires a redeploy.
 
 GitHub Actions secrets (repo-level):
 - `CRON_SECRET` — same value as Doppler `prd.CRON_SECRET`. Used by `live-scores.yml` for the every-minute poll.


### PR DESCRIPTION
## Summary

Critical follow-up to Phase 4.5: \`NEXT_PUBLIC_APP_URL\` is read by \`src/lib/auth-client.ts:4\` but was never documented in \`.env.example\` or \`AGENTS.md\`, so it wasn't in Doppler when the production deploy went out. The fallback (\`http://localhost:3000\`) got baked into the client bundle, breaking sign-up at runtime with \`net::ERR_CONNECTION_REFUSED\` pointing at localhost.

The env var is now set in Doppler dev/stg/prd. This PR adds the documentation so future agents/contributors know about it.

After this merges, a redeploy picks up the value into a fresh client bundle.

## Test plan
- [ ] CI green
- [ ] After merge: production redeploy succeeds
- [ ] After redeploy: signup form on prod URL successfully POSTs to /api/auth/sign-up/email (no localhost reference in network tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)