### PR TITLE
fix(launch-feedback): order fixtures chronologically across all queries

### DIFF
--- a/src/app/api/cron/process-rounds/route.ts
+++ b/src/app/api/cron/process-rounds/route.ts
@@ -27,7 +27,7 @@ export async function POST(request: Request) {
 		// Check if the round's fixtures are all finished
 		const roundData = await db.query.round.findFirst({
 			where: eq(round.id, g.currentRoundId),
-			with: { fixtures: true },
+			with: { fixtures: { orderBy: (fx, { asc }) => asc(fx.kickoff) } },
 		})
 
 		if (!roundData) continue

--- a/src/app/api/picks/[gameId]/[roundId]/route.ts
+++ b/src/app/api/picks/[gameId]/[roundId]/route.ts
@@ -67,7 +67,12 @@ export async function POST(request: Request, { params }: { params: Params }) {
 	// Get round (with team relations so cup-mode validation can inspect tiers)
 	const roundData = await db.query.round.findFirst({
 		where: eq(round.id, roundId),
-		with: { fixtures: { with: { homeTeam: true, awayTeam: true } } },
+		with: {
+			fixtures: {
+				with: { homeTeam: true, awayTeam: true },
+				orderBy: (fx, { asc }) => asc(fx.kickoff),
+			},
+		},
 	})
 	if (!roundData) {
 		return NextResponse.json({ error: 'Round not found' }, { status: 404 })
@@ -119,7 +124,11 @@ export async function POST(request: Request, { params }: { params: Params }) {
 			// Load all rounds + fixtures for the competition to check tournament elimination
 			const allRounds = await db.query.round.findMany({
 				where: eq(round.competitionId, gameData.competitionId),
-				with: { fixtures: true },
+				with: {
+					fixtures: {
+						orderBy: (fx, { asc }) => asc(fx.kickoff),
+					},
+				},
 			})
 			const finishedKnockoutFixtures = allRounds.flatMap((r) =>
 				r.fixtures.map((f) => ({

--- a/src/lib/game/auto-submit.ts
+++ b/src/lib/game/auto-submit.ts
@@ -1,4 +1,4 @@
-import { and, eq } from 'drizzle-orm'
+import { and, asc, eq } from 'drizzle-orm'
 import { db } from '@/lib/db'
 import { fixture } from '@/lib/schema/competition'
 import { gamePlayer, pick, plannedPick } from '@/lib/schema/game'
@@ -23,8 +23,13 @@ export async function submitPlannedPick(
 	})
 	if (existingPick) return { submitted: false, reason: 'already-picked' }
 
-	// Find the fixture where this team plays in this round
-	const fixturesInRound = await db.query.fixture.findMany({ where: eq(fixture.roundId, roundId) })
+	// Find the fixture where this team plays in this round. Ordered by kickoff
+	// so when a team has multiple fixtures in a round (e.g. PL rearrangements),
+	// the auto-submit picks the earliest one deterministically.
+	const fixturesInRound = await db.query.fixture.findMany({
+		where: eq(fixture.roundId, roundId),
+		orderBy: [asc(fixture.kickoff)],
+	})
 	const fx = fixturesInRound.find((f) => f.homeTeamId === teamId || f.awayTeamId === teamId)
 	if (!fx) return { submitted: false, reason: 'team-not-in-round' }
 

--- a/src/lib/game/cup-standings-queries.ts
+++ b/src/lib/game/cup-standings-queries.ts
@@ -81,7 +81,12 @@ export async function getCupStandingsData(
 		with: {
 			competition: true,
 			currentRound: {
-				with: { fixtures: { with: { homeTeam: true, awayTeam: true } } },
+				with: {
+					fixtures: {
+						with: { homeTeam: true, awayTeam: true },
+						orderBy: (fx, { asc }) => asc(fx.kickoff),
+					},
+				},
 			},
 			players: true,
 		},
@@ -263,7 +268,12 @@ export async function getCupLadderData(
 		with: {
 			competition: true,
 			currentRound: {
-				with: { fixtures: { with: { homeTeam: true, awayTeam: true } } },
+				with: {
+					fixtures: {
+						with: { homeTeam: true, awayTeam: true },
+						orderBy: (fx, { asc }) => asc(fx.kickoff),
+					},
+				},
 			},
 		},
 	})

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -23,7 +23,14 @@ export async function getGameDetail(gameId: string, userId: string) {
 		where: eq(game.id, gameId),
 		with: {
 			competition: true,
-			currentRound: { with: { fixtures: { with: { homeTeam: true, awayTeam: true } } } },
+			currentRound: {
+				with: {
+					fixtures: {
+						with: { homeTeam: true, awayTeam: true },
+						orderBy: (fx, { asc }) => asc(fx.kickoff),
+					},
+				},
+			},
 			players: true,
 			picks: {
 				with: {
@@ -347,7 +354,10 @@ export async function getClassicPickData(gameId: string, roundId: string, gamePl
 	const roundData = await db.query.round.findFirst({
 		where: eq(round.id, roundId),
 		with: {
-			fixtures: { with: { homeTeam: true, awayTeam: true } },
+			fixtures: {
+				with: { homeTeam: true, awayTeam: true },
+				orderBy: (fx, { asc }) => asc(fx.kickoff),
+			},
 			competition: true,
 		},
 	})
@@ -415,7 +425,10 @@ export async function getTurboPickData(gameId: string, roundId: string, gamePlay
 	const roundData = await db.query.round.findFirst({
 		where: eq(round.id, roundId),
 		with: {
-			fixtures: { with: { homeTeam: true, awayTeam: true } },
+			fixtures: {
+				with: { homeTeam: true, awayTeam: true },
+				orderBy: (fx, { asc }) => asc(fx.kickoff),
+			},
 			competition: true,
 		},
 	})
@@ -863,7 +876,14 @@ export async function getLivePayload(gameId: string, viewerUserId: string) {
 	const gameData = await db.query.game.findFirst({
 		where: eq(game.id, gameId),
 		with: {
-			currentRound: { with: { fixtures: { with: { homeTeam: true, awayTeam: true } } } },
+			currentRound: {
+				with: {
+					fixtures: {
+						with: { homeTeam: true, awayTeam: true },
+						orderBy: (fx, { asc }) => asc(fx.kickoff),
+					},
+				},
+			},
 			players: true,
 		},
 	})
@@ -926,7 +946,12 @@ export async function getClassicPlannerData(
 				with: {
 					rounds: {
 						orderBy: (r, { asc }) => asc(r.number),
-						with: { fixtures: { with: { homeTeam: true, awayTeam: true } } },
+						with: {
+							fixtures: {
+								with: { homeTeam: true, awayTeam: true },
+								orderBy: (fx, { asc }) => asc(fx.kickoff),
+							},
+						},
 					},
 				},
 			},

--- a/src/lib/game/no-pick-handler.ts
+++ b/src/lib/game/no-pick-handler.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, ne } from 'drizzle-orm'
+import { and, asc, eq, inArray, ne } from 'drizzle-orm'
 import { db } from '@/lib/db'
 import { fixture, round, team } from '@/lib/schema/competition'
 import { game, gamePlayer, pick } from '@/lib/schema/game'
@@ -86,6 +86,7 @@ async function applyRule2Classic(
 	const fixtures = await db.query.fixture.findMany({
 		where: eq(fixture.roundId, roundId),
 		with: { homeTeam: true, awayTeam: true },
+		orderBy: [asc(fixture.kickoff)],
 	})
 	const usedPicks = await db.query.pick.findMany({
 		where: and(eq(pick.gameId, gameId), eq(pick.gamePlayerId, player.id)),

--- a/src/lib/game/process-round.ts
+++ b/src/lib/game/process-round.ts
@@ -52,6 +52,7 @@ export async function processGameRound(gameId: string, roundId: string) {
 		with: {
 			fixtures: {
 				with: { homeTeam: true, awayTeam: true },
+				orderBy: (fx, { asc }) => asc(fx.kickoff),
 			},
 		},
 	})
@@ -118,7 +119,7 @@ export async function processGameRound(gameId: string, roundId: string) {
 		if (gameData.competition.type === 'group_knockout') {
 			const allRounds = await db.query.round.findMany({
 				where: eq(round.competitionId, gameData.competitionId),
-				with: { fixtures: true },
+				with: { fixtures: { orderBy: (fx, { asc }) => asc(fx.kickoff) } },
 			})
 			const finishedKnockoutFixtures: WcFixture[] = allRounds.flatMap((r) =>
 				r.fixtures.map((f) => ({

--- a/src/lib/share/data.ts
+++ b/src/lib/share/data.ts
@@ -230,7 +230,14 @@ export async function getShareLiveData(
 		with: {
 			competition: {
 				with: {
-					rounds: { with: { fixtures: { with: { homeTeam: true, awayTeam: true } } } },
+					rounds: {
+						with: {
+							fixtures: {
+								with: { homeTeam: true, awayTeam: true },
+								orderBy: (fx, { asc }) => asc(fx.kickoff),
+							},
+						},
+					},
 				},
 			},
 			players: true,


### PR DESCRIPTION
## Summary

- Drizzle's default ordering for related records is undefined; fixtures were appearing in wrong order in pick interfaces, planner views, and standings
- Adds \`orderBy: (fx, { asc }) => asc(fx.kickoff)\` to every query that loads round fixtures for display or processing
- Also makes the auto-submit fallback deterministic when a team has multiple fixtures in a round (earliest kickoff wins)

## Files touched

8 files: detail-queries, cup-standings-queries, picks API route, process-rounds cron, process-round, auto-submit, no-pick-handler, share/data.

## Test plan

- [x] Typecheck clean
- [x] Full suite passes (384/384)
- [ ] Smoke test: GW with rearranged kickoff times shows fixtures in chronological order across classic-pick, turbo-pick, cup standings, planner

🤖 Generated with [Claude Code](https://claude.com/claude-code)