### PR TITLE
fix(4.5): football-data adapter handles null matchday on knockouts

### DIFF
--- a/src/lib/data/football-data.test.ts
+++ b/src/lib/data/football-data.test.ts
@@ -134,6 +134,31 @@ describe('FootballDataAdapter', () => {
 		expect(teams.find((t) => t.externalId === 'null')).toBeUndefined()
 	})
 
+	it('skips matches with null matchday in fetchRounds', async () => {
+		const withKnockouts = {
+			matches: [
+				...mockMatches.matches,
+				{
+					id: 998,
+					matchday: null,
+					homeTeam: { id: 64, name: 'Liverpool', tla: 'LIV', crest: '' },
+					awayTeam: { id: 66, name: 'Man United', tla: 'MUN', crest: '' },
+					utcDate: '2026-07-15T15:00:00Z',
+					status: 'TIMED',
+					score: { fullTime: { home: null, away: null } },
+				},
+			],
+		}
+		vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+			Promise.resolve(new Response(JSON.stringify(withKnockouts))),
+		)
+		const rounds = await adapter.fetchRounds()
+		expect(rounds.every((r) => r.number != null)).toBe(true)
+		expect(rounds.find((r) => r.name === 'Matchday null')).toBeUndefined()
+		const allFixtures = rounds.flatMap((r) => r.fixtures)
+		expect(allFixtures.find((f) => f.externalId === '998')).toBeUndefined()
+	})
+
 	it('skips fixtures with placeholder teams in fetchRounds', async () => {
 		const placeholderMatches = {
 			matches: [

--- a/src/lib/data/football-data.ts
+++ b/src/lib/data/football-data.ts
@@ -34,7 +34,7 @@ interface FdTeam {
 
 interface FdMatch {
 	id: number
-	matchday: number
+	matchday: number | null
 	homeTeam: FdTeam
 	awayTeam: FdTeam
 	utcDate: string
@@ -102,6 +102,7 @@ export class FootballDataAdapter implements CompetitionAdapter {
 		)
 		const roundMap = new Map<number, FdMatch[]>()
 		for (const match of data.matches) {
+			if (match.matchday == null) continue
 			const list = roundMap.get(match.matchday) ?? []
 			list.push(match)
 			roundMap.set(match.matchday, list)


### PR DESCRIPTION
Follow-up to #10. After filtering null teams, bootstrap still aborted because WC knockouts have null matchday in the API (32 of 104 WC matches). Adapter was producing a "Matchday null" round and trying to insert null into round.number.

Fix: fetchRounds skips matches with null matchday. Knockouts will land via daily-sync cron once their matchday is assigned post-group-stage.

Plus regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)