### PR TITLE
fix: default classic 'allow paid rebuys' to on

### DIFF
--- a/src/components/game/create-game-form.tsx
+++ b/src/components/game/create-game-form.tsx
@@ -38,7 +38,7 @@ export function CreateGameForm({ competitions }: CreateGameFormProps) {
 	const [entryFee, setEntryFee] = useState(10)
 	const [startingLives, setStartingLives] = useState(0)
 	const [numberOfPicks, setNumberOfPicks] = useState(10)
-	const [allowRebuys, setAllowRebuys] = useState(false)
+	const [allowRebuys, setAllowRebuys] = useState(true)
 	const [loading, setLoading] = useState(false)
 	const [error, setError] = useState<string | null>(null)
 


### PR DESCRIPTION
## Summary

One-liner: flip the create-game form's default for classic-mode `allowRebuys` from `false` to `true`. Matches predecessor app behaviour and creator expectations.

## Test plan

- [x] Tests still pass (384/384) — no test asserted the prior default
- [ ] Smoke test: create a new classic game; paid-rebuys toggle reads as on by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)