### PR TITLE
fix(launch-feedback): guard advance against TBD/empty next rounds

### DIFF
--- a/src/app/api/cron/daily-sync/route.test.ts
+++ b/src/app/api/cron/daily-sync/route.test.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/lib/db', () => ({
-	db: { query: { competition: { findMany: vi.fn() } } },
+	db: {
+		query: {
+			competition: { findMany: vi.fn() },
+			game: { findMany: vi.fn().mockResolvedValue([]) },
+		},
+	},
 }))
 
 vi.mock('@/lib/game/bootstrap-competitions', () => ({
@@ -16,9 +21,14 @@ vi.mock('@/lib/game/no-pick-handler', () => ({
 		.mockResolvedValue({ autoPicksInserted: 0, playersEliminated: 0, paymentsRefunded: 0 }),
 }))
 
+vi.mock('@/lib/game/process-round', () => ({
+	advanceGameIfReady: vi.fn().mockResolvedValue({ advanced: false, reason: 'not-active' }),
+}))
+
 import { db } from '@/lib/db'
 import { syncCompetition } from '@/lib/game/bootstrap-competitions'
 import { processDeadlineLock } from '@/lib/game/no-pick-handler'
+import { advanceGameIfReady } from '@/lib/game/process-round'
 import { POST } from './route'
 
 describe('daily-sync route', () => {
@@ -91,5 +101,29 @@ describe('daily-sync route', () => {
 			playersEliminated: 0,
 			paymentsRefunded: 0,
 		})
+	})
+
+	it('retries advancement for stuck games after sync', async () => {
+		vi.mocked(db.query.competition.findMany).mockResolvedValue([{ id: 'c1' }] as never)
+		vi.mocked(db.query.game.findMany).mockResolvedValue([
+			{ id: 'g-stuck', currentRoundId: 'r-completed' },
+			{ id: 'g-clean', currentRoundId: 'r-open' },
+			{ id: 'g-no-round', currentRoundId: null },
+		] as never)
+		vi.mocked(advanceGameIfReady)
+			.mockResolvedValueOnce({ advanced: true, reason: 'advanced' })
+			.mockResolvedValueOnce({ advanced: false, reason: 'round-not-completed' })
+
+		const res = await POST(
+			new Request('http://x', {
+				method: 'POST',
+				headers: { authorization: 'Bearer test-secret' },
+			}),
+		)
+
+		// Skips the game with currentRoundId=null
+		expect(advanceGameIfReady).toHaveBeenCalledTimes(2)
+		const body = (await res.json()) as { advanced: string[] }
+		expect(body.advanced).toEqual(['g-stuck'])
 	})
 })

--- a/src/app/api/cron/daily-sync/route.ts
+++ b/src/app/api/cron/daily-sync/route.ts
@@ -7,7 +7,9 @@ import {
 	syncCompetition,
 } from '@/lib/game/bootstrap-competitions'
 import { processDeadlineLock } from '@/lib/game/no-pick-handler'
+import { advanceGameIfReady } from '@/lib/game/process-round'
 import { competition } from '@/lib/schema/competition'
+import { game } from '@/lib/schema/game'
 
 export async function POST(request: Request) {
 	const secret = process.env.CRON_SECRET
@@ -56,5 +58,22 @@ export async function POST(request: Request) {
 	if (deadlineLockedRoundIds.length > 0) {
 		deadlineLock = await processDeadlineLock(deadlineLockedRoundIds)
 	}
-	return NextResponse.json({ competitions: results, deadlineLock })
+
+	// Retry advancement for games stuck pointing at a completed round. The
+	// per-game process-rounds dispatch only fires when a round just finished,
+	// so it can't pick up a game whose advance was a no-op (e.g. WC bracket
+	// not yet published). This is the load-bearing retry slot — daily-sync
+	// has just refreshed round deadlines and fixtures, so any previously-TBD
+	// round that's now populated will be advanceable here.
+	const activeGames = await db.query.game.findMany({
+		where: eq(game.status, 'active'),
+	})
+	const advanced: string[] = []
+	for (const g of activeGames) {
+		if (!g.currentRoundId) continue
+		const r = await advanceGameIfReady(g.id)
+		if (r.advanced) advanced.push(g.id)
+	}
+
+	return NextResponse.json({ competitions: results, deadlineLock, advanced })
 }

--- a/src/app/api/cron/process-rounds/route.ts
+++ b/src/app/api/cron/process-rounds/route.ts
@@ -1,7 +1,7 @@
 import { eq } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import { db } from '@/lib/db'
-import { processGameRound } from '@/lib/game/process-round'
+import { advanceGameIfReady, processGameRound } from '@/lib/game/process-round'
 import { round } from '@/lib/schema/competition'
 import { game } from '@/lib/schema/game'
 
@@ -42,5 +42,16 @@ export async function POST(request: Request) {
 		results.push({ gameId: g.id, ...result })
 	}
 
-	return NextResponse.json({ processed: results })
+	// Retry advancement for games stuck on a completed round (typically
+	// because the next round was TBD when last processed — e.g. WC knockouts
+	// before the bracket was published). Safe to call every tick: returns
+	// 'round-not-completed' (no-op) for healthy games.
+	const advanced = []
+	for (const g of activeGames) {
+		if (!g.currentRoundId) continue
+		const r = await advanceGameIfReady(g.id)
+		if (r.advanced) advanced.push({ gameId: g.id })
+	}
+
+	return NextResponse.json({ processed: results, advanced })
 }

--- a/src/lib/game/process-round.test.ts
+++ b/src/lib/game/process-round.test.ts
@@ -27,7 +27,7 @@ const { dbMock } = vi.hoisted(() => ({
 }))
 vi.mock('@/lib/db', () => ({ db: dbMock }))
 
-import { processGameRound } from './process-round'
+import { advanceGameIfReady, processGameRound } from './process-round'
 
 function makeClassicGameAndRound(opts: { roundNumber: number; allowRebuys?: boolean }) {
 	dbMock.query.game.findFirst.mockResolvedValue({
@@ -74,5 +74,105 @@ describe('processGameRound: isStartingRound derivation', () => {
 		expect(processClassicRoundMock).toHaveBeenCalledWith(
 			expect.objectContaining({ isStartingRound: false }),
 		)
+	})
+})
+
+describe('advanceGameIfReady', () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it('returns not-active when game status is not active', async () => {
+		dbMock.query.game.findFirst.mockResolvedValue({
+			id: 'g1',
+			status: 'completed',
+			competitionId: 'c1',
+			currentRound: { id: 'r1', number: 5, status: 'completed', deadline: null },
+		} as never)
+		const r = await advanceGameIfReady('g1')
+		expect(r).toEqual({ advanced: false, reason: 'not-active' })
+	})
+
+	it('returns no-current-round when game has none', async () => {
+		dbMock.query.game.findFirst.mockResolvedValue({
+			id: 'g1',
+			status: 'active',
+			competitionId: 'c1',
+			currentRound: null,
+		} as never)
+		const r = await advanceGameIfReady('g1')
+		expect(r).toEqual({ advanced: false, reason: 'no-current-round' })
+	})
+
+	it('returns round-not-completed for healthy in-progress games', async () => {
+		dbMock.query.game.findFirst.mockResolvedValue({
+			id: 'g1',
+			status: 'active',
+			competitionId: 'c1',
+			currentRound: { id: 'r1', number: 5, status: 'open', deadline: new Date() },
+		} as never)
+		const r = await advanceGameIfReady('g1')
+		expect(r).toEqual({ advanced: false, reason: 'round-not-completed' })
+	})
+
+	it('refuses to advance to round with no fixtures (TBD knockout)', async () => {
+		dbMock.query.game.findFirst.mockResolvedValue({
+			id: 'g1',
+			status: 'active',
+			competitionId: 'c1',
+			currentRound: { id: 'r1', number: 3, status: 'completed', deadline: new Date() },
+		} as never)
+		dbMock.query.round.findFirst.mockResolvedValue({
+			id: 'r2',
+			number: 4,
+			fixtures: [],
+			deadline: null,
+		} as never)
+		const r = await advanceGameIfReady('g1')
+		expect(r).toEqual({ advanced: false, reason: 'next-round-tbd' })
+	})
+
+	it('refuses to advance to round with null deadline even if it has fixtures', async () => {
+		dbMock.query.game.findFirst.mockResolvedValue({
+			id: 'g1',
+			status: 'active',
+			competitionId: 'c1',
+			currentRound: { id: 'r1', number: 3, status: 'completed', deadline: new Date() },
+		} as never)
+		dbMock.query.round.findFirst.mockResolvedValue({
+			id: 'r2',
+			number: 4,
+			fixtures: [{ id: 'f1' }],
+			deadline: null,
+		} as never)
+		const r = await advanceGameIfReady('g1')
+		expect(r).toEqual({ advanced: false, reason: 'next-round-tbd' })
+	})
+
+	it('advances when next round has fixtures and deadline', async () => {
+		dbMock.query.game.findFirst.mockResolvedValue({
+			id: 'g1',
+			status: 'active',
+			competitionId: 'c1',
+			currentRound: { id: 'r1', number: 3, status: 'completed', deadline: new Date() },
+		} as never)
+		dbMock.query.round.findFirst.mockResolvedValue({
+			id: 'r2',
+			number: 4,
+			fixtures: [{ id: 'f1' }],
+			deadline: new Date('2026-06-15T15:00:00Z'),
+		} as never)
+		const r = await advanceGameIfReady('g1')
+		expect(r).toEqual({ advanced: true, reason: 'advanced' })
+	})
+
+	it('reports no-next-round when none exists (and clears currentRoundId)', async () => {
+		dbMock.query.game.findFirst.mockResolvedValue({
+			id: 'g1',
+			status: 'active',
+			competitionId: 'c1',
+			currentRound: { id: 'r-final', number: 38, status: 'completed', deadline: new Date() },
+		} as never)
+		dbMock.query.round.findFirst.mockResolvedValue(undefined as never)
+		const r = await advanceGameIfReady('g1')
+		expect(r).toEqual({ advanced: false, reason: 'no-next-round' })
 	})
 })

--- a/src/lib/game/process-round.ts
+++ b/src/lib/game/process-round.ts
@@ -20,24 +20,56 @@ import { game, gamePlayer, pick } from '@/lib/schema/game'
 
 /**
  * Advance the game's currentRoundId pointer to the next round in the
- * competition (or null if there are no further rounds). Called after
- * a round has been processed so that picks can begin on the next round
- * for this game. Round-state is per-game: each game advances independently
+ * competition. Round-state is per-game: each game advances independently
  * based on when its rounds complete, not on a global competition timeline.
+ *
+ * Refuses to advance to a round with no fixtures or no deadline (e.g. a
+ * WC knockout round where the bracket hasn't been published yet). In that
+ * case the game stays pointed at the just-completed round; the cron will
+ * retry via advanceGameIfReady on subsequent ticks once the next round
+ * is fully populated.
  */
 async function advanceGameToNextRound(
 	gameId: string,
 	competitionId: string,
 	completedRoundNumber: number,
-): Promise<void> {
+): Promise<{ advanced: boolean; reason?: 'no-next-round' | 'next-round-tbd' }> {
 	const nextRound = await db.query.round.findFirst({
 		where: and(eq(round.competitionId, competitionId), gt(round.number, completedRoundNumber)),
 		orderBy: [asc(round.number)],
+		with: { fixtures: true },
 	})
-	await db
-		.update(game)
-		.set({ currentRoundId: nextRound?.id ?? null })
-		.where(eq(game.id, gameId))
+	if (!nextRound) {
+		await db.update(game).set({ currentRoundId: null }).where(eq(game.id, gameId))
+		return { advanced: false, reason: 'no-next-round' }
+	}
+	if (nextRound.fixtures.length === 0 || nextRound.deadline == null) {
+		return { advanced: false, reason: 'next-round-tbd' }
+	}
+	await db.update(game).set({ currentRoundId: nextRound.id }).where(eq(game.id, gameId))
+	return { advanced: true }
+}
+
+/**
+ * Retry advancement for games stuck pointing at a completed round. Used
+ * by the cron to pick up games whose next round was TBD at process-time
+ * and has since been populated by bootstrap.
+ */
+export async function advanceGameIfReady(
+	gameId: string,
+): Promise<{ advanced: boolean; reason: string }> {
+	const g = await db.query.game.findFirst({
+		where: eq(game.id, gameId),
+		with: { currentRound: true },
+	})
+	if (!g) return { advanced: false, reason: 'not-found' }
+	if (g.status !== 'active') return { advanced: false, reason: 'not-active' }
+	if (!g.currentRound) return { advanced: false, reason: 'no-current-round' }
+	if (g.currentRound.status !== 'completed') {
+		return { advanced: false, reason: 'round-not-completed' }
+	}
+	const result = await advanceGameToNextRound(g.id, g.competitionId, g.currentRound.number)
+	return { advanced: result.advanced, reason: result.reason ?? 'advanced' }
 }
 
 export async function processGameRound(gameId: string, roundId: string) {


### PR DESCRIPTION
## Summary

- `advanceGameToNextRound` now refuses to move a game to a round that has zero fixtures or no deadline
- Protects against the WC bracket-publication lag: between group-stage finish and bracket sync, R16 exists with no fixtures
- Adds `advanceGameIfReady` for the cron to retry advancement on subsequent ticks once the target round is populated

## Stacked on

PR #23 (auto-completion). Base set to that branch — review/merge that first.

## Test plan

- [x] 7 new tests for advance/retry behaviour (TBD knockout, null deadline, no fixtures, healthy advance, no-next-round)
- [x] Full suite passes (385/385)
- [x] Typecheck clean
- [ ] After merge: confirm cron retries advancement for any stuck games (likely none in production yet, since no game has reached an end-of-rounds boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)