### PR TITLE
fix(4.5): football-data adapter handles WC placeholder teams

### DIFF
--- a/src/lib/data/football-data.test.ts
+++ b/src/lib/data/football-data.test.ts
@@ -111,6 +111,53 @@ describe('FootballDataAdapter', () => {
 		)
 	})
 
+	it('skips matches with placeholder (null) teams in fetchTeams', async () => {
+		const placeholderMatches = {
+			matches: [
+				...mockMatches.matches,
+				{
+					id: 999,
+					matchday: 4,
+					homeTeam: { id: null, name: null, tla: null, crest: null },
+					awayTeam: { id: null, name: null, tla: null, crest: null },
+					utcDate: '2026-07-15T15:00:00Z',
+					status: 'SCHEDULED',
+					score: { fullTime: { home: null, away: null } },
+				},
+			],
+		}
+		vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+			Promise.resolve(new Response(JSON.stringify(placeholderMatches))),
+		)
+		const teams = await adapter.fetchTeams()
+		expect(teams.every((t) => t.name && t.externalId !== 'null')).toBe(true)
+		expect(teams.find((t) => t.externalId === 'null')).toBeUndefined()
+	})
+
+	it('skips fixtures with placeholder teams in fetchRounds', async () => {
+		const placeholderMatches = {
+			matches: [
+				...mockMatches.matches,
+				{
+					id: 999,
+					matchday: 1,
+					homeTeam: { id: null, name: null, tla: null, crest: null },
+					awayTeam: { id: 64, name: 'Liverpool', tla: 'LIV', crest: '' },
+					utcDate: '2026-07-15T15:00:00Z',
+					status: 'SCHEDULED',
+					score: { fullTime: { home: null, away: null } },
+				},
+			],
+		}
+		vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+			Promise.resolve(new Response(JSON.stringify(placeholderMatches))),
+		)
+		const rounds = await adapter.fetchRounds()
+		const allFixtures = rounds.flatMap((r) => r.fixtures)
+		expect(allFixtures.find((f) => f.externalId === '999')).toBeUndefined()
+		expect(allFixtures.every((f) => f.homeTeamExternalId !== 'null')).toBe(true)
+	})
+
 	it('fetches standings', async () => {
 		const standings = await adapter.fetchStandings()
 		expect(standings).toHaveLength(2)

--- a/src/lib/data/football-data.ts
+++ b/src/lib/data/football-data.ts
@@ -25,11 +25,18 @@ export function resolveFootballDataCode(
 	return null
 }
 
+interface FdTeam {
+	id: number | null
+	name: string | null
+	tla: string | null
+	crest: string | null
+}
+
 interface FdMatch {
 	id: number
 	matchday: number
-	homeTeam: { id: number; name: string; tla: string; crest: string }
-	awayTeam: { id: number; name: string; tla: string; crest: string }
+	homeTeam: FdTeam
+	awayTeam: FdTeam
 	utcDate: string
 	status: string
 	score: { fullTime: { home: number | null; away: number | null } }
@@ -75,12 +82,13 @@ export class FootballDataAdapter implements CompetitionAdapter {
 		const teamMap = new Map<string, AdapterTeam>()
 		for (const match of data.matches) {
 			for (const t of [match.homeTeam, match.awayTeam]) {
+				if (t.id == null || t.name == null) continue
 				if (!teamMap.has(String(t.id))) {
 					teamMap.set(String(t.id), {
 						externalId: String(t.id),
 						name: t.name,
-						shortName: t.tla,
-						badgeUrl: t.crest,
+						shortName: t.tla ?? t.name.slice(0, 3).toUpperCase(),
+						badgeUrl: t.crest ?? null,
 					})
 				}
 			}
@@ -106,17 +114,19 @@ export class FootballDataAdapter implements CompetitionAdapter {
 				name: `Matchday ${matchday}`,
 				deadline: null,
 				finished: matches.every((m) => m.status === 'FINISHED'),
-				fixtures: matches.map(
-					(m): AdapterFixture => ({
-						externalId: String(m.id),
-						homeTeamExternalId: String(m.homeTeam.id),
-						awayTeamExternalId: String(m.awayTeam.id),
-						kickoff: new Date(m.utcDate),
-						status: this.mapStatus(m.status),
-						homeScore: m.score.fullTime.home,
-						awayScore: m.score.fullTime.away,
-					}),
-				),
+				fixtures: matches
+					.filter((m) => m.homeTeam.id != null && m.awayTeam.id != null)
+					.map(
+						(m): AdapterFixture => ({
+							externalId: String(m.id),
+							homeTeamExternalId: String(m.homeTeam.id),
+							awayTeamExternalId: String(m.awayTeam.id),
+							kickoff: new Date(m.utcDate),
+							status: this.mapStatus(m.status),
+							homeScore: m.score.fullTime.home,
+							awayScore: m.score.fullTime.away,
+						}),
+					),
 			}))
 	}
 


### PR DESCRIPTION
## Summary

Bootstrap WC against prod failed during Phase 4.5 execution because the football-data \`/competitions/WC/matches\` endpoint returns knockout-stage fixtures with placeholder teams (\`{ id: null, name: null, tla: null, crest: null }\` for "Winner of Group A vs Winner of Group B" before the group stage completes). The adapter naively converted these to \`AdapterTeam\` records with \`externalId="null"\` and \`name=null\`, then the bootstrap insert hit the \`team.name NOT NULL\` constraint and aborted the entire sync.

This is a Phase 4a bug that never surfaced because 4a's tests mocked the API with fully-populated teams.

## Changes
- \`FdTeam\` type widened to nullable fields (matches the actual API)
- \`fetchTeams\` skips entries with null \`id\` or \`name\`
- \`fetchRounds.fixtures\` filters out matches with null team IDs
- \`shortName\` falls back to \`name.slice(0, 3).toUpperCase()\` when \`tla\` is null
- Two regression tests covering the placeholder-team path

## Test plan
- [ ] CI green
- [ ] After merge: re-run \`pnpm exec tsx scripts/bootstrap-competitions.ts\` against prod and confirm the WC competition is fully synced (48 teams, all known fixtures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)