### PR TITLE
fix(launch-feedback): derive WC round deadlines from earliest kickoff

### DIFF
--- a/src/lib/data/football-data.test.ts
+++ b/src/lib/data/football-data.test.ts
@@ -89,6 +89,36 @@ describe('FootballDataAdapter', () => {
 		expect(rounds[0].fixtures).toHaveLength(2)
 	})
 
+	it('derives round deadline from earliest fixture kickoff', async () => {
+		const rounds = await adapter.fetchRounds()
+		// mockMatches earliest kickoff is 2025-08-16T15:00:00Z
+		expect(rounds[0].deadline).toEqual(new Date('2025-08-16T15:00:00Z'))
+	})
+
+	it('returns null deadline when round has no playable fixtures (e.g. WC knockout pre-draw)', async () => {
+		const onlyPlaceholders = {
+			matches: [
+				{
+					id: 9001,
+					matchday: 4,
+					homeTeam: { id: null, name: null, tla: null, crest: null },
+					awayTeam: { id: null, name: null, tla: null, crest: null },
+					utcDate: '2026-06-30T20:00:00Z',
+					status: 'TIMED',
+					score: { fullTime: { home: null, away: null } },
+				},
+			],
+		}
+		vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+			Promise.resolve(new Response(JSON.stringify(onlyPlaceholders))),
+		)
+		const rounds = await adapter.fetchRounds()
+		expect(rounds).toHaveLength(1)
+		expect(rounds[0].number).toBe(4)
+		expect(rounds[0].fixtures).toHaveLength(0)
+		expect(rounds[0].deadline).toBeNull()
+	})
+
 	it('maps status correctly', async () => {
 		const rounds = await adapter.fetchRounds()
 		expect(rounds[0].fixtures[0].status).toBe('finished')

--- a/src/lib/data/football-data.ts
+++ b/src/lib/data/football-data.ts
@@ -109,15 +109,24 @@ export class FootballDataAdapter implements CompetitionAdapter {
 		}
 		return Array.from(roundMap.entries())
 			.sort(([a], [b]) => a - b)
-			.map(([matchday, matches]) => ({
-				externalId: String(matchday),
-				number: matchday,
-				name: `Matchday ${matchday}`,
-				deadline: null,
-				finished: matches.every((m) => m.status === 'FINISHED'),
-				fixtures: matches
-					.filter((m) => m.homeTeam.id != null && m.awayTeam.id != null)
-					.map(
+			.map(([matchday, matches]) => {
+				const playable = matches.filter((m) => m.homeTeam.id != null && m.awayTeam.id != null)
+				// Round deadline = earliest kickoff in the round. Picks lock when the
+				// first match starts. football-data doesn't supply a separate
+				// deadline concept (unlike FPL), so we derive from kickoffs. Knockout
+				// rounds with TBD fixtures have no kickoffs yet — deadline stays null
+				// until the bracket is published and the next bootstrap sync runs.
+				const earliestKickoff = playable
+					.map((m) => new Date(m.utcDate).getTime())
+					.filter((t) => Number.isFinite(t))
+					.reduce((min, t) => (min === null || t < min ? t : min), null as number | null)
+				return {
+					externalId: String(matchday),
+					number: matchday,
+					name: `Matchday ${matchday}`,
+					deadline: earliestKickoff != null ? new Date(earliestKickoff) : null,
+					finished: matches.every((m) => m.status === 'FINISHED'),
+					fixtures: playable.map(
 						(m): AdapterFixture => ({
 							externalId: String(m.id),
 							homeTeamExternalId: String(m.homeTeam.id),
@@ -128,7 +137,8 @@ export class FootballDataAdapter implements CompetitionAdapter {
 							awayScore: m.score.fullTime.away,
 						}),
 					),
-			}))
+				}
+			})
 	}
 
 	async fetchLiveScores(roundNumber: number): Promise<AdapterFixtureScore[]> {


### PR DESCRIPTION
## Summary

- football-data adapter was hardcoding `deadline=null` for every round, regardless of competition
- PL got deadlines via the FPL adapter so the bug was invisible there
- WC group-stage rounds and all knockout rounds came through with null deadlines, which means `processDeadlineLock` never fires for WC players
- Round deadline now derives from the earliest fixture kickoff in the round; TBD knockout rounds still return null until the bracket is published

## Test plan

- [x] Unit tests added for kickoff-derivation and TBD-knockout cases
- [x] Full test suite passes (380/380)
- [x] Existing FPL behaviour unchanged (FPL adapter populates deadline directly from `event.deadline_time`)
- [ ] After merge: confirm next daily-sync cron run updates existing WC rounds' deadlines from null to earliest kickoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)