### PR TITLE
fix(launch-feedback): zero-mismatch FPL/football-data merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,19 @@ GitHub Actions secrets (repo-level):
 - `VERCEL_PROD_URL` — full https URL of the Vercel production deployment. Used by `live-scores.yml` as the request target.
 - `PROD_DATABASE_URL` — same value as Doppler `prd.DATABASE_URL`. Used by `migrate.yml` to apply Drizzle migrations on push to `main`. Duplicated from Doppler intentionally; revisit if rotation cadence increases.
 
+## PL season rollover (annual ritual)
+
+Every August, the Premier League season changes — 3 promoted teams replace 3 relegated ones. Bootstrap merges FPL data with football-data IDs by `short_name === tla`, plus an alias map `FPL_TO_FD_TLA` in `src/lib/game/bootstrap-competitions.ts` for the rare cases where the two sources disagree on a team's 3-letter code. (As of 2025/26: only Nottingham Forest mismatched — FPL `NFO`, football-data `NOT`.)
+
+After a season rollover:
+
+1. **Re-run bootstrap once** locally with prod creds (or wait for the daily Vercel Cron at 04:00 UTC).
+2. **If `mergeFootballDataIds` throws** with `missing football-data IDs after merge: <list>`, that's the new-season gap. The error names the unmatched team(s).
+3. **Look up the team's football-data tla** at `https://api.football-data.org/v4/competitions/PL/teams` and add a one-line entry to `FPL_TO_FD_TLA`.
+4. **Re-run bootstrap.** Coverage assertion passes; live scoring works for the new team.
+
+Fixture-level coverage gaps are warn-only (rescheduled / late-published matches fill in on subsequent bootstrap runs). Team gaps fail loudly because every team must be matchable for live scoring to work.
+
 ## Platform Context
 
 Platform standards and choices: see ~/code/platform/

--- a/src/lib/game/bootstrap-competitions.test.ts
+++ b/src/lib/game/bootstrap-competitions.test.ts
@@ -413,14 +413,22 @@ describe('mergeFootballDataIds', () => {
 		const teamArs = {
 			id: 'our-ARS',
 			shortName: 'ARS',
+			name: 'Arsenal',
 			externalIds: { fpl: '1' },
 		}
 		const teamLiv = {
 			id: 'our-LIV',
 			shortName: 'LIV',
+			name: 'Liverpool',
 			externalIds: { fpl: '12' },
 		}
-		dbQueryTeamFindMany.mockResolvedValueOnce([teamArs, teamLiv])
+		// First findMany: pre-merge state for the merge step. Second findMany:
+		// post-merge state for the coverage assertion (mocks the writes that
+		// would have happened in real DB).
+		dbQueryTeamFindMany.mockResolvedValueOnce([teamArs, teamLiv]).mockResolvedValueOnce([
+			{ ...teamArs, externalIds: { fpl: '1', football_data: '57' } },
+			{ ...teamLiv, externalIds: { fpl: '12', football_data: '64' } },
+		])
 
 		const ourFixture = {
 			id: 'our-fx-1',
@@ -484,9 +492,22 @@ describe('mergeFootballDataIds', () => {
 	it('matches rescheduled fixtures across different matchdays (FPL gameweek vs football-data matchday)', async () => {
 		// Real prod case: FPL says GW26 WOL v ARS but football-data has the same
 		// fixture under matchday 31 because of a reschedule. Match must succeed.
-		const teamWol = { id: 'our-WOL', shortName: 'WOL', externalIds: { fpl: '20' } }
-		const teamArs = { id: 'our-ARS', shortName: 'ARS', externalIds: { fpl: '1' } }
-		dbQueryTeamFindMany.mockResolvedValueOnce([teamWol, teamArs])
+		const teamWol = {
+			id: 'our-WOL',
+			shortName: 'WOL',
+			name: 'Wolves',
+			externalIds: { fpl: '20' },
+		}
+		const teamArs = {
+			id: 'our-ARS',
+			shortName: 'ARS',
+			name: 'Arsenal',
+			externalIds: { fpl: '1' },
+		}
+		dbQueryTeamFindMany.mockResolvedValueOnce([teamWol, teamArs]).mockResolvedValueOnce([
+			{ ...teamWol, externalIds: { fpl: '20', football_data: '76' } },
+			{ ...teamArs, externalIds: { fpl: '1', football_data: '57' } },
+		])
 
 		const ourFixtureRescheduled = {
 			id: 'our-fx-reschedule',
@@ -545,9 +566,12 @@ describe('mergeFootballDataIds', () => {
 		const teamForest = {
 			id: 'our-NFO',
 			shortName: 'NFO',
+			name: "Nott'm Forest",
 			externalIds: { fpl: '16' },
 		}
-		dbQueryTeamFindMany.mockResolvedValueOnce([teamForest])
+		dbQueryTeamFindMany
+			.mockResolvedValueOnce([teamForest])
+			.mockResolvedValueOnce([{ ...teamForest, externalIds: { fpl: '16', football_data: '351' } }])
 		dbQueryRoundFindMany.mockResolvedValue([])
 
 		// Football-data returns the team with its `tla=NOT`, our DB has `short_name=NFO`.
@@ -572,7 +596,9 @@ describe('mergeFootballDataIds', () => {
 	})
 
 	it('skips fixtures when our DB has no matching team for the football-data tla', async () => {
-		dbQueryTeamFindMany.mockResolvedValueOnce([])
+		// Both findMany calls (merge + coverage assertion) get [] — no FPL teams
+		// in our DB so the assertion is trivially satisfied.
+		dbQueryTeamFindMany.mockResolvedValue([])
 		dbQueryRoundFindMany.mockResolvedValue([])
 
 		fdFetchTeams.mockResolvedValue([
@@ -587,6 +613,35 @@ describe('mergeFootballDataIds', () => {
 
 		// No team matched → no team updates → no fixture updates either.
 		expect(dbUpdateSet).not.toHaveBeenCalled()
+	})
+
+	it('throws if any FPL team is missing football_data id after merge (alias map gap)', async () => {
+		// Hypothetical 2026/27 promoted team that we forgot to add to FPL_TO_FD_TLA.
+		const newPromotedTeam = {
+			id: 'our-XYZ',
+			shortName: 'XYZ',
+			name: 'Hypothetical FC',
+			externalIds: { fpl: '99' },
+		}
+		// First call: pre-merge state. Second call: post-merge state — still missing
+		// football_data id because the merge couldn't find a matching tla.
+		dbQueryTeamFindMany
+			.mockResolvedValueOnce([newPromotedTeam])
+			.mockResolvedValueOnce([newPromotedTeam])
+		dbQueryRoundFindMany.mockResolvedValue([])
+
+		// Football-data has the team but under a different tla; merge can't link them.
+		fdFetchTeams.mockResolvedValue([
+			{ externalId: '999', name: 'Hypothetical FC', shortName: 'HYP', badgeUrl: null },
+		])
+		fdFetchRounds.mockResolvedValue([])
+
+		await expect(
+			mergeFootballDataIds(
+				{ id: 'comp-pl', dataSource: 'fpl', externalId: null } as never,
+				'fd-key',
+			),
+		).rejects.toThrow(/missing football-data IDs.*FPL_TO_FD_TLA/s)
 	})
 })
 

--- a/src/lib/game/bootstrap-competitions.test.ts
+++ b/src/lib/game/bootstrap-competitions.test.ts
@@ -481,6 +481,96 @@ describe('mergeFootballDataIds', () => {
 		})
 	})
 
+	it('matches rescheduled fixtures across different matchdays (FPL gameweek vs football-data matchday)', async () => {
+		// Real prod case: FPL says GW26 WOL v ARS but football-data has the same
+		// fixture under matchday 31 because of a reschedule. Match must succeed.
+		const teamWol = { id: 'our-WOL', shortName: 'WOL', externalIds: { fpl: '20' } }
+		const teamArs = { id: 'our-ARS', shortName: 'ARS', externalIds: { fpl: '1' } }
+		dbQueryTeamFindMany.mockResolvedValueOnce([teamWol, teamArs])
+
+		const ourFixtureRescheduled = {
+			id: 'our-fx-reschedule',
+			homeTeamId: 'our-WOL',
+			awayTeamId: 'our-ARS',
+			externalIds: { fpl: '310' },
+		}
+		// Our DB tracks it under round 26 (FPL event)
+		dbQueryRoundFindMany.mockResolvedValue([
+			{ id: 'our-r-26', number: 26, fixtures: [ourFixtureRescheduled] },
+		])
+
+		fdFetchTeams.mockResolvedValue([
+			{ externalId: '76', name: 'Wolverhampton Wanderers FC', shortName: 'WOL', badgeUrl: null },
+			{ externalId: '57', name: 'Arsenal FC', shortName: 'ARS', badgeUrl: null },
+		])
+		// Football-data tracks the same fixture under matchday 31 (rescheduled)
+		fdFetchRounds.mockResolvedValue([
+			{
+				externalId: '31',
+				number: 31,
+				name: 'Matchday 31',
+				deadline: null,
+				finished: true,
+				fixtures: [
+					{
+						externalId: '538200',
+						homeTeamExternalId: '76',
+						awayTeamExternalId: '57',
+						kickoff: new Date('2026-02-18T20:00:00Z'),
+						status: 'finished' as const,
+						homeScore: 2,
+						awayScore: 2,
+					},
+				],
+			},
+		])
+
+		await mergeFootballDataIds(
+			{ id: 'comp-pl', dataSource: 'fpl', externalId: null } as never,
+			'fd-key',
+		)
+
+		// The fixture should now have football_data id even though our matchday was 26 and fd's was 31.
+		const update = dbUpdateSet.mock.calls.find(
+			(c) =>
+				(c[0] as { externalIds?: { football_data?: string } }).externalIds?.football_data ===
+				'538200',
+		)
+		expect(update?.[0]).toEqual({
+			externalIds: { fpl: '310', football_data: '538200' },
+		})
+	})
+
+	it('matches teams via FPL_TO_FD_TLA alias when codes differ across sources (NFO → NOT)', async () => {
+		const teamForest = {
+			id: 'our-NFO',
+			shortName: 'NFO',
+			externalIds: { fpl: '16' },
+		}
+		dbQueryTeamFindMany.mockResolvedValueOnce([teamForest])
+		dbQueryRoundFindMany.mockResolvedValue([])
+
+		// Football-data returns the team with its `tla=NOT`, our DB has `short_name=NFO`.
+		fdFetchTeams.mockResolvedValue([
+			{ externalId: '351', name: 'Nottingham Forest FC', shortName: 'NOT', badgeUrl: 'fd-not.png' },
+		])
+		fdFetchRounds.mockResolvedValue([])
+
+		await mergeFootballDataIds(
+			{ id: 'comp-pl', dataSource: 'fpl', externalId: null } as never,
+			'fd-key',
+		)
+
+		const update = dbUpdateSet.mock.calls.find(
+			(c) =>
+				(c[0] as { externalIds?: { football_data?: string } }).externalIds?.football_data === '351',
+		)
+		expect(update?.[0]).toMatchObject({
+			externalIds: { fpl: '16', football_data: '351' },
+			badgeUrl: 'fd-not.png',
+		})
+	})
+
 	it('skips fixtures when our DB has no matching team for the football-data tla', async () => {
 		dbQueryTeamFindMany.mockResolvedValueOnce([])
 		dbQueryRoundFindMany.mockResolvedValue([])
@@ -521,8 +611,8 @@ describe('scheduleUpcomingFixturePolls', () => {
 		const [[trigger1, dedup1], [trigger2, dedup2]] = enqueuePollScoresAtMock.mock.calls
 		expect((trigger1 as Date).getTime()).toBe(future1.getTime() - 10 * 60 * 1000)
 		expect((trigger2 as Date).getTime()).toBe(future2.getTime() - 10 * 60 * 1000)
-		expect(dedup1).toBe(`poll-fixture:fx-1:${(trigger1 as Date).toISOString()}`)
-		expect(dedup2).toBe(`poll-fixture:fx-2:${(trigger2 as Date).toISOString()}`)
+		expect(dedup1).toBe(`poll-fixture-fx-1-${(trigger1 as Date).getTime()}`)
+		expect(dedup2).toBe(`poll-fixture-fx-2-${(trigger2 as Date).getTime()}`)
 	})
 
 	it('skips fixtures whose kickoff is closer than the lead window', async () => {

--- a/src/lib/game/bootstrap-competitions.test.ts
+++ b/src/lib/game/bootstrap-competitions.test.ts
@@ -641,7 +641,7 @@ describe('mergeFootballDataIds', () => {
 				{ id: 'comp-pl', dataSource: 'fpl', externalId: null } as never,
 				'fd-key',
 			),
-		).rejects.toThrow(/missing football-data IDs.*FPL_TO_FD_TLA/s)
+		).rejects.toThrow(/missing football-data IDs[\s\S]*FPL_TO_FD_TLA/)
 	})
 })
 

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -98,11 +98,11 @@ export async function scheduleUpcomingFixturePolls(): Promise<void> {
 		// Don't schedule for moments already past — covers the edge case where a
 		// fixture's kickoff is closer than the lead window.
 		if (triggerAt <= now) continue
-		// Stable dedup id per fixture+trigger so a second bootstrap in the
-		// dedup window is a no-op. We don't include date because the kickoff is
-		// the unique key — if a fixture's kickoff is rescheduled, it gets a new
-		// trigger time and a new dedup key.
-		const dedupId = `poll-fixture:${f.id}:${triggerAt.toISOString()}`
+		// Stable dedup id per fixture+trigger so a second bootstrap inside the
+		// QStash dedup window is a no-op. Use epoch ms (not ISO) because QStash
+		// rejects deduplication IDs containing `:`. If a fixture's kickoff is
+		// rescheduled, it gets a different epoch → different dedup key.
+		const dedupId = `poll-fixture-${f.id}-${triggerAt.getTime()}`
 		try {
 			await enqueuePollScoresAt(triggerAt, dedupId)
 		} catch (e) {
@@ -113,6 +113,25 @@ export async function scheduleUpcomingFixturePolls(): Promise<void> {
 }
 
 /**
+ * Alias for the (rare) cases where FPL and football-data disagree on a team's
+ * 3-letter code. Map: FPL `short_name` → football-data `tla`.
+ *
+ * Known mismatches:
+ * - Nottingham Forest: FPL `NFO`, football-data `NOT`. Confirmed 2026-05-03
+ *   on the 2025/26 PL season — every other PL team's tla aligns across sources.
+ *
+ * If a new mismatch surfaces (e.g. promoted team next season), add an entry
+ * here and re-run bootstrap.
+ */
+const FPL_TO_FD_TLA: Record<string, string> = {
+	NFO: 'NOT',
+}
+
+function fdTlaForFplShortName(fplShortName: string): string {
+	return FPL_TO_FD_TLA[fplShortName] ?? fplShortName
+}
+
+/**
  * For competitions whose primary adapter is FPL, this fetches the same matchdays
  * from football-data.org and merges football-data IDs into existing teams +
  * fixtures. The FPL adapter remains the source of truth for round structure
@@ -120,8 +139,8 @@ export async function scheduleUpcomingFixturePolls(): Promise<void> {
  * polling — which uses football-data.org — can match against the right rows.
  *
  * Matching strategy:
- * - Teams: match our `team.short_name` against football-data's `tla`. PL team
- *   3-letter codes are stable and align across both sources.
+ * - Teams: match our `team.short_name` against football-data's `tla`, with the
+ *   `FPL_TO_FD_TLA` alias map covering the known mismatch (NFO → NOT).
  * - Fixtures: within a round (same `matchday` number), match by the resolved
  *   home/away team UUIDs. We do NOT trust kickoff times to match exactly — FPL
  *   sometimes has slightly older snapshots than football-data after a match
@@ -138,11 +157,12 @@ export async function mergeFootballDataIds(comp: CompetitionRow, apiKey: string)
 	const fdTeams = await fdAdapter.fetchTeams()
 	const fdRounds = await fdAdapter.fetchRounds()
 
-	// 1) Merge football-data team IDs onto our teams via short_name === tla.
+	// 1) Merge football-data team IDs onto our teams via short_name === tla
+	// (with the FPL_TO_FD_TLA alias map covering the NFO → NOT case).
 	const ourTeams = await db.query.team.findMany({})
 	const ourTeamIdByFdId = new Map<string, string>() // football-data id -> our team UUID
 	for (const fdTeam of fdTeams) {
-		const ourTeam = ourTeams.find((t) => t.shortName === fdTeam.shortName)
+		const ourTeam = ourTeams.find((t) => fdTlaForFplShortName(t.shortName) === fdTeam.shortName)
 		if (!ourTeam) continue
 		ourTeamIdByFdId.set(fdTeam.externalId, ourTeam.id)
 		await db
@@ -159,23 +179,29 @@ export async function mergeFootballDataIds(comp: CompetitionRow, apiKey: string)
 			.where(eq(team.id, ourTeam.id))
 	}
 
-	// 2) Merge football-data fixture IDs onto our fixtures via (matchday, home, away).
+	// 2) Merge football-data fixture IDs onto our fixtures via (home, away) team
+	// UUIDs alone — NOT including matchday. Rescheduled matches sometimes end
+	// up under a different matchday in football-data than the FPL gameweek
+	// they're tracked under in our DB. Since each PL pairing happens exactly
+	// once per home venue per season, (home, away) is a unique key across the
+	// whole competition and gives us a one-shot match regardless of round.
 	const ourRounds = await db.query.round.findMany({
 		where: eq(round.competitionId, comp.id),
 		with: { fixtures: true },
 	})
-	const ourRoundsByNumber = new Map(ourRounds.map((r) => [r.number, r]))
+	const ourFixtureByPair = new Map<string, (typeof ourRounds)[number]['fixtures'][number]>()
+	for (const r of ourRounds) {
+		for (const f of r.fixtures) {
+			ourFixtureByPair.set(`${f.homeTeamId}|${f.awayTeamId}`, f)
+		}
+	}
 
 	for (const fdRound of fdRounds) {
-		const ourRound = ourRoundsByNumber.get(fdRound.number)
-		if (!ourRound) continue
 		for (const fdFx of fdRound.fixtures) {
 			const ourHomeId = ourTeamIdByFdId.get(fdFx.homeTeamExternalId)
 			const ourAwayId = ourTeamIdByFdId.get(fdFx.awayTeamExternalId)
 			if (!ourHomeId || !ourAwayId) continue
-			const ourFx = ourRound.fixtures.find(
-				(f) => f.homeTeamId === ourHomeId && f.awayTeamId === ourAwayId,
-			)
+			const ourFx = ourFixtureByPair.get(`${ourHomeId}|${ourAwayId}`)
 			if (!ourFx) continue
 			await db
 				.update(fixture)

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -214,6 +214,44 @@ export async function mergeFootballDataIds(comp: CompetitionRow, apiKey: string)
 				.where(eq(fixture.id, ourFx.id))
 		}
 	}
+
+	// 3) Coverage assertion. Self-diagnosing for the next time the FPL/football-
+	// data data shape drifts (likely each August when promoted PL teams arrive).
+	// Fails loudly on team-level gaps because every PL team must be matchable
+	// for live scoring to work; warns on fixture-level gaps because rescheduled
+	// or yet-to-be-published fixtures may legitimately be absent from
+	// football-data temporarily.
+	const refreshedTeams = await db.query.team.findMany({})
+	const fplTeams = refreshedTeams.filter(
+		(t) => (t.externalIds as Record<string, string | number> | null)?.fpl != null,
+	)
+	const teamsMissing = fplTeams.filter(
+		(t) => (t.externalIds as Record<string, string | number> | null)?.football_data == null,
+	)
+	if (teamsMissing.length > 0) {
+		const detail = teamsMissing.map((t) => `${t.shortName} (${t.name})`).join(', ')
+		throw new Error(
+			`mergeFootballDataIds: ${teamsMissing.length}/${fplTeams.length} FPL team(s) missing football-data IDs after merge: ${detail}. Likely tla mismatch — add to FPL_TO_FD_TLA alias map.`,
+		)
+	}
+
+	const fixturesAll = (
+		await db.query.round.findMany({
+			where: eq(round.competitionId, comp.id),
+			with: { fixtures: true },
+		})
+	).flatMap((r) => r.fixtures)
+	const fixturesMissing = fixturesAll.filter(
+		(f) => (f.externalIds as Record<string, string | number> | null)?.football_data == null,
+	)
+	if (fixturesMissing.length > 0) {
+		console.warn(
+			`[mergeFootballDataIds] ${fixturesMissing.length}/${fixturesAll.length} fixtures still missing football-data IDs after merge. Usually rescheduled or not yet published; will be filled on a future bootstrap run. First few: ${fixturesMissing
+				.slice(0, 5)
+				.map((f) => f.id)
+				.join(', ')}`,
+		)
+	}
 }
 
 export async function syncCompetition(


### PR DESCRIPTION
Validating PR #21 against real prod data surfaced three issues:

## Three fixes

1. **QStash dedup IDs reject \`:\`.** Pre-schedule enqueues all failed silently (caught by try/catch) with \`DeduplicationId cannot contain ':'\`. Switched to dashes + epoch ms: \`poll-fixture-{id}-{epochMs}\`.

2. **Nottingham Forest tla mismatch:** FPL says \`NFO\`, football-data says \`NOT\`. Every other PL team aligns. Added \`FPL_TO_FD_TLA\` alias map (one entry).

3. **Rescheduled fixtures (5 of them):** football-data tracks them under a different \`matchday\` than FPL's \`event\` (e.g. WOL v ARS in our GW26, fd matchday 31). Switched fixture match key from \`(matchday, home, away)\` to \`(home, away)\` — unique per home venue per PL season.

## Validation
| Source | Total | with \`football_data\` ID |
|---|---|---|
| PL teams | 20 | **20 (100%)** |
| PL fixtures | 380 | **380 (100%)** |
| WC fixtures | 72 | **72 (100%)** |

11 fixture-kickoff pre-schedules confirmed in QStash. Live-poll chain firing for in-progress matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)