### PR TITLE
fix(launch-feedback): auto-complete games at natural end-state

### DIFF
--- a/src/lib/game-logic/auto-complete-tiebreakers.test.ts
+++ b/src/lib/game-logic/auto-complete-tiebreakers.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import { classicTiebreaker, cupTiebreaker, turboTiebreaker } from './auto-complete-tiebreakers'
+
+describe('classicTiebreaker', () => {
+	it('picks the sole top scorer', () => {
+		expect(
+			classicTiebreaker([
+				{ gamePlayerId: 'a', totalWinningGoals: 7 },
+				{ gamePlayerId: 'b', totalWinningGoals: 5 },
+				{ gamePlayerId: 'c', totalWinningGoals: 3 },
+			]),
+		).toEqual(['a'])
+	})
+
+	it('returns all tied at top for split', () => {
+		expect(
+			classicTiebreaker([
+				{ gamePlayerId: 'a', totalWinningGoals: 7 },
+				{ gamePlayerId: 'b', totalWinningGoals: 7 },
+				{ gamePlayerId: 'c', totalWinningGoals: 3 },
+			]),
+		).toEqual(['a', 'b'])
+	})
+
+	it('handles all zeros (no wins) by splitting', () => {
+		expect(
+			classicTiebreaker([
+				{ gamePlayerId: 'a', totalWinningGoals: 0 },
+				{ gamePlayerId: 'b', totalWinningGoals: 0 },
+			]),
+		).toEqual(['a', 'b'])
+	})
+
+	it('returns empty for empty input', () => {
+		expect(classicTiebreaker([])).toEqual([])
+	})
+})
+
+describe('turboTiebreaker', () => {
+	it('picks sole top streak', () => {
+		expect(
+			turboTiebreaker([
+				{ gamePlayerId: 'a', streak: 8, goalsInStreak: 10 },
+				{ gamePlayerId: 'b', streak: 5, goalsInStreak: 20 },
+			]),
+		).toEqual(['a'])
+	})
+
+	it('falls through to goals-in-streak when streak ties', () => {
+		expect(
+			turboTiebreaker([
+				{ gamePlayerId: 'a', streak: 7, goalsInStreak: 12 },
+				{ gamePlayerId: 'b', streak: 7, goalsInStreak: 18 },
+				{ gamePlayerId: 'c', streak: 6, goalsInStreak: 99 },
+			]),
+		).toEqual(['b'])
+	})
+
+	it('splits on full tie (streak + goals)', () => {
+		expect(
+			turboTiebreaker([
+				{ gamePlayerId: 'a', streak: 7, goalsInStreak: 18 },
+				{ gamePlayerId: 'b', streak: 7, goalsInStreak: 18 },
+				{ gamePlayerId: 'c', streak: 5, goalsInStreak: 30 },
+			]),
+		).toEqual(['a', 'b'])
+	})
+})
+
+describe('cupTiebreaker', () => {
+	it('picks sole top by streak', () => {
+		expect(
+			cupTiebreaker([
+				{ gamePlayerId: 'a', cumulativeStreak: 12, livesRemaining: 0, cumulativeGoals: 5 },
+				{ gamePlayerId: 'b', cumulativeStreak: 9, livesRemaining: 3, cumulativeGoals: 30 },
+			]),
+		).toEqual(['a'])
+	})
+
+	it('falls through to lives when streak ties', () => {
+		expect(
+			cupTiebreaker([
+				{ gamePlayerId: 'a', cumulativeStreak: 10, livesRemaining: 1, cumulativeGoals: 5 },
+				{ gamePlayerId: 'b', cumulativeStreak: 10, livesRemaining: 3, cumulativeGoals: 0 },
+				{ gamePlayerId: 'c', cumulativeStreak: 5, livesRemaining: 99, cumulativeGoals: 0 },
+			]),
+		).toEqual(['b'])
+	})
+
+	it('falls through to goals when streak and lives tie', () => {
+		expect(
+			cupTiebreaker([
+				{ gamePlayerId: 'a', cumulativeStreak: 10, livesRemaining: 2, cumulativeGoals: 12 },
+				{ gamePlayerId: 'b', cumulativeStreak: 10, livesRemaining: 2, cumulativeGoals: 18 },
+				{ gamePlayerId: 'c', cumulativeStreak: 10, livesRemaining: 1, cumulativeGoals: 99 },
+			]),
+		).toEqual(['b'])
+	})
+
+	it('splits when all three metrics tie', () => {
+		expect(
+			cupTiebreaker([
+				{ gamePlayerId: 'a', cumulativeStreak: 10, livesRemaining: 2, cumulativeGoals: 18 },
+				{ gamePlayerId: 'b', cumulativeStreak: 10, livesRemaining: 2, cumulativeGoals: 18 },
+			]),
+		).toEqual(['a', 'b'])
+	})
+})

--- a/src/lib/game-logic/auto-complete-tiebreakers.ts
+++ b/src/lib/game-logic/auto-complete-tiebreakers.ts
@@ -1,0 +1,47 @@
+// Tiebreaker rules ported from the predecessor app, with explicit secondary
+// rules where the old SQL had undefined ordering. Confirmed 2026-05-07.
+
+export interface ClassicTiebreakerInput {
+	gamePlayerId: string
+	totalWinningGoals: number
+}
+
+export interface TurboTiebreakerInput {
+	gamePlayerId: string
+	streak: number
+	goalsInStreak: number
+}
+
+export interface CupTiebreakerInput {
+	gamePlayerId: string
+	cumulativeStreak: number
+	livesRemaining: number
+	cumulativeGoals: number
+}
+
+function maxBy<T>(items: T[], key: (t: T) => number): T[] {
+	if (items.length === 0) return []
+	const max = items.reduce((m, t) => Math.max(m, key(t)), Number.NEGATIVE_INFINITY)
+	return items.filter((t) => key(t) === max)
+}
+
+export function classicTiebreaker(players: ClassicTiebreakerInput[]): string[] {
+	const top = maxBy(players, (p) => p.totalWinningGoals)
+	return top.map((p) => p.gamePlayerId)
+}
+
+export function turboTiebreaker(players: TurboTiebreakerInput[]): string[] {
+	const topStreak = maxBy(players, (p) => p.streak)
+	if (topStreak.length <= 1) return topStreak.map((p) => p.gamePlayerId)
+	const topGoals = maxBy(topStreak, (p) => p.goalsInStreak)
+	return topGoals.map((p) => p.gamePlayerId)
+}
+
+export function cupTiebreaker(players: CupTiebreakerInput[]): string[] {
+	const topStreak = maxBy(players, (p) => p.cumulativeStreak)
+	if (topStreak.length <= 1) return topStreak.map((p) => p.gamePlayerId)
+	const topLives = maxBy(topStreak, (p) => p.livesRemaining)
+	if (topLives.length <= 1) return topLives.map((p) => p.gamePlayerId)
+	const topGoals = maxBy(topLives, (p) => p.cumulativeGoals)
+	return topGoals.map((p) => p.gamePlayerId)
+}

--- a/src/lib/game/auto-complete.test.ts
+++ b/src/lib/game/auto-complete.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { dbMock } = vi.hoisted(() => ({
+	dbMock: {
+		query: {
+			gamePlayer: { findMany: vi.fn() },
+			pick: { findMany: vi.fn() },
+			round: { findFirst: vi.fn() },
+			payment: { findMany: vi.fn() },
+		},
+		update: vi.fn(() => ({
+			set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+		})),
+		insert: vi.fn(() => ({
+			values: vi.fn().mockResolvedValue(undefined),
+		})),
+	},
+}))
+vi.mock('@/lib/db', () => ({ db: dbMock }))
+
+import { checkClassicCompletion, checkCupCompletion, checkTurboCompletion } from './auto-complete'
+
+describe('checkClassicCompletion', () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it('completes with last-alive winner when exactly 1 alive', async () => {
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([
+			{ id: 'p1', status: 'alive', eliminatedRoundId: null, livesRemaining: 0 },
+			{ id: 'p2', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+		] as never)
+
+		const result = await checkClassicCompletion('g1', 'c1', 'r1', 5)
+		expect(result).toEqual({
+			completed: true,
+			winnerPlayerIds: ['p1'],
+			reason: 'last-alive',
+		})
+	})
+
+	it('handles mass extinction with goals tiebreaker', async () => {
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([
+			{ id: 'p1', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+			{ id: 'p2', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+			{ id: 'p3', status: 'eliminated', eliminatedRoundId: 'r0', livesRemaining: 0 },
+		] as never)
+		dbMock.query.pick.findMany.mockResolvedValue([
+			{ gamePlayerId: 'p1', result: 'win', goalsScored: 3 },
+			{ gamePlayerId: 'p1', result: 'win', goalsScored: 2 },
+			{ gamePlayerId: 'p2', result: 'win', goalsScored: 4 },
+			{ gamePlayerId: 'p2', result: 'loss', goalsScored: 0 },
+			{ gamePlayerId: 'p3', result: 'win', goalsScored: 99 },
+		] as never)
+
+		const result = await checkClassicCompletion('g1', 'c1', 'r1', 5)
+		expect(result).toEqual({
+			completed: true,
+			winnerPlayerIds: ['p1'],
+			reason: 'mass-extinction',
+		})
+	})
+
+	it('splits when mass extinction tied on goals', async () => {
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([
+			{ id: 'p1', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+			{ id: 'p2', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+		] as never)
+		dbMock.query.pick.findMany.mockResolvedValue([
+			{ gamePlayerId: 'p1', result: 'win', goalsScored: 5 },
+			{ gamePlayerId: 'p2', result: 'win', goalsScored: 5 },
+		] as never)
+
+		const result = await checkClassicCompletion('g1', 'c1', 'r1', 5)
+		expect(result.completed).toBe(true)
+		expect(result.reason).toBe('mass-extinction')
+		expect(result.winnerPlayerIds.sort()).toEqual(['p1', 'p2'])
+	})
+
+	it('completes with rounds-exhausted when >1 alive and no next round', async () => {
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([
+			{ id: 'p1', status: 'alive', eliminatedRoundId: null, livesRemaining: 0 },
+			{ id: 'p2', status: 'alive', eliminatedRoundId: null, livesRemaining: 0 },
+		] as never)
+		dbMock.query.round.findFirst.mockResolvedValue(null as never)
+		dbMock.query.pick.findMany.mockResolvedValue([
+			{ gamePlayerId: 'p1', result: 'win', goalsScored: 12 },
+			{ gamePlayerId: 'p2', result: 'win', goalsScored: 7 },
+		] as never)
+
+		const result = await checkClassicCompletion('g1', 'c1', 'r1', 38)
+		expect(result).toEqual({
+			completed: true,
+			winnerPlayerIds: ['p1'],
+			reason: 'rounds-exhausted',
+		})
+	})
+
+	it('does not complete when >1 alive and a next round exists', async () => {
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([
+			{ id: 'p1', status: 'alive', eliminatedRoundId: null, livesRemaining: 0 },
+			{ id: 'p2', status: 'alive', eliminatedRoundId: null, livesRemaining: 0 },
+		] as never)
+		dbMock.query.round.findFirst.mockResolvedValue({ id: 'r2', number: 6 } as never)
+
+		const result = await checkClassicCompletion('g1', 'c1', 'r1', 5)
+		expect(result.completed).toBe(false)
+	})
+
+	it('does not complete when 0 alive and no eliminated cohort this round (degenerate state)', async () => {
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([
+			{ id: 'p1', status: 'eliminated', eliminatedRoundId: 'r-old', livesRemaining: 0 },
+		] as never)
+
+		const result = await checkClassicCompletion('g1', 'c1', 'r1', 5)
+		expect(result.completed).toBe(false)
+	})
+})
+
+describe('checkTurboCompletion', () => {
+	it('always completes', () => {
+		const result = checkTurboCompletion([
+			{ gamePlayerId: 'p1', streak: 7, goalsInStreak: 12 },
+			{ gamePlayerId: 'p2', streak: 5, goalsInStreak: 99 },
+		])
+		expect(result.completed).toBe(true)
+		expect(result.reason).toBe('turbo-single-round')
+		expect(result.winnerPlayerIds).toEqual(['p1'])
+	})
+
+	it('splits on full tie', () => {
+		const result = checkTurboCompletion([
+			{ gamePlayerId: 'p1', streak: 5, goalsInStreak: 8 },
+			{ gamePlayerId: 'p2', streak: 5, goalsInStreak: 8 },
+		])
+		expect(result.completed).toBe(true)
+		expect(result.winnerPlayerIds.sort()).toEqual(['p1', 'p2'])
+	})
+
+	it('completes with empty winners when no players', () => {
+		const result = checkTurboCompletion([])
+		expect(result.completed).toBe(true)
+		expect(result.winnerPlayerIds).toEqual([])
+	})
+})
+
+describe('checkCupCompletion', () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it('completes with last-alive when 1 alive', async () => {
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([
+			{ id: 'p1', status: 'alive', eliminatedRoundId: null, livesRemaining: 2 },
+			{ id: 'p2', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+		] as never)
+
+		const result = await checkCupCompletion('g1', 'c1', 'r1', 3)
+		expect(result.reason).toBe('last-alive')
+		expect(result.winnerPlayerIds).toEqual(['p1'])
+	})
+
+	it('mass extinction tiebreaks streak then lives then goals', async () => {
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([
+			{ id: 'p1', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+			{ id: 'p2', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+		] as never)
+		// p1: 5 successful picks, 7 goals; p2: 5 successful picks, 12 goals
+		dbMock.query.pick.findMany.mockResolvedValue([
+			{ gamePlayerId: 'p1', result: 'win', goalsScored: 3 },
+			{ gamePlayerId: 'p1', result: 'win', goalsScored: 2 },
+			{ gamePlayerId: 'p1', result: 'draw', goalsScored: 1 },
+			{ gamePlayerId: 'p1', result: 'saved_by_life', goalsScored: 1 },
+			{ gamePlayerId: 'p1', result: 'win', goalsScored: 0 },
+			{ gamePlayerId: 'p2', result: 'win', goalsScored: 4 },
+			{ gamePlayerId: 'p2', result: 'win', goalsScored: 4 },
+			{ gamePlayerId: 'p2', result: 'win', goalsScored: 4 },
+			{ gamePlayerId: 'p2', result: 'draw', goalsScored: 0 },
+			{ gamePlayerId: 'p2', result: 'saved_by_life', goalsScored: 0 },
+		] as never)
+
+		const result = await checkCupCompletion('g1', 'c1', 'r1', 3)
+		// streak ties (5=5), lives ties (0=0), goals: p2 wins 12 > 7
+		expect(result.reason).toBe('mass-extinction')
+		expect(result.winnerPlayerIds).toEqual(['p2'])
+	})
+
+	it('rounds-exhausted with multiple alive uses cup tiebreaker', async () => {
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([
+			{ id: 'p1', status: 'alive', eliminatedRoundId: null, livesRemaining: 1 },
+			{ id: 'p2', status: 'alive', eliminatedRoundId: null, livesRemaining: 3 },
+		] as never)
+		dbMock.query.round.findFirst.mockResolvedValue(null as never)
+		// equal streak: p1=3, p2=3; p2 has more lives
+		dbMock.query.pick.findMany.mockResolvedValue([
+			{ gamePlayerId: 'p1', result: 'win', goalsScored: 5 },
+			{ gamePlayerId: 'p1', result: 'win', goalsScored: 5 },
+			{ gamePlayerId: 'p1', result: 'win', goalsScored: 5 },
+			{ gamePlayerId: 'p2', result: 'win', goalsScored: 1 },
+			{ gamePlayerId: 'p2', result: 'win', goalsScored: 1 },
+			{ gamePlayerId: 'p2', result: 'win', goalsScored: 1 },
+		] as never)
+
+		const result = await checkCupCompletion('g1', 'c1', 'r1', 7)
+		expect(result.reason).toBe('rounds-exhausted')
+		expect(result.winnerPlayerIds).toEqual(['p2'])
+	})
+})

--- a/src/lib/game/auto-complete.ts
+++ b/src/lib/game/auto-complete.ts
@@ -1,0 +1,194 @@
+import { and, asc, eq, gt } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import {
+	classicTiebreaker,
+	cupTiebreaker,
+	type TurboTiebreakerInput,
+	turboTiebreaker,
+} from '@/lib/game-logic/auto-complete-tiebreakers'
+import { calculatePayouts, calculatePot } from '@/lib/game-logic/prizes'
+import { round } from '@/lib/schema/competition'
+import { game, gamePlayer, pick } from '@/lib/schema/game'
+import { payment, payout } from '@/lib/schema/payment'
+
+export type CompletionReason =
+	| 'last-alive'
+	| 'mass-extinction'
+	| 'rounds-exhausted'
+	| 'turbo-single-round'
+
+export interface CompletionCheckResult {
+	completed: boolean
+	winnerPlayerIds: string[]
+	reason?: CompletionReason
+}
+
+async function nextRoundExists(
+	competitionId: string,
+	completedRoundNumber: number,
+): Promise<boolean> {
+	const next = await db.query.round.findFirst({
+		where: and(eq(round.competitionId, competitionId), gt(round.number, completedRoundNumber)),
+		orderBy: [asc(round.number)],
+	})
+	return next != null
+}
+
+async function tiebreakClassicByGoals(
+	gameId: string,
+	candidatePlayerIds: string[],
+): Promise<string[]> {
+	const allPicks = await db.query.pick.findMany({
+		where: eq(pick.gameId, gameId),
+	})
+	const inputs = candidatePlayerIds.map((pid) => ({
+		gamePlayerId: pid,
+		totalWinningGoals: allPicks
+			.filter((p) => p.gamePlayerId === pid && p.result === 'win')
+			.reduce((sum, p) => sum + (p.goalsScored ?? 0), 0),
+	}))
+	return classicTiebreaker(inputs)
+}
+
+async function tiebreakCup(
+	gameId: string,
+	candidates: { id: string; livesRemaining: number }[],
+): Promise<string[]> {
+	const allPicks = await db.query.pick.findMany({
+		where: eq(pick.gameId, gameId),
+	})
+	const inputs = candidates.map((c) => {
+		const myPicks = allPicks.filter((p) => p.gamePlayerId === c.id)
+		const cumulativeStreak = myPicks.filter(
+			(p) => p.result === 'win' || p.result === 'draw' || p.result === 'saved_by_life',
+		).length
+		const cumulativeGoals = myPicks.reduce((sum, p) => sum + (p.goalsScored ?? 0), 0)
+		return {
+			gamePlayerId: c.id,
+			cumulativeStreak,
+			livesRemaining: c.livesRemaining,
+			cumulativeGoals,
+		}
+	})
+	return cupTiebreaker(inputs)
+}
+
+export async function checkClassicCompletion(
+	gameId: string,
+	competitionId: string,
+	completedRoundId: string,
+	completedRoundNumber: number,
+): Promise<CompletionCheckResult> {
+	const allPlayers = await db.query.gamePlayer.findMany({
+		where: eq(gamePlayer.gameId, gameId),
+	})
+	const alive = allPlayers.filter((p) => p.status === 'alive')
+
+	if (alive.length === 1) {
+		return { completed: true, winnerPlayerIds: [alive[0].id], reason: 'last-alive' }
+	}
+
+	if (alive.length === 0) {
+		const cohort = allPlayers.filter(
+			(p) => p.status === 'eliminated' && p.eliminatedRoundId === completedRoundId,
+		)
+		if (cohort.length === 0) return { completed: false, winnerPlayerIds: [] }
+		const winners = await tiebreakClassicByGoals(
+			gameId,
+			cohort.map((p) => p.id),
+		)
+		return { completed: true, winnerPlayerIds: winners, reason: 'mass-extinction' }
+	}
+
+	const hasNext = await nextRoundExists(competitionId, completedRoundNumber)
+	if (!hasNext) {
+		const winners = await tiebreakClassicByGoals(
+			gameId,
+			alive.map((p) => p.id),
+		)
+		return { completed: true, winnerPlayerIds: winners, reason: 'rounds-exhausted' }
+	}
+
+	return { completed: false, winnerPlayerIds: [] }
+}
+
+export function checkTurboCompletion(playerScores: TurboTiebreakerInput[]): CompletionCheckResult {
+	const winners = turboTiebreaker(playerScores)
+	return {
+		completed: true,
+		winnerPlayerIds: winners,
+		reason: 'turbo-single-round',
+	}
+}
+
+export async function checkCupCompletion(
+	gameId: string,
+	competitionId: string,
+	completedRoundId: string,
+	completedRoundNumber: number,
+): Promise<CompletionCheckResult> {
+	const allPlayers = await db.query.gamePlayer.findMany({
+		where: eq(gamePlayer.gameId, gameId),
+	})
+	const alive = allPlayers.filter((p) => p.status === 'alive')
+
+	if (alive.length === 1) {
+		return { completed: true, winnerPlayerIds: [alive[0].id], reason: 'last-alive' }
+	}
+
+	if (alive.length === 0) {
+		const cohort = allPlayers.filter(
+			(p) => p.status === 'eliminated' && p.eliminatedRoundId === completedRoundId,
+		)
+		if (cohort.length === 0) return { completed: false, winnerPlayerIds: [] }
+		const winners = await tiebreakCup(gameId, cohort)
+		return { completed: true, winnerPlayerIds: winners, reason: 'mass-extinction' }
+	}
+
+	const hasNext = await nextRoundExists(competitionId, completedRoundNumber)
+	if (!hasNext) {
+		const winners = await tiebreakCup(gameId, alive)
+		return { completed: true, winnerPlayerIds: winners, reason: 'rounds-exhausted' }
+	}
+
+	return { completed: false, winnerPlayerIds: [] }
+}
+
+export async function applyAutoCompletion(
+	gameId: string,
+	winnerPlayerIds: string[],
+): Promise<void> {
+	if (winnerPlayerIds.length === 0) return
+
+	for (const playerId of winnerPlayerIds) {
+		await db.update(gamePlayer).set({ status: 'winner' }).where(eq(gamePlayer.id, playerId))
+	}
+
+	const players = await db.query.gamePlayer.findMany({
+		where: eq(gamePlayer.gameId, gameId),
+	})
+	const winnerUserIds = winnerPlayerIds
+		.map((pid) => players.find((p) => p.id === pid)?.userId)
+		.filter((u): u is string => u != null)
+
+	const payments = await db.query.payment.findMany({
+		where: eq(payment.gameId, gameId),
+	})
+	const pot = calculatePot(payments)
+	const payoutEntries = calculatePayouts(pot.total, winnerUserIds)
+	if (payoutEntries.length > 0) {
+		await db.insert(payout).values(
+			payoutEntries.map((p) => ({
+				gameId,
+				userId: p.userId,
+				amount: p.amount,
+				isSplit: p.isSplit,
+			})),
+		)
+	}
+
+	await db
+		.update(game)
+		.set({ status: 'completed', currentRoundId: null })
+		.where(eq(game.id, gameId))
+}

--- a/src/lib/game/process-round.test.ts
+++ b/src/lib/game/process-round.test.ts
@@ -15,9 +15,13 @@ const { dbMock } = vi.hoisted(() => ({
 			round: { findFirst: vi.fn() },
 			pick: { findMany: vi.fn() },
 			gamePlayer: { findMany: vi.fn() },
+			payment: { findMany: vi.fn() },
 		},
 		update: vi.fn(() => ({
 			set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+		})),
+		insert: vi.fn(() => ({
+			values: vi.fn().mockResolvedValue(undefined),
 		})),
 	},
 }))
@@ -40,6 +44,8 @@ function makeClassicGameAndRound(opts: { roundNumber: number; allowRebuys?: bool
 		fixtures: [{ status: 'finished', homeScore: 0, awayScore: 0 }],
 	} as never)
 	dbMock.query.pick.findMany.mockResolvedValue([])
+	dbMock.query.gamePlayer.findMany.mockResolvedValue([])
+	dbMock.query.payment.findMany.mockResolvedValue([])
 	processClassicRoundMock.mockReturnValue({ results: [] })
 }
 

--- a/src/lib/game/process-round.ts
+++ b/src/lib/game/process-round.ts
@@ -1,5 +1,11 @@
 import { and, asc, eq, gt } from 'drizzle-orm'
 import { db } from '@/lib/db'
+import {
+	applyAutoCompletion,
+	checkClassicCompletion,
+	checkCupCompletion,
+	checkTurboCompletion,
+} from '@/lib/game/auto-complete'
 import { processClassicRound } from '@/lib/game-logic/classic'
 import { evaluateCupPicks } from '@/lib/game-logic/cup'
 import { computeTierDifference } from '@/lib/game-logic/cup-tier'
@@ -170,6 +176,18 @@ export async function processGameRound(gameId: string, roundId: string) {
 		}
 
 		await db.update(round).set({ status: 'completed' }).where(eq(round.id, roundId))
+
+		const completion = await checkClassicCompletion(
+			gameId,
+			gameData.competitionId,
+			roundId,
+			roundData.number,
+		)
+		if (completion.completed) {
+			await applyAutoCompletion(gameId, completion.winnerPlayerIds)
+			return { processed: true, eliminations, completed: true, reason: completion.reason }
+		}
+
 		await advanceGameToNextRound(gameId, gameData.competitionId, roundData.number)
 		return { processed: true, eliminations }
 	}
@@ -212,8 +230,17 @@ export async function processGameRound(gameId: string, roundId: string) {
 
 		const standings = calculateTurboStandings(playerResults)
 		await db.update(round).set({ status: 'completed' }).where(eq(round.id, roundId))
-		await advanceGameToNextRound(gameId, gameData.competitionId, roundData.number)
-		return { processed: true, eliminations: 0, standings }
+
+		// Turbo is a single-round format. Auto-complete and never advance.
+		const completion = checkTurboCompletion(playerResults)
+		await applyAutoCompletion(gameId, completion.winnerPlayerIds)
+		return {
+			processed: true,
+			eliminations: 0,
+			standings,
+			completed: true,
+			reason: completion.reason,
+		}
 	}
 
 	if (gameData.gameMode === 'cup') {
@@ -278,6 +305,18 @@ export async function processGameRound(gameId: string, roundId: string) {
 		}
 
 		await db.update(round).set({ status: 'completed' }).where(eq(round.id, roundId))
+
+		const completion = await checkCupCompletion(
+			gameId,
+			gameData.competitionId,
+			roundId,
+			roundData.number,
+		)
+		if (completion.completed) {
+			await applyAutoCompletion(gameId, completion.winnerPlayerIds)
+			return { processed: true, eliminations, completed: true, reason: completion.reason }
+		}
+
 		await advanceGameToNextRound(gameId, gameData.competitionId, roundData.number)
 		return { processed: true, eliminations }
 	}


### PR DESCRIPTION
## Summary

- Games never auto-completed before — admin had to manually split-pot for every game. Turbo games rolled into a second round because round processing unconditionally advanced.
- New auto-complete module detects natural end-states (1 alive, 0 alive, rounds exhausted) and sets `game.status='completed'` + winner(s) + payouts.
- Turbo never advances; auto-completes after its single round.
- Tiebreaker rules ported from the predecessor app, with the old app's SQL undefined-order bug for mass-extinction fixed by an explicit split.

## Tiebreaker rules (confirmed via interview, anchored on old app)

- **Classic** mass-extinction & rounds-exhausted: cumulative goals from winning picks; ties split.
- **Turbo**: streak desc → goals-in-streak desc; ties split.
- **Cup**: cumulative successful picks → lives remaining → cumulative goals; ties split.

`split-pot` admin endpoint now means "early termination by mutual agreement" — no longer the primary completion path.

## Test plan

- [x] 11 pure-function tiebreaker unit tests (`auto-complete-tiebreakers.test.ts`)
- [x] 12 DB-mocked integration tests covering all 9 completion scenarios across 3 modes (`auto-complete.test.ts`)
- [x] Existing process-round tests still pass (mocks updated for new `gamePlayer.findMany` / `payment.findMany` calls)
- [x] Full suite: 378/378 passing
- [x] Typecheck clean
- [ ] Smoke test on preview: trigger a turbo round-end, confirm game completes and doesn't advance to next GW
- [ ] Verify a classic game with 1 alive auto-completes after round-processing cron fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)