### PR TITLE
fix(launch-feedback): planner pick-ahead badges shrink on mobile

### DIFF
--- a/src/components/picks/fixture-row.tsx
+++ b/src/components/picks/fixture-row.tsx
@@ -175,14 +175,31 @@ function TeamPickButton({
 			<div
 				className={cn('flex flex-col gap-1.5 min-w-0 flex-1', isHome ? 'items-end' : 'items-start')}
 			>
-				<span className="font-semibold text-base leading-tight truncate w-full">{team.name}</span>
+				{/* Country/long names truncate to first chars on narrow phones — show
+				 * the 3-letter shortName instead and switch to the full name from `sm`
+				 * upward. Keeps the touch target useful and avoids "Argen…" / "C". */}
+				<span className="font-semibold text-base leading-tight truncate w-full">
+					<span className="sm:hidden">{team.shortName}</span>
+					<span className="hidden sm:inline">{team.name}</span>
+				</span>
 				<div className="flex items-center gap-2">
 					{team.leaguePosition != null && (
 						<span className="text-xs text-muted-foreground font-medium">
 							{ordinal(team.leaguePosition)}
 						</span>
 					)}
-					{team.form && team.form.length > 0 && <FormDots results={team.form} size="md" />}
+					{/* sm-and-up uses larger dots; below sm we shrink so the form guide
+					 * stays inside the row even when the team name is long. */}
+					{team.form && team.form.length > 0 && (
+						<>
+							<span className="sm:hidden">
+								<FormDots results={team.form} size="sm" />
+							</span>
+							<span className="hidden sm:inline">
+								<FormDots results={team.form} size="md" />
+							</span>
+						</>
+					)}
 				</div>
 				{chip && <div className={cn('flex', isHome ? 'justify-end' : 'justify-start')}>{chip}</div>}
 			</div>

--- a/src/components/picks/fixture-row.tsx
+++ b/src/components/picks/fixture-row.tsx
@@ -171,7 +171,7 @@ function TeamPickButton({
 				stateCls,
 			)}
 		>
-			<TeamBadge shortName={team.shortName} badgeUrl={team.badgeUrl} size="lg" />
+			<TeamBadge shortName={team.shortName} badgeUrl={team.badgeUrl} size="lg" responsive />
 			<div
 				className={cn('flex flex-col gap-1.5 min-w-0 flex-1', isHome ? 'items-end' : 'items-start')}
 			>

--- a/src/components/picks/ranked-item.tsx
+++ b/src/components/picks/ranked-item.tsx
@@ -84,11 +84,17 @@ export function RankedItem({
 					badgeUrl={pick.homeTeam.badgeUrl}
 					size="md"
 				/>
-				<span className="font-semibold text-sm truncate">{pick.homeTeam.name}</span>
+				<span className="font-semibold text-sm truncate">
+					<span className="sm:hidden">{pick.homeTeam.shortName}</span>
+					<span className="hidden sm:inline">{pick.homeTeam.name}</span>
+				</span>
 				<span className="text-xs text-muted-foreground font-semibold uppercase tracking-wide px-1">
 					vs
 				</span>
-				<span className="font-semibold text-sm truncate">{pick.awayTeam.name}</span>
+				<span className="font-semibold text-sm truncate">
+					<span className="sm:hidden">{pick.awayTeam.shortName}</span>
+					<span className="hidden sm:inline">{pick.awayTeam.name}</span>
+				</span>
 				<TeamBadge
 					shortName={pick.awayTeam.shortName}
 					badgeUrl={pick.awayTeam.badgeUrl}

--- a/src/components/picks/team-badge.tsx
+++ b/src/components/picks/team-badge.tsx
@@ -6,6 +6,12 @@ interface TeamBadgeProps {
 	shortName: string
 	badgeUrl?: string | null
 	size?: 'sm' | 'md' | 'lg' | 'xl'
+	/**
+	 * When true, render one size smaller below the `sm` breakpoint. Used on
+	 * tight contexts (planner pick-ahead, card-in-card layouts) where the
+	 * default `lg` badge eats half the available row width on phones.
+	 */
+	responsive?: boolean
 	className?: string
 }
 
@@ -16,7 +22,42 @@ const SIZES = {
 	xl: { wrapper: 'w-14 h-14 text-sm', px: 56 },
 }
 
-export function TeamBadge({ shortName, badgeUrl, size = 'md', className }: TeamBadgeProps) {
+const SMALLER: Record<'sm' | 'md' | 'lg' | 'xl', 'sm' | 'md' | 'lg' | 'xl'> = {
+	sm: 'sm',
+	md: 'sm',
+	lg: 'md',
+	xl: 'lg',
+}
+
+export function TeamBadge({
+	shortName,
+	badgeUrl,
+	size = 'md',
+	responsive = false,
+	className,
+}: TeamBadgeProps) {
+	if (responsive) {
+		const small = SIZES[SMALLER[size]]
+		const large = SIZES[size]
+		// Render two badges and toggle visibility — keeps each badge's <Image>
+		// pinned to its own px dimensions without runtime media query JS.
+		return (
+			<>
+				<TeamBadge
+					shortName={shortName}
+					badgeUrl={badgeUrl}
+					size={SMALLER[size]}
+					className={cn('sm:hidden', className)}
+				/>
+				<TeamBadge
+					shortName={shortName}
+					badgeUrl={badgeUrl}
+					size={size}
+					className={cn('hidden sm:flex', className)}
+				/>
+			</>
+		)
+	}
 	const { wrapper, px } = SIZES[size]
 
 	if (badgeUrl) {

--- a/src/components/picks/turbo-pick.tsx
+++ b/src/components/picks/turbo-pick.tsx
@@ -259,7 +259,8 @@ export function TurboPick({
 											/>
 											<div className="flex flex-col gap-1.5 min-w-0 flex-1 items-end">
 												<span className="font-semibold text-base leading-tight truncate w-full text-right">
-													{fix.home.name}
+													<span className="sm:hidden">{fix.home.shortName}</span>
+													<span className="hidden sm:inline">{fix.home.name}</span>
 												</span>
 												<div className="flex items-center gap-2">
 													{fix.home.leaguePosition != null && (
@@ -268,7 +269,14 @@ export function TurboPick({
 														</span>
 													)}
 													{fix.home.form && fix.home.form.length > 0 && (
-														<FormDots results={fix.home.form} size="md" />
+														<>
+															<span className="sm:hidden">
+																<FormDots results={fix.home.form} size="sm" />
+															</span>
+															<span className="hidden sm:inline">
+																<FormDots results={fix.home.form} size="md" />
+															</span>
+														</>
 													)}
 												</div>
 											</div>
@@ -291,7 +299,8 @@ export function TurboPick({
 											/>
 											<div className="flex flex-col gap-1.5 min-w-0 flex-1 items-start">
 												<span className="font-semibold text-base leading-tight truncate w-full">
-													{fix.away.name}
+													<span className="sm:hidden">{fix.away.shortName}</span>
+													<span className="hidden sm:inline">{fix.away.name}</span>
 												</span>
 												<div className="flex items-center gap-2">
 													{fix.away.leaguePosition != null && (
@@ -300,7 +309,14 @@ export function TurboPick({
 														</span>
 													)}
 													{fix.away.form && fix.away.form.length > 0 && (
-														<FormDots results={fix.away.form} size="md" />
+														<>
+															<span className="sm:hidden">
+																<FormDots results={fix.away.form} size="sm" />
+															</span>
+															<span className="hidden sm:inline">
+																<FormDots results={fix.away.form} size="md" />
+															</span>
+														</>
 													)}
 												</div>
 											</div>

--- a/src/components/picks/turbo-pick.tsx
+++ b/src/components/picks/turbo-pick.tsx
@@ -256,6 +256,7 @@ export function TurboPick({
 												shortName={fix.home.shortName}
 												badgeUrl={fix.home.badgeUrl}
 												size="lg"
+												responsive
 											/>
 											<div className="flex flex-col gap-1.5 min-w-0 flex-1 items-end">
 												<span className="font-semibold text-base leading-tight truncate w-full text-right">
@@ -296,6 +297,7 @@ export function TurboPick({
 												shortName={fix.away.shortName}
 												badgeUrl={fix.away.badgeUrl}
 												size="lg"
+												responsive
 											/>
 											<div className="flex flex-col gap-1.5 min-w-0 flex-1 items-start">
 												<span className="font-semibold text-base leading-tight truncate w-full">


### PR DESCRIPTION
Follow-up to #19. The mobile-truncation fix worked for main pick interfaces but the planner pick-ahead still hit single-character truncation because its two nested cards (\`Plan ahead\` + \`PlannerRound\`) each add \`p-3\` padding, and the \`lg\` (40px) badge ate half the remaining row width on a 393px iPhone.

## Fix

\`TeamBadge\` gets a \`responsive\` prop. When true, the badge renders two copies — one \`sm:hidden\` at the next-size-down (\`lg\` → \`md\`, \`md\` → \`sm\`), one \`hidden sm:flex\` at the original size. Applied to \`FixtureRow\` and the two inline badges in \`turbo-pick.tsx\`. Reclaims ~12px per button on phones.

Tested locally — typecheck + 347 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)