### PR TITLE
fix(launch-feedback): WC pot assignment by name with unmatched warning

### DIFF
--- a/src/lib/game/apply-pot-assignments.test.ts
+++ b/src/lib/game/apply-pot-assignments.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { dbMock } = vi.hoisted(() => ({
+	dbMock: {
+		query: {
+			round: { findMany: vi.fn() },
+			team: { findMany: vi.fn() },
+		},
+		update: vi.fn(() => ({
+			set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+		})),
+	},
+}))
+vi.mock('@/lib/db', () => ({ db: dbMock }))
+
+import { applyPotAssignments } from './bootstrap-competitions'
+
+describe('applyPotAssignments', () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it('returns matched=0, unmatched=[] when no fixtures/teams in competition', async () => {
+		dbMock.query.round.findMany.mockResolvedValue([] as never)
+		const result = await applyPotAssignments('c1')
+		expect(result).toEqual({ matched: 0, unmatched: [] })
+	})
+
+	it('matches teams by name when WC_2026_POTS footballDataId is empty (current state)', async () => {
+		dbMock.query.round.findMany.mockResolvedValue([
+			{
+				fixtures: [{ homeTeamId: 't-spain', awayTeamId: 't-brazil' }],
+			},
+		] as never)
+		dbMock.query.team.findMany.mockResolvedValue([
+			{ id: 't-spain', name: 'Spain', externalIds: { football_data: 999 } },
+			{ id: 't-brazil', name: 'Brazil', externalIds: { football_data: 998 } },
+		] as never)
+
+		const result = await applyPotAssignments('c1')
+		expect(result.matched).toBe(2)
+		expect(result.unmatched).toEqual([])
+	})
+
+	it('case-insensitive name matching', async () => {
+		dbMock.query.round.findMany.mockResolvedValue([
+			{ fixtures: [{ homeTeamId: 't', awayTeamId: 't' }] },
+		] as never)
+		dbMock.query.team.findMany.mockResolvedValue([
+			{ id: 't', name: 'PORTUGAL', externalIds: {} },
+		] as never)
+
+		const result = await applyPotAssignments('c1')
+		expect(result.matched).toBe(1)
+		expect(result.unmatched).toEqual([])
+	})
+
+	it('reports unmatched teams (e.g. unfilled playoff winner)', async () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+		dbMock.query.round.findMany.mockResolvedValue([
+			{
+				fixtures: [{ homeTeamId: 't-known', awayTeamId: 't-unknown' }],
+			},
+		] as never)
+		dbMock.query.team.findMany.mockResolvedValue([
+			{ id: 't-known', name: 'Germany', externalIds: {} },
+			{ id: 't-unknown', name: 'Italy', externalIds: {} }, // not in WC_2026_POTS
+		] as never)
+
+		const result = await applyPotAssignments('c1')
+		expect(result.matched).toBe(1)
+		expect(result.unmatched).toEqual(['Italy'])
+		expect(warn).toHaveBeenCalledWith(
+			expect.stringContaining('not in WC_2026_POTS'),
+			expect.stringContaining('Italy'),
+		)
+		warn.mockRestore()
+	})
+})

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -419,7 +419,9 @@ export async function syncCompetition(
 	return { rounds: adapterRounds.length, fixtures: totalFixtures, transitionedRoundIds }
 }
 
-export async function applyPotAssignments(competitionId: string): Promise<void> {
+export async function applyPotAssignments(
+	competitionId: string,
+): Promise<{ matched: number; unmatched: string[] }> {
 	const rounds = await db.query.round.findMany({
 		where: eq(round.competitionId, competitionId),
 		with: { fixtures: true },
@@ -431,23 +433,42 @@ export async function applyPotAssignments(competitionId: string): Promise<void> 
 			teamIds.add(f.awayTeamId)
 		}
 	}
-	if (teamIds.size === 0) return
+	if (teamIds.size === 0) return { matched: 0, unmatched: [] }
 
 	const teams = await db.query.team.findMany({
 		where: inArray(team.id, [...teamIds]),
 	})
+	let matched = 0
+	const unmatched: string[] = []
 	for (const t of teams) {
 		const fdId = (t.externalIds as Record<string, string | number> | null)?.football_data
-		if (!fdId) continue
-		const entry = WC_2026_POTS.find((p) => p.footballDataId === String(fdId))
-		if (!entry) continue
+		// Match by football-data ID first (when WC_2026_POTS has been backfilled
+		// from /competitions/WC/teams), fall back to team name. Name matching
+		// covers the common case today: pots are seeded with names only and
+		// football-data uses canonical country names that align with the list.
+		const entry =
+			(fdId
+				? WC_2026_POTS.find((p) => p.footballDataId && p.footballDataId === String(fdId))
+				: undefined) ?? WC_2026_POTS.find((p) => p.name.toLowerCase() === t.name.toLowerCase())
+		if (!entry) {
+			unmatched.push(t.name)
+			continue
+		}
 		await db
 			.update(team)
 			.set({
 				externalIds: { ...(t.externalIds ?? {}), fifa_pot: entry.pot },
 			})
 			.where(eq(team.id, t.id))
+		matched++
 	}
+	if (unmatched.length > 0) {
+		console.warn(
+			`[bootstrap] ${unmatched.length} WC team(s) not in WC_2026_POTS — cup tier-difference will be 0:`,
+			unmatched.join(', '),
+		)
+	}
+	return { matched, unmatched }
 }
 
 function adapterFor(comp: CompetitionRow, opts: BootstrapOptions): CompetitionAdapter | null {


### PR DESCRIPTION
## Summary

- WC_2026_POTS has empty `footballDataId` for all 48 entries (pre-existing TODO that was deferred)
- `applyPotAssignments` matched only by `footballDataId`, so no team ever got a pot, so cup tier-difference was always 0 for WC games — silently breaking the lives mechanic
- Adds case-insensitive name-based fallback matching against football-data's canonical country names
- Tracks unmatched team names and `console.warn`s the list — surfaces TBD playoff winners once they qualify and start appearing in fixtures

## Test plan

- [x] 4 new tests for name matching, case-insensitivity, and unmatched warning
- [x] Full suite passes
- [ ] After merge: confirm next bootstrap run logs no unmatched WC teams (current 42 confirmed qualifiers should all match by name; 6 TBD playoff entries won't appear until those teams qualify)
- [ ] Smoke test: cup tier-difference now non-zero for WC games

🤖 Generated with [Claude Code](https://claude.com/claude-code)