### PR TITLE
fix(launch-feedback): pre-schedule live-poll triggers at fixture kickoffs

### DIFF
--- a/src/app/api/cron/daily-sync/route.test.ts
+++ b/src/app/api/cron/daily-sync/route.test.ts
@@ -6,6 +6,8 @@ vi.mock('@/lib/db', () => ({
 
 vi.mock('@/lib/game/bootstrap-competitions', () => ({
 	syncCompetition: vi.fn().mockResolvedValue({ rounds: 0, fixtures: 0, transitionedRoundIds: [] }),
+	mergeFootballDataIds: vi.fn().mockResolvedValue(undefined),
+	scheduleUpcomingFixturePolls: vi.fn().mockResolvedValue(undefined),
 }))
 
 vi.mock('@/lib/game/no-pick-handler', () => ({

--- a/src/app/api/cron/daily-sync/route.ts
+++ b/src/app/api/cron/daily-sync/route.ts
@@ -1,7 +1,11 @@
 import { eq } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import { db } from '@/lib/db'
-import { syncCompetition } from '@/lib/game/bootstrap-competitions'
+import {
+	mergeFootballDataIds,
+	scheduleUpcomingFixturePolls,
+	syncCompetition,
+} from '@/lib/game/bootstrap-competitions'
 import { processDeadlineLock } from '@/lib/game/no-pick-handler'
 import { competition } from '@/lib/schema/competition'
 
@@ -29,7 +33,21 @@ export async function POST(request: Request) {
 		if (summary.transitionedRoundIds?.length) {
 			deadlineLockedRoundIds.push(...summary.transitionedRoundIds)
 		}
+		// For FPL-bootstrapped competitions, merge football-data IDs onto fresh
+		// fixtures + teams so the live-score poll can match by external_ids.football_data.
+		// Was previously only run by the manual `scripts/bootstrap-competitions.ts`
+		// path; missing it here meant new fixtures (rescheduled / late-published)
+		// stayed invisible to live polling.
+		if (c.dataSource === 'fpl' && apiKey) {
+			await mergeFootballDataIds(c, apiKey)
+		}
 	}
+
+	// Pre-schedule a poll-scores trigger for every upcoming fixture across all
+	// competitions. Solves the "GH Actions heartbeat missed the match window"
+	// gap: each fixture gets its own QStash trigger 10 min before kickoff,
+	// which starts the self-perpetuating chain reliably.
+	await scheduleUpcomingFixturePolls()
 	let deadlineLock: {
 		autoPicksInserted: number
 		playersEliminated: number

--- a/src/lib/data/qstash.test.ts
+++ b/src/lib/data/qstash.test.ts
@@ -12,6 +12,7 @@ import {
 	enqueueAutoSubmit,
 	enqueueDeadlineReminder,
 	enqueuePollScores,
+	enqueuePollScoresAt,
 	enqueueProcessRound,
 } from './qstash'
 
@@ -81,5 +82,24 @@ describe('qstash helpers', () => {
 	it('enqueuePollScores throws when CRON_SECRET is missing', async () => {
 		process.env.CRON_SECRET = ''
 		await expect(enqueuePollScores()).rejects.toThrow(/CRON_SECRET/)
+	})
+
+	it('enqueuePollScoresAt schedules with notBefore (epoch seconds) and dedupId', async () => {
+		process.env.CRON_SECRET = 'shh'
+		const triggerAt = new Date('2026-06-11T18:50:00Z') // WC opener kickoff -10min
+		await enqueuePollScoresAt(triggerAt, 'poll-fixture:abc:2026-06-11T18:50:00.000Z')
+		const call = publishJSONMock.mock.calls[0][0]
+		expect(call.url).toBe('https://example.com/api/cron/poll-scores')
+		expect(call.body).toEqual({ source: 'fixture-kickoff' })
+		expect(call.notBefore).toBe(Math.floor(triggerAt.getTime() / 1000))
+		expect(call.deduplicationId).toBe('poll-fixture:abc:2026-06-11T18:50:00.000Z')
+		expect(call.headers).toEqual({ Authorization: 'Bearer shh' })
+	})
+
+	it('enqueuePollScoresAt omits deduplicationId when not provided', async () => {
+		process.env.CRON_SECRET = 'shh'
+		await enqueuePollScoresAt(new Date('2026-06-11T18:50:00Z'))
+		const call = publishJSONMock.mock.calls[0][0]
+		expect(call.deduplicationId).toBeUndefined()
 	})
 })

--- a/src/lib/data/qstash.ts
+++ b/src/lib/data/qstash.ts
@@ -74,3 +74,30 @@ export async function enqueuePollScores(delaySeconds = 60): Promise<void> {
 		delay: delaySeconds,
 	})
 }
+
+/**
+ * Pre-schedule a single poll-scores call for a future moment (e.g. a fixture's
+ * kickoff time minus a grace window). Solves the "live polling didn't start"
+ * gap where GitHub Actions heartbeats run every ~50-90 minutes in practice
+ * and may miss a match's live window entirely. We schedule one trigger per
+ * upcoming fixture; each trigger starts a chain that self-terminates when
+ * matches finish.
+ *
+ * Pass a stable `dedupId` (e.g. fixture id + scheduled epoch) so re-running
+ * bootstrap doesn't queue duplicates. QStash dedup window is ~10min by
+ * default, so two bootstrap runs within that window won't double up.
+ */
+export async function enqueuePollScoresAt(notBefore: Date, dedupId?: string): Promise<void> {
+	const base = process.env.VERCEL_URL ?? ''
+	if (!base) throw new Error('VERCEL_URL must be set to enqueue poll-scores')
+	const cronSecret = process.env.CRON_SECRET
+	if (!cronSecret) throw new Error('CRON_SECRET must be set to enqueue poll-scores')
+	const withScheme = base.startsWith('http') ? base : `https://${base}`
+	await client().publishJSON({
+		url: `${withScheme}/api/cron/poll-scores`,
+		body: { source: 'fixture-kickoff' },
+		headers: { Authorization: `Bearer ${cronSecret}` },
+		notBefore: Math.floor(notBefore.getTime() / 1000),
+		...(dedupId ? { deduplicationId: dedupId } : {}),
+	})
+}

--- a/src/lib/game/bootstrap-competitions.test.ts
+++ b/src/lib/game/bootstrap-competitions.test.ts
@@ -11,6 +11,8 @@ const {
 	dbInsertFn,
 	dbUpdateFn,
 	dbUpdateSet,
+	dbSelectFn,
+	dbSelectWhere,
 	fplFetchTeams,
 	fplFetchRounds,
 	fplFetchStandings,
@@ -18,9 +20,14 @@ const {
 	fdFetchRounds,
 	fdFetchStandings,
 	enqueueAutoSubmitMock,
+	enqueuePollScoresAtMock,
 } = vi.hoisted(() => {
 	const updateSet = vi.fn((_payload: Record<string, unknown>) => ({
 		where: vi.fn().mockResolvedValue(undefined),
+	}))
+	const selectWhere = vi.fn().mockResolvedValue([])
+	const selectFn = vi.fn(() => ({
+		from: () => ({ where: selectWhere }),
 	}))
 	return {
 		dbQueryCompetitionFindFirst: vi.fn(),
@@ -37,6 +44,8 @@ const {
 		})),
 		dbUpdateFn: vi.fn(() => ({ set: updateSet })),
 		dbUpdateSet: updateSet,
+		dbSelectFn: selectFn,
+		dbSelectWhere: selectWhere,
 		fplFetchTeams: vi.fn().mockResolvedValue([]),
 		fplFetchRounds: vi.fn().mockResolvedValue([]),
 		fplFetchStandings: vi.fn().mockResolvedValue([]),
@@ -44,6 +53,7 @@ const {
 		fdFetchRounds: vi.fn().mockResolvedValue([]),
 		fdFetchStandings: vi.fn().mockResolvedValue([]),
 		enqueueAutoSubmitMock: vi.fn().mockResolvedValue(undefined),
+		enqueuePollScoresAtMock: vi.fn().mockResolvedValue(undefined),
 	}
 })
 
@@ -58,10 +68,14 @@ vi.mock('@/lib/db', () => ({
 		},
 		insert: dbInsertFn,
 		update: dbUpdateFn,
+		select: dbSelectFn,
 	},
 }))
 
-vi.mock('@/lib/data/qstash', () => ({ enqueueAutoSubmit: enqueueAutoSubmitMock }))
+vi.mock('@/lib/data/qstash', () => ({
+	enqueueAutoSubmit: enqueueAutoSubmitMock,
+	enqueuePollScoresAt: enqueuePollScoresAtMock,
+}))
 
 vi.mock('@/lib/data/fpl', () => ({
 	// biome-ignore lint/complexity/useArrowFunction: vi.fn().mockImplementation needs a constructable function for `new FplAdapter()`
@@ -89,6 +103,7 @@ vi.mock('@/lib/data/football-data', () => ({
 import {
 	bootstrapCompetitions,
 	mergeFootballDataIds,
+	scheduleUpcomingFixturePolls,
 	syncCompetition,
 } from './bootstrap-competitions'
 
@@ -482,5 +497,54 @@ describe('mergeFootballDataIds', () => {
 
 		// No team matched → no team updates → no fixture updates either.
 		expect(dbUpdateSet).not.toHaveBeenCalled()
+	})
+})
+
+describe('scheduleUpcomingFixturePolls', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		dbSelectWhere.mockReset()
+		enqueuePollScoresAtMock.mockClear()
+	})
+
+	it('enqueues one trigger per upcoming fixture, scheduled 10 min before kickoff, with stable dedup id', async () => {
+		const future1 = new Date(Date.now() + 60 * 60 * 1000) // 1h from now
+		const future2 = new Date(Date.now() + 24 * 60 * 60 * 1000) // 24h from now
+		dbSelectWhere.mockResolvedValue([
+			{ id: 'fx-1', kickoff: future1 },
+			{ id: 'fx-2', kickoff: future2 },
+		])
+
+		await scheduleUpcomingFixturePolls()
+
+		expect(enqueuePollScoresAtMock).toHaveBeenCalledTimes(2)
+		const [[trigger1, dedup1], [trigger2, dedup2]] = enqueuePollScoresAtMock.mock.calls
+		expect((trigger1 as Date).getTime()).toBe(future1.getTime() - 10 * 60 * 1000)
+		expect((trigger2 as Date).getTime()).toBe(future2.getTime() - 10 * 60 * 1000)
+		expect(dedup1).toBe(`poll-fixture:fx-1:${(trigger1 as Date).toISOString()}`)
+		expect(dedup2).toBe(`poll-fixture:fx-2:${(trigger2 as Date).toISOString()}`)
+	})
+
+	it('skips fixtures whose kickoff is closer than the lead window', async () => {
+		const veryClose = new Date(Date.now() + 5 * 60 * 1000) // 5min from now (lead is 10min)
+		dbSelectWhere.mockResolvedValue([{ id: 'fx-imminent', kickoff: veryClose }])
+
+		await scheduleUpcomingFixturePolls()
+
+		expect(enqueuePollScoresAtMock).not.toHaveBeenCalled()
+	})
+
+	it('does not throw when an individual enqueue fails', async () => {
+		const future = new Date(Date.now() + 60 * 60 * 1000)
+		dbSelectWhere.mockResolvedValue([
+			{ id: 'fx-bad', kickoff: future },
+			{ id: 'fx-good', kickoff: future },
+		])
+		enqueuePollScoresAtMock
+			.mockRejectedValueOnce(new Error('QStash transient'))
+			.mockResolvedValueOnce(undefined)
+
+		await expect(scheduleUpcomingFixturePolls()).resolves.toBeUndefined()
+		expect(enqueuePollScoresAtMock).toHaveBeenCalledTimes(2)
 	})
 })

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -1,7 +1,7 @@
-import { and, eq, inArray } from 'drizzle-orm'
+import { and, eq, gt, inArray, lt } from 'drizzle-orm'
 import { FootballDataAdapter } from '@/lib/data/football-data'
 import { FplAdapter } from '@/lib/data/fpl'
-import { enqueueAutoSubmit } from '@/lib/data/qstash'
+import { enqueueAutoSubmit, enqueuePollScoresAt } from '@/lib/data/qstash'
 import type { CompetitionAdapter } from '@/lib/data/types'
 import { WC_2026_POTS } from '@/lib/data/wc-pots'
 import { db } from '@/lib/db'
@@ -59,6 +59,57 @@ export async function bootstrapCompetitions(opts: BootstrapOptions): Promise<voi
 	}
 	await syncCompetition(wc, opts)
 	await applyPotAssignments(wc.id)
+
+	// Pre-schedule a poll-scores trigger for each upcoming fixture across both
+	// competitions. Without this, the live-score chain only restarts when the
+	// GitHub Actions heartbeat happens to fire during a match window — and on
+	// the free tier those run every ~60-90 minutes. A 90-min match could end
+	// without the chain ever waking.
+	await scheduleUpcomingFixturePolls()
+}
+
+/**
+ * For every fixture whose kickoff is in the future (and within a 7-day
+ * lookahead — beyond that we'd risk QStash dedup expiring before the message
+ * fires), enqueue a single QStash trigger scheduled for `kickoff − 10 min`.
+ * The trigger hits /api/cron/poll-scores, which starts a self-perpetuating
+ * chain that runs through the match window and self-terminates.
+ *
+ * Idempotent within QStash's dedup window: re-running this within ~10 min
+ * (e.g. multiple bootstrap calls in quick succession) won't queue duplicates.
+ * Across longer intervals (the daily cron), duplicates are technically possible
+ * but harmless — each just starts a redundant chain that converges on the same
+ * DB state.
+ */
+const PRE_SCHEDULE_LEAD_MS = 10 * 60 * 1000
+const PRE_SCHEDULE_LOOKAHEAD_MS = 7 * 24 * 60 * 60 * 1000
+
+export async function scheduleUpcomingFixturePolls(): Promise<void> {
+	const now = new Date()
+	const lookahead = new Date(now.getTime() + PRE_SCHEDULE_LOOKAHEAD_MS)
+	const upcoming = await db
+		.select({ id: fixture.id, kickoff: fixture.kickoff })
+		.from(fixture)
+		.where(and(gt(fixture.kickoff, now), lt(fixture.kickoff, lookahead)))
+
+	for (const f of upcoming) {
+		if (!f.kickoff) continue
+		const triggerAt = new Date(f.kickoff.getTime() - PRE_SCHEDULE_LEAD_MS)
+		// Don't schedule for moments already past — covers the edge case where a
+		// fixture's kickoff is closer than the lead window.
+		if (triggerAt <= now) continue
+		// Stable dedup id per fixture+trigger so a second bootstrap in the
+		// dedup window is a no-op. We don't include date because the kickoff is
+		// the unique key — if a fixture's kickoff is rescheduled, it gets a new
+		// trigger time and a new dedup key.
+		const dedupId = `poll-fixture:${f.id}:${triggerAt.toISOString()}`
+		try {
+			await enqueuePollScoresAt(triggerAt, dedupId)
+		} catch (e) {
+			// Don't fail the whole bootstrap if a single enqueue errors.
+			console.warn(`[scheduleUpcomingFixturePolls] enqueue failed for fixture ${f.id}`, e)
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
## Why

You opened the turbo game during BOU v Crystal Palace and saw nothing live. Investigation showed:

- The QStash chain self-terminates between matches (correct).
- We rely on the GH Actions heartbeat (\`live-scores.yml\`, \`*/15 * * * *\`) to restart the chain when a new match goes live.
- GH Actions free-tier schedules actually run every ~50-90 min in practice. The 12:34Z heartbeat fired BEFORE BOU v CRY's window opened. Next heartbeat would have been ~13:30Z+ — well after kickoff.
- Result: ~30 min of zero updates between kickoff and the heartbeat catching up. Worst-case for a short match: entirely missed.

## Fix

**Pre-schedule one QStash trigger per upcoming fixture**, set to fire at \`kickoff − 10 min\`. Each trigger lands on \`poll-scores\` inside the live window, starts a chain, self-terminates when matches finish. Free tier: ~10-16 fixtures/week × 1 trigger = trivial cost.

While in there, fixed a separate bug: \`daily-sync\` calls \`syncCompetition\` directly, **not** \`bootstrapCompetitions\`. After PR #16 added \`mergeFootballDataIds\` to the orchestrator, the daily cron silently skipped the merge — explaining why 43/380 PL fixtures were missing football-data IDs on prod.

\`daily-sync\` now also runs \`mergeFootballDataIds\` per FPL competition and \`scheduleUpcomingFixturePolls\` once at the end.

## Note on the kickoff "drift"

I flagged a 1h kickoff drift earlier (DB 12:00Z vs FPL 13:00Z). Turned out to be client-side: my BST laptop's \`new Date('2026-05-03 13:00:00')\` interprets the naive timestamp as local BST and shows 12:00 UTC. The DB stores the correct raw value, Vercel runtime reads it correctly. No code fix needed — verified via \`kickoff::text\` and \`at time zone 'UTC'\`.

## Test plan
- [ ] CI green (5 new tests; 352 total)
- [ ] After merge: re-run bootstrap manually to fill in any still-missing football-data IDs and pre-schedule today's remaining kickoffs (AVL v TOT at 17:00Z, MUN v LIV next-up at 14:30Z)
- [ ] After merge: confirm the schedule fires by watching QStash events around 14:20Z (10 min before MUN v LIV kickoff)
- [ ] Long-term: tomorrow's daily-sync at 04:00 UTC should run the new merge + pre-schedule paths automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)