### PR TITLE
fix(launch-feedback): live bar results, progress grid scores, deadline-locked pick UI

### DIFF
--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -182,8 +182,16 @@ export default async function GameDetailPage({
 		? { gamePlayerId: actingAsTarget.gamePlayerId, userName: actingAsTarget.userName }
 		: undefined
 
+	// Once a round's deadline has passed (and processGameRound has not yet
+	// advanced the game's currentRoundId), the pick interface is locked: showing
+	// it would just surface options the user can no longer use. We render a
+	// concise "Round closed" panel instead. Standings views (rendered below the
+	// pickSection) are where the user gets the live/results detail.
+	const now = new Date()
+	const roundDeadlinePassed = !!game.currentRound?.deadline && now >= game.currentRound.deadline
+
 	const pickSection =
-		game.currentRound && isAlive ? (
+		game.currentRound && isAlive && !roundDeadlinePassed ? (
 			game.gameMode === 'classic' && classicPickData ? (
 				<ClassicPick
 					gameId={game.id}
@@ -232,7 +240,9 @@ export default async function GameDetailPage({
 					? 'You have been eliminated from this game.'
 					: game.status === 'completed'
 						? 'This game has ended.'
-						: 'Waiting for the next round.'}
+						: roundDeadlinePassed
+							? 'Round closed — picks locked. Live scores and standings update below.'
+							: 'Waiting for the next round.'}
 			</div>
 		)
 

--- a/src/components/live/live-fixture-card.tsx
+++ b/src/components/live/live-fixture-card.tsx
@@ -21,8 +21,16 @@ function statusText(
 	if (state === 'live') return 'LIVE'
 	if (!kickoff) return 'TBC'
 	const t = typeof kickoff === 'string' ? Date.parse(kickoff) : kickoff.getTime()
-	const mins = Math.max(0, Math.round((t - now.getTime()) / 60_000))
-	return mins === 0 ? 'KICKING OFF' : `KICKS OFF IN ${mins}m`
+	const totalMins = Math.max(0, Math.round((t - now.getTime()) / 60_000))
+	if (totalMins === 0) return 'KICKING OFF'
+	// Days/hours/minutes for kickoffs more than an hour away — pure-minutes
+	// loses context (e.g. WC opener showing "60480m" is meaningless).
+	const days = Math.floor(totalMins / (60 * 24))
+	const hours = Math.floor((totalMins % (60 * 24)) / 60)
+	const mins = totalMins % 60
+	if (days > 0) return `KICKS OFF IN ${days}d ${hours}h`
+	if (hours > 0) return `KICKS OFF IN ${hours}h ${mins}m`
+	return `KICKS OFF IN ${mins}m`
 }
 
 export function LiveFixtureCard({
@@ -46,11 +54,14 @@ export function LiveFixtureCard({
 				'relative flex min-w-[170px] flex-col gap-1 rounded-lg border bg-card px-3 py-2',
 				statusClasses,
 				state === 'pre' && 'opacity-70',
+				state === 'ft' && 'opacity-80',
 				className,
 			)}
 		>
 			{isMyPick && (
-				<span className="absolute -top-1.5 right-2 rounded-sm bg-primary px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-primary-foreground">
+				// Inline at top of card (was previously `absolute -top-1.5` which got
+				// clipped by the live-ticker's overflow-x-auto wrapper on mobile).
+				<span className="self-end -mb-0.5 rounded-sm bg-primary px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-primary-foreground">
 					My pick
 				</span>
 			)}

--- a/src/components/live/live-score-ticker.tsx
+++ b/src/components/live/live-score-ticker.tsx
@@ -11,11 +11,35 @@ export function LiveScoreTicker() {
 	if (!payload) return null
 
 	const now = new Date()
-	const livish = payload.fixtures.filter((f) => {
-		const state = deriveMatchState(f, now)
-		return state === 'pre' || state === 'live' || state === 'ht'
+
+	// Surface every fixture in the current round, with state-aware ordering so
+	// the most actionable ones (live → upcoming → finished) appear left-to-right.
+	// Within each state group, sort sensibly: live by kickoff asc (oldest first
+	// = most match minutes elapsed), upcoming by kickoff asc (next first),
+	// finished by kickoff desc (most recent first).
+	const stateOrder: Record<'live' | 'ht' | 'pre' | 'ft', number> = {
+		live: 0,
+		ht: 0,
+		pre: 1,
+		ft: 2,
+	}
+	const annotated = payload.fixtures.map((f) => ({ fixture: f, state: deriveMatchState(f, now) }))
+	annotated.sort((a, b) => {
+		const orderDiff = stateOrder[a.state] - stateOrder[b.state]
+		if (orderDiff !== 0) return orderDiff
+		const aKickoff = a.fixture.kickoff
+			? typeof a.fixture.kickoff === 'string'
+				? Date.parse(a.fixture.kickoff)
+				: a.fixture.kickoff.getTime()
+			: 0
+		const bKickoff = b.fixture.kickoff
+			? typeof b.fixture.kickoff === 'string'
+				? Date.parse(b.fixture.kickoff)
+				: b.fixture.kickoff.getTime()
+			: 0
+		return a.state === 'ft' ? bKickoff - aKickoff : aKickoff - bKickoff
 	})
-	if (livish.length === 0) return null
+	if (annotated.length === 0) return null
 
 	const viewerPicksByFixture = new Map<string, LivePick>()
 	const viewerPlayerIds = new Set(
@@ -30,7 +54,7 @@ export function LiveScoreTicker() {
 	return (
 		<div className="mb-4 flex items-start gap-2">
 			<div className="flex flex-1 gap-2 overflow-x-auto pb-1">
-				{livish.map((fixture) => {
+				{annotated.map(({ fixture }) => {
 					const viewerPick = viewerPicksByFixture.get(fixture.id) ?? null
 					return (
 						<GoalCelebration key={fixture.id} fixtureId={fixture.id} viewerPick={viewerPick}>

--- a/src/components/standings/progress-grid.tsx
+++ b/src/components/standings/progress-grid.tsx
@@ -405,8 +405,11 @@ function GridCellView({
 		: (colours[cell.result] ?? 'bg-muted text-muted-foreground')
 
 	const pickedLabel = cell.teamShortName ?? '?'
+	// Build the under-line as `<v|@><opponent> [score]` so users can see at a
+	// glance whether their pick won/lost without hovering for the tooltip.
+	// Score replaces no info — when score is unset the opponent line stays as-is.
 	const opponentLabel = cell.opponentShortName
-		? `${cell.homeAway === 'A' ? '@' : 'v'}${cell.opponentShortName}`
+		? `${cell.homeAway === 'A' ? '@' : 'v'}${cell.opponentShortName}${cell.score ? ` ${cell.score}` : ''}`
 		: null
 
 	const scorePart = cell.score ? ` (${cell.score})` : ''


### PR DESCRIPTION
## Why

Three of your post-launch feedback items, all on the "context within a gameweek" theme:

> Unable to validate if [score updates] have happened since as only upcoming fixtures are displayed. Results are definitely relevant too
> Want results to be reflected appropriately in the progress grid too
> Once deadline passes pick interface should be locked as it just adds noise to open it
> On live bar on mobile 'my pick' is partially obscured in top right corner of match box
> Countdown timer for live kickoff is in minutes. Should be days, hours, minutes

## Changes

### Live bar — \`LiveScoreTicker\` + \`LiveFixtureCard\`
- **Show finished fixtures** (was filtered out — \`livish\` only kept \`pre/live/ht\` states). Past results stay visible alongside live + upcoming.
- **State-aware sort**: live → upcoming → finished, with kickoff-asc within live/upcoming and kickoff-desc within finished (most recent first).
- **\"My pick\" badge inline** at the top of each card. Was \`absolute -top-1.5\` which got clipped by the \`overflow-x-auto\` parent on mobile, hiding the indicator entirely on right-most cards.
- **Countdown formatting**: \`d/h/m\` instead of pure minutes — e.g. \`KICKS OFF IN 2d 16h\`, \`5h 30m\`, \`45m\`. (Pure minutes for a WC opener showing as \`60480m\` was meaningless.)

### Progress grid
- Score now visible in the cell's opponent line (e.g. \`vBUR 3-1\`) — was tooltip-only.

### Pick interface deadline lock
- Once \`now >= round.deadline\` (and \`processGameRound\` hasn't advanced \`currentRoundId\` yet), the pick interface is replaced with a \"Round closed — picks locked. Live scores and standings update below.\" panel. Stops the user seeing options they can't use anymore. Standings + live bar remain the source of in-progress and final state.

## Test plan
- [ ] CI green (343 tests; no new ones — these are pure UI tweaks)
- [ ] After merge: open the WC test game on prod with a fresh round and verify the live bar shows all 10 PL fixtures sorted live→upcoming→finished
- [ ] After merge: open the round 35 view; cells for played fixtures show "v<OPP> 3-1"
- [ ] After merge: pick interface for round whose deadline has passed shows the "Round closed" panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)