### PR TITLE
fix(launch-feedback): block game creation past deadline + admin delete game

### DIFF
--- a/src/app/api/games/[id]/route.test.ts
+++ b/src/app/api/games/[id]/route.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/auth-helpers', () => ({
+	requireSession: vi.fn(),
+}))
+
+const txMock = {
+	query: {
+		gamePlayer: { findMany: vi.fn() },
+	},
+	delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+}
+
+vi.mock('@/lib/db', () => ({
+	db: {
+		query: {
+			game: { findFirst: vi.fn() },
+			payment: { findMany: vi.fn() },
+		},
+		transaction: vi.fn(async (cb: (tx: typeof txMock) => Promise<void>) => {
+			await cb(txMock)
+		}),
+	},
+}))
+
+import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { DELETE } from './route'
+
+const params = { params: Promise.resolve({ id: 'g1' }) }
+
+describe('DELETE /api/games/[id]', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.mocked(requireSession).mockResolvedValue({ user: { id: 'u-admin' } } as never)
+		txMock.delete.mockClear()
+		txMock.query.gamePlayer.findMany.mockReset()
+	})
+
+	it('returns 404 when game does not exist', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue(undefined as never)
+		const res = await DELETE(new Request('http://x', { method: 'DELETE' }), params)
+		expect(res.status).toBe(404)
+	})
+
+	it('returns 403 when caller is not the game creator', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({
+			id: 'g1',
+			createdBy: 'u-someone-else',
+		} as never)
+		const res = await DELETE(new Request('http://x', { method: 'DELETE' }), params)
+		expect(res.status).toBe(403)
+	})
+
+	it('runs deletes inside a transaction in deepest-first order when admin', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({
+			id: 'g1',
+			createdBy: 'u-admin',
+		} as never)
+		txMock.query.gamePlayer.findMany.mockResolvedValue([{ id: 'gp-1' }, { id: 'gp-2' }] as never)
+
+		const res = await DELETE(new Request('http://x', { method: 'DELETE' }), params)
+		expect(res.status).toBe(200)
+		const body = await res.json()
+		expect(body.deleted).toBe(true)
+
+		// 6 deletes: plannedPick, pick, payment, payout, gamePlayer, game.
+		expect(txMock.delete).toHaveBeenCalledTimes(6)
+	})
+
+	it('skips the plannedPick delete when the game has no players', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({
+			id: 'g1',
+			createdBy: 'u-admin',
+		} as never)
+		txMock.query.gamePlayer.findMany.mockResolvedValue([] as never)
+
+		await DELETE(new Request('http://x', { method: 'DELETE' }), params)
+		// 5 deletes: pick, payment, payout, gamePlayer, game (plannedPick skipped).
+		expect(txMock.delete).toHaveBeenCalledTimes(5)
+	})
+})

--- a/src/app/api/games/[id]/route.ts
+++ b/src/app/api/games/[id]/route.ts
@@ -1,10 +1,10 @@
-import { eq } from 'drizzle-orm'
+import { eq, inArray } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import { requireSession } from '@/lib/auth-helpers'
 import { db } from '@/lib/db'
 import { calculatePot } from '@/lib/game-logic/prizes'
-import { game } from '@/lib/schema/game'
-import { payment } from '@/lib/schema/payment'
+import { game, gamePlayer, pick, plannedPick } from '@/lib/schema/game'
+import { payment, payout } from '@/lib/schema/payment'
 
 export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
 	const session = await requireSession()
@@ -44,4 +44,37 @@ export async function GET(_request: Request, { params }: { params: Promise<{ id:
 		isAdmin: gameData.createdBy === session.user.id,
 		payments: gameData.createdBy === session.user.id ? payments : undefined,
 	})
+}
+
+/**
+ * Hard-delete a game and every row that FKs back to it. Admin (game creator)
+ * only. Removes test/abandoned games cleanly. Order is deepest-first so FK
+ * constraints don't trip; wrapped in a transaction for atomicity.
+ */
+export async function DELETE(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+	const session = await requireSession()
+	const { id } = await params
+
+	const gameRow = await db.query.game.findFirst({ where: eq(game.id, id) })
+	if (!gameRow) return NextResponse.json({ error: 'not-found' }, { status: 404 })
+	if (gameRow.createdBy !== session.user.id) {
+		return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+	}
+
+	await db.transaction(async (tx) => {
+		const playerIds = (
+			await tx.query.gamePlayer.findMany({ where: eq(gamePlayer.gameId, id) })
+		).map((p) => p.id)
+		if (playerIds.length > 0) {
+			// plannedPick FKs to gamePlayer (not to game directly).
+			await tx.delete(plannedPick).where(inArray(plannedPick.gamePlayerId, playerIds))
+		}
+		await tx.delete(pick).where(eq(pick.gameId, id))
+		await tx.delete(payment).where(eq(payment.gameId, id))
+		await tx.delete(payout).where(eq(payout.gameId, id))
+		await tx.delete(gamePlayer).where(eq(gamePlayer.gameId, id))
+		await tx.delete(game).where(eq(game.id, id))
+	})
+
+	return NextResponse.json({ deleted: true })
 }

--- a/src/app/api/games/route.ts
+++ b/src/app/api/games/route.ts
@@ -59,15 +59,33 @@ export async function POST(request: Request) {
 
 	const inviteCode = generateInviteCode()
 
-	// Link to the competition's earliest non-completed round so the game
-	// has somewhere to start. If none exist the game just waits.
-	const firstRound = await db.query.round.findFirst({
+	// Link to the competition's earliest still-pickable round. A round is
+	// pickable iff its deadline is in the future — once the deadline has
+	// passed, attaching a new game to it would be dead-on-arrival because
+	// validateClassicPick / validateTurboPicks / validateCupPicks all reject
+	// post-deadline submissions. Skip those rounds and roll to the next.
+	//
+	// Rounds without a deadline (e.g. WC knockouts pre-draw with TBD fixtures)
+	// are still pickable in principle — we keep them as candidates.
+	const candidates = await db.query.round.findMany({
 		where: and(
 			eq(round.competitionId, competitionId),
 			inArray(round.status, ['open', 'active', 'upcoming']),
 		),
 		orderBy: [asc(round.number)],
 	})
+	const now = new Date()
+	const firstRound = candidates.find((r) => !r.deadline || r.deadline > now)
+	if (!firstRound) {
+		return NextResponse.json(
+			{
+				error: 'no-pickable-round',
+				message:
+					'This competition has no upcoming rounds. The deadline for every remaining gameweek has passed.',
+			},
+			{ status: 400 },
+		)
+	}
 
 	const [newGame] = await db
 		.insert(game)
@@ -80,8 +98,8 @@ export async function POST(request: Request) {
 			entryFee: entryFee ?? null,
 			maxPlayers: maxPlayers ?? null,
 			inviteCode,
-			status: firstRound ? 'active' : 'open',
-			currentRoundId: firstRound?.id ?? null,
+			status: 'active',
+			currentRoundId: firstRound.id,
 		})
 		.returning()
 

--- a/src/components/game/admin-panel.tsx
+++ b/src/components/game/admin-panel.tsx
@@ -1,16 +1,39 @@
 'use client'
-import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useState, useTransition } from 'react'
 import { AddPlayerModal } from './add-player-modal'
 import { SplitPotModal } from './split-pot-modal'
 
 interface AdminPanelProps {
 	gameId: string
+	gameName: string
 	aliveCount: number
 	potTotal: string
 }
 
-export function AdminPanel({ gameId, aliveCount, potTotal }: AdminPanelProps) {
+export function AdminPanel({ gameId, gameName, aliveCount, potTotal }: AdminPanelProps) {
 	const [openModal, setOpenModal] = useState<'add' | 'split' | null>(null)
+	const [deleteError, setDeleteError] = useState<string | null>(null)
+	const [isPending, startTransition] = useTransition()
+	const router = useRouter()
+
+	function handleDelete() {
+		const ok = window.confirm(
+			`Delete "${gameName}"? This permanently removes the game and every pick, payment, and player record attached to it. Cannot be undone.`,
+		)
+		if (!ok) return
+		setDeleteError(null)
+		startTransition(async () => {
+			const res = await fetch(`/api/games/${gameId}`, { method: 'DELETE' })
+			if (!res.ok) {
+				const body = await res.json().catch(() => ({}))
+				setDeleteError(body.message ?? body.error ?? 'Delete failed')
+				return
+			}
+			router.push('/dashboard')
+			router.refresh()
+		})
+	}
 
 	return (
 		<>
@@ -37,7 +60,16 @@ export function AdminPanel({ gameId, aliveCount, potTotal }: AdminPanelProps) {
 					>
 						Split pot ({aliveCount} alive)
 					</button>
+					<button
+						type="button"
+						onClick={handleDelete}
+						disabled={isPending}
+						className="ml-auto rounded-md border border-[color-mix(in_oklab,var(--eliminated)_60%,transparent)] bg-background px-3 py-1.5 text-xs font-semibold text-[var(--eliminated)] hover:bg-[color-mix(in_oklab,var(--eliminated)_10%,transparent)] disabled:cursor-not-allowed disabled:opacity-50"
+					>
+						{isPending ? 'Deleting…' : 'Delete game'}
+					</button>
 				</div>
+				{deleteError && <p className="mt-2 text-xs text-[var(--eliminated)]">{deleteError}</p>}
 			</div>
 			<AddPlayerModal
 				gameId={gameId}

--- a/src/components/game/game-detail-view.tsx
+++ b/src/components/game/game-detail-view.tsx
@@ -158,7 +158,12 @@ export function GameDetailView({
 
 				{game.isAdmin && (
 					<div className="mt-6">
-						<AdminPanel gameId={game.id} aliveCount={game.aliveCount} potTotal={game.pot.total} />
+						<AdminPanel
+							gameId={game.id}
+							gameName={game.name}
+							aliveCount={game.aliveCount}
+							potTotal={game.pot.total}
+						/>
 					</div>
 				)}
 


### PR DESCRIPTION
Two more from the post-launch feedback list — #5 (game-creation cutoff) and #10 (admin delete).

## Game creation cutoff
Previously attached new games to the earliest non-completed round even when its deadline had already passed. With per-game round state (PR #14), this made the game dead-on-arrival — user lands on round 1, validate immediately rejects \"Deadline has passed\".

Fix: skip rounds with past deadlines; auto-roll to the next pickable round. Rounds without a deadline (e.g. WC knockouts pre-draw) stay pickable. Block creation outright if every remaining round has passed its deadline (returns \`400 no-pickable-round\`).

## Admin delete game
New \`DELETE /api/games/[id]\` handler. Game creator only — 403 / 404 otherwise. Wraps deletion in a transaction and removes \`plannedPick\` → \`pick\` → \`payment\` → \`payout\` → \`gamePlayer\` → \`game\` in dependency order.

\`AdminPanel\` gains a \`Delete game\` button (red border styling, \`window.confirm\` gate, redirects to \`/dashboard\` on success). Solves the immediate need to clean up your two test games and serves as the long-term \"abandoned game\" tool.

## Test plan
- [ ] CI green (4 new DELETE-handler tests; 347 total)
- [ ] After merge: try to create a game while a round is past its deadline → it auto-rolls to the next round
- [ ] After merge: open one of your test games on prod, click \"Delete game\", confirm → redirect to dashboard, game gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)