### PR TITLE
fix(4.5): proxy.ts allows /api/cron through to route-level auth

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,7 +2,14 @@ import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { auth } from '@/lib/auth'
 
-const publicPaths = ['/auth', '/api/auth']
+// Paths that bypass the Better Auth session check in this proxy.
+// /auth — login page renders for unauthenticated users.
+// /api/auth — Better Auth's own request handler.
+// /api/cron — every route under this checks CRON_SECRET (or QStash signature
+//   for qstash-handler) at the route level. The proxy must let them through
+//   so route-level auth can run; otherwise GitHub Actions and QStash callbacks
+//   get redirected to /auth.
+const publicPaths = ['/auth', '/api/auth', '/api/cron']
 
 export const config = {
 	matcher: ['/((?!_next/static|_next/image|favicon.ico|public).*)'],


### PR DESCRIPTION
The \`live-scores.yml\` GitHub Action was returning HTTP 307 in prod — \`proxy.ts\` was redirecting every \`/api/cron/*\` request to \`/auth\` despite the requests carrying valid \`CRON_SECRET\` bearer tokens.

Every cron route already does its own auth at the route level. Proxy must let them through so route-level auth can run.

Verified by grepping each route:
- poll-scores, daily-sync, sync-fpl, process-rounds — all check \`Authorization: Bearer \${CRON_SECRET}\`
- qstash-handler — uses \`verifySignatureAppRouter\` from \`@upstash/qstash/nextjs\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)