### PR TITLE
fix(launch-feedback): mobile truncation in pick interfaces

### DIFF
--- a/src/components/picks/fixture-row.tsx
+++ b/src/components/picks/fixture-row.tsx
@@ -175,14 +175,31 @@ function TeamPickButton({
 			<div
 				className={cn('flex flex-col gap-1.5 min-w-0 flex-1', isHome ? 'items-end' : 'items-start')}
 			>
-				<span className="font-semibold text-base leading-tight truncate w-full">{team.name}</span>
+				{/* Country/long names truncate to first chars on narrow phones — show
+				 * the 3-letter shortName instead and switch to the full name from `sm`
+				 * upward. Keeps the touch target useful and avoids "Argen…" / "C". */}
+				<span className="font-semibold text-base leading-tight truncate w-full">
+					<span className="sm:hidden">{team.shortName}</span>
+					<span className="hidden sm:inline">{team.name}</span>
+				</span>
 				<div className="flex items-center gap-2">
 					{team.leaguePosition != null && (
 						<span className="text-xs text-muted-foreground font-medium">
 							{ordinal(team.leaguePosition)}
 						</span>
 					)}
-					{team.form && team.form.length > 0 && <FormDots results={team.form} size="md" />}
+					{/* sm-and-up uses larger dots; below sm we shrink so the form guide
+					 * stays inside the row even when the team name is long. */}
+					{team.form && team.form.length > 0 && (
+						<>
+							<span className="sm:hidden">
+								<FormDots results={team.form} size="sm" />
+							</span>
+							<span className="hidden sm:inline">
+								<FormDots results={team.form} size="md" />
+							</span>
+						</>
+					)}
 				</div>
 				{chip && <div className={cn('flex', isHome ? 'justify-end' : 'justify-start')}>{chip}</div>}
 			</div>

--- a/src/components/picks/ranked-item.tsx
+++ b/src/components/picks/ranked-item.tsx
@@ -84,11 +84,17 @@ export function RankedItem({
 					badgeUrl={pick.homeTeam.badgeUrl}
 					size="md"
 				/>
-				<span className="font-semibold text-sm truncate">{pick.homeTeam.name}</span>
+				<span className="font-semibold text-sm truncate">
+					<span className="sm:hidden">{pick.homeTeam.shortName}</span>
+					<span className="hidden sm:inline">{pick.homeTeam.name}</span>
+				</span>
 				<span className="text-xs text-muted-foreground font-semibold uppercase tracking-wide px-1">
 					vs
 				</span>
-				<span className="font-semibold text-sm truncate">{pick.awayTeam.name}</span>
+				<span className="font-semibold text-sm truncate">
+					<span className="sm:hidden">{pick.awayTeam.shortName}</span>
+					<span className="hidden sm:inline">{pick.awayTeam.name}</span>
+				</span>
 				<TeamBadge
 					shortName={pick.awayTeam.shortName}
 					badgeUrl={pick.awayTeam.badgeUrl}

--- a/src/components/picks/turbo-pick.tsx
+++ b/src/components/picks/turbo-pick.tsx
@@ -259,7 +259,8 @@ export function TurboPick({
 											/>
 											<div className="flex flex-col gap-1.5 min-w-0 flex-1 items-end">
 												<span className="font-semibold text-base leading-tight truncate w-full text-right">
-													{fix.home.name}
+													<span className="sm:hidden">{fix.home.shortName}</span>
+													<span className="hidden sm:inline">{fix.home.name}</span>
 												</span>
 												<div className="flex items-center gap-2">
 													{fix.home.leaguePosition != null && (
@@ -268,7 +269,14 @@ export function TurboPick({
 														</span>
 													)}
 													{fix.home.form && fix.home.form.length > 0 && (
-														<FormDots results={fix.home.form} size="md" />
+														<>
+															<span className="sm:hidden">
+																<FormDots results={fix.home.form} size="sm" />
+															</span>
+															<span className="hidden sm:inline">
+																<FormDots results={fix.home.form} size="md" />
+															</span>
+														</>
 													)}
 												</div>
 											</div>
@@ -291,7 +299,8 @@ export function TurboPick({
 											/>
 											<div className="flex flex-col gap-1.5 min-w-0 flex-1 items-start">
 												<span className="font-semibold text-base leading-tight truncate w-full">
-													{fix.away.name}
+													<span className="sm:hidden">{fix.away.shortName}</span>
+													<span className="hidden sm:inline">{fix.away.name}</span>
 												</span>
 												<div className="flex items-center gap-2">
 													{fix.away.leaguePosition != null && (
@@ -300,7 +309,14 @@ export function TurboPick({
 														</span>
 													)}
 													{fix.away.form && fix.away.form.length > 0 && (
-														<FormDots results={fix.away.form} size="md" />
+														<>
+															<span className="sm:hidden">
+																<FormDots results={fix.away.form} size="sm" />
+															</span>
+															<span className="hidden sm:inline">
+																<FormDots results={fix.away.form} size="md" />
+															</span>
+														</>
 													)}
 												</div>
 											</div>


### PR DESCRIPTION
Final items from the post-launch feedback list — #3 (mobile pick-interface text truncation for >6-char names), #4 (pick-ahead interface, only first character fits), #9 (turbo PL form icons + team names cut off on mobile).

## Fix

Show \`team.shortName\` on \`< sm\` viewports, full \`team.name\` from \`sm\` upward. Form-guide dots shrink from \`md\` to \`sm\` on mobile to fit comfortably.

Touches three components that render team names in pick interfaces:

- \`fixture-row.tsx\` — classic-pick + planner-round
- \`turbo-pick.tsx\` — both home and away inline blocks (turbo doesn't use FixtureRow)
- \`ranked-item.tsx\` — already-ranked picks list above turbo's remaining fixtures

## Test plan
- [ ] CI green (no new tests; pure CSS responsive tweaks; 347 still pass)
- [ ] After merge: open WC classic game on phone — country names (Argentina, Brazil, etc.) display as 3-letter codes, full names visible on tablet+
- [ ] After merge: open turbo PL game on phone — form dots fit inside the row even for long club names like "Manchester United"
- [ ] After merge: open the planner pick-ahead view on phone — team labels visible, no single-char truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)