### PR TITLE
feat(picks): redesign form guide with team-detail bottom sheet

### DIFF
--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -197,6 +197,8 @@ export default async function GameDetailPage({
 					gameId={game.id}
 					roundId={game.currentRound.id}
 					roundName={classicPickData.roundName}
+					roundNumber={classicPickData.roundNumber}
+					competitionId={classicPickData.competitionId}
 					deadline={classicPickData.deadline}
 					fixtures={classicPickData.fixtures}
 					usedTeamsByRound={classicPickData.usedTeamsByRound}
@@ -228,6 +230,8 @@ export default async function GameDetailPage({
 					deadline={game.currentRound.deadline}
 					readonly={game.status !== 'open'}
 					actingAs={actingAsForPickUI}
+					competitionId={game.competition.id}
+					roundNumber={game.currentRound.number}
 				/>
 			) : (
 				<div className="p-4 rounded-lg border border-border bg-card text-sm text-muted-foreground">

--- a/src/app/actions/team-form.ts
+++ b/src/app/actions/team-form.ts
@@ -1,0 +1,19 @@
+'use server'
+
+import { requireSession } from '@/lib/auth-helpers'
+import { getTeamFormDetail, type TeamFormDetail } from '@/lib/game/team-form-detail'
+
+export async function loadTeamFormDetail(input: {
+	teamId: string
+	competitionId: string
+	opponentTeamId?: string
+	beforeRoundNumber?: number
+}): Promise<TeamFormDetail | null> {
+	await requireSession()
+	return getTeamFormDetail(
+		input.teamId,
+		input.competitionId,
+		input.opponentTeamId,
+		input.beforeRoundNumber,
+	)
+}

--- a/src/components/picks/classic-pick.tsx
+++ b/src/components/picks/classic-pick.tsx
@@ -28,6 +28,8 @@ interface ClassicPickProps {
 	gameId: string
 	roundId: string
 	roundName: string
+	roundNumber: number
+	competitionId: string
 	deadline: Date | null
 	fixtures: ClassicPickFixture[]
 	usedTeamsByRound: Record<string, string>
@@ -43,6 +45,8 @@ export function ClassicPick({
 	gameId,
 	roundId,
 	roundName,
+	roundNumber,
+	competitionId,
 	deadline,
 	fixtures,
 	usedTeamsByRound,
@@ -194,6 +198,8 @@ export function ClassicPick({
 							usedLabel={usedSide === 'both' ? `Both used` : undefined}
 							onPickHome={() => handlePick(fixture, 'home')}
 							onPickAway={() => handlePick(fixture, 'away')}
+							competitionId={competitionId}
+							roundNumber={roundNumber}
 						/>
 					)
 				})}

--- a/src/components/picks/cup-pick-form.tsx
+++ b/src/components/picks/cup-pick-form.tsx
@@ -15,6 +15,8 @@ interface CupPickFormProps {
 	readonly?: boolean
 	/** When set, the admin is picking on behalf of this player. */
 	actingAs?: { gamePlayerId: string; userName: string }
+	competitionId?: string
+	roundNumber?: number
 }
 
 export function CupPickForm({
@@ -28,6 +30,8 @@ export function CupPickForm({
 	deadline,
 	readonly,
 	actingAs,
+	competitionId,
+	roundNumber,
 }: CupPickFormProps) {
 	const router = useRouter()
 
@@ -64,6 +68,8 @@ export function CupPickForm({
 			deadline={deadline}
 			readonly={readonly}
 			submitLabelOverride={actingAs ? `Submit as ${actingAs.userName}` : undefined}
+			competitionId={competitionId}
+			roundNumber={roundNumber}
 		/>
 	)
 }

--- a/src/components/picks/cup-pick.tsx
+++ b/src/components/picks/cup-pick.tsx
@@ -45,6 +45,8 @@ interface CupPickProps {
 	readonly?: boolean
 	/** When set (e.g. "Submit as Rachel" for admin acting-as), overrides the default submit label. */
 	submitLabelOverride?: string
+	competitionId?: string
+	roundNumber?: number
 }
 
 function tierForDisplay(fixture: CupPickFixture): { value: number; plusN: number; heart: boolean } {
@@ -124,6 +126,8 @@ export function CupPick({
 	deadline,
 	readonly,
 	submitLabelOverride,
+	competitionId,
+	roundNumber,
 }: CupPickProps) {
 	// Normalise initial slots into rank order (1..N) — defensive against callers passing gaps.
 	const normalisedInitial = useMemo<CupPickSlot[]>(
@@ -256,6 +260,8 @@ export function CupPick({
 									awayState={awayState}
 									onPickHome={() => handlePickTeam(f.id, 'home')}
 									onPickAway={() => handlePickTeam(f.id, 'away')}
+									competitionId={competitionId}
+									roundNumber={roundNumber}
 								/>
 							)
 						})}

--- a/src/components/picks/fixture-row.tsx
+++ b/src/components/picks/fixture-row.tsx
@@ -1,11 +1,14 @@
 'use client'
 
+import { ChevronRight } from 'lucide-react'
 import type React from 'react'
+import { useState } from 'react'
 import { cn } from '@/lib/utils'
 import { FormDots, type FormResult } from './form-dots'
 import { HeartIcon } from './heart-icon'
 import { PlusNBadge } from './plus-n-badge'
 import { TeamBadge } from './team-badge'
+import { TeamFormSheet } from './team-form-sheet'
 import { TierPips } from './tier-pips'
 
 export interface FixtureTeamInfo {
@@ -36,14 +39,16 @@ export interface FixtureRowProps {
 	onPickAway?: () => void
 	disabledSide?: 'home' | 'away' | 'both' | null
 	disabledReason?: string
-	// Tier strip (per-fixture annotations)
 	tierValue?: number
 	tierMax?: 3 | 5
 	plusN?: number
 	showHeart?: boolean
-	// Per-side state
 	homeState?: SideState
 	awayState?: SideState
+	// Required for the form-detail sheet. Optional only for old callsites that
+	// don't yet pass them — when omitted, the form row is non-tappable.
+	competitionId?: string
+	roundNumber?: number
 }
 
 export function FixtureRow({
@@ -63,9 +68,13 @@ export function FixtureRow({
 	showHeart,
 	homeState,
 	awayState,
+	competitionId,
+	roundNumber,
 }: FixtureRowProps) {
 	const isFullyUsed = usedSide === 'both'
 	const showTierStrip = tierValue != null || plusN != null || showHeart
+	const [sheetTeam, setSheetTeam] = useState<'home' | 'away' | null>(null)
+	const sheetEnabled = !!competitionId
 
 	return (
 		<div className={cn(isFullyUsed && 'opacity-30 pointer-events-none')}>
@@ -79,48 +88,154 @@ export function FixtureRow({
 					{kickoff && <span className="ml-auto">{kickoff}</span>}
 				</div>
 			)}
-			<div
-				className={cn(
-					'rounded-lg border border-border bg-card flex items-stretch transition-all overflow-hidden',
-				)}
-			>
-				<TeamPickButton
-					team={home}
-					side="home"
-					selected={selectedSide === 'home'}
-					used={usedSide === 'home'}
-					disabled={disabledSide === 'home' || disabledSide === 'both'}
-					disabledReason={disabledReason}
-					state={homeState}
-					onClick={onPickHome}
-				/>
-				<div className="flex flex-col items-center justify-center px-3 shrink-0 min-w-[64px] bg-muted/30 border-l border-r border-border">
-					<span className="text-xs text-muted-foreground font-semibold uppercase tracking-wide">
-						vs
-					</span>
-					{kickoff && !showTierStrip && (
-						<span className="text-[0.7rem] text-muted-foreground mt-1 text-center leading-tight">
-							{kickoff}
+			<div className="rounded-lg border border-border bg-card overflow-hidden">
+				<div className="flex items-stretch transition-all">
+					<TeamPickButton
+						team={home}
+						side="home"
+						selected={selectedSide === 'home'}
+						used={usedSide === 'home'}
+						disabled={disabledSide === 'home' || disabledSide === 'both'}
+						disabledReason={disabledReason}
+						state={homeState}
+						onClick={onPickHome}
+					/>
+					<div className="flex flex-col items-center justify-center px-3 shrink-0 min-w-[56px] bg-muted/30 border-l border-r border-border">
+						<span className="text-xs text-muted-foreground font-semibold uppercase tracking-wide">
+							vs
+						</span>
+						{kickoff && !showTierStrip && (
+							<span className="text-[0.7rem] text-muted-foreground mt-1 text-center leading-tight">
+								{kickoff}
+							</span>
+						)}
+					</div>
+					<TeamPickButton
+						team={away}
+						side="away"
+						selected={selectedSide === 'away'}
+						used={usedSide === 'away'}
+						disabled={disabledSide === 'away' || disabledSide === 'both'}
+						disabledReason={disabledReason}
+						state={awayState}
+						onClick={onPickAway}
+					/>
+					{usedLabel && (
+						<span className="text-[0.7rem] text-muted-foreground px-2 self-center shrink-0">
+							{usedLabel}
 						</span>
 					)}
 				</div>
-				<TeamPickButton
-					team={away}
-					side="away"
-					selected={selectedSide === 'away'}
-					used={usedSide === 'away'}
-					disabled={disabledSide === 'away' || disabledSide === 'both'}
-					disabledReason={disabledReason}
-					state={awayState}
-					onClick={onPickAway}
-				/>
-				{usedLabel && (
-					<span className="text-[0.7rem] text-muted-foreground px-2 self-center shrink-0">
-						{usedLabel}
-					</span>
+				{Boolean(home.form?.length || away.form?.length) && (
+					<FormBar
+						home={home}
+						away={away}
+						sheetEnabled={sheetEnabled}
+						onOpenSheet={(side) => setSheetTeam(side)}
+					/>
 				)}
 			</div>
+
+			{sheetEnabled && competitionId && (
+				<TeamFormSheet
+					open={sheetTeam !== null}
+					onOpenChange={(open) => {
+						if (!open) setSheetTeam(null)
+					}}
+					teamId={sheetTeam === 'home' ? home.id : away.id}
+					competitionId={competitionId}
+					opponentTeamId={sheetTeam === 'home' ? away.id : home.id}
+					beforeRoundNumber={roundNumber}
+					teamPreview={sheetTeam === 'home' ? home : away}
+					opponentPreview={
+						sheetTeam === 'home' ? { shortName: away.shortName } : { shortName: home.shortName }
+					}
+				/>
+			)}
 		</div>
+	)
+}
+
+interface FormBarProps {
+	home: FixtureTeamInfo
+	away: FixtureTeamInfo
+	sheetEnabled: boolean
+	onOpenSheet: (side: 'home' | 'away') => void
+}
+
+function FormBar({ home, away, sheetEnabled, onOpenSheet }: FormBarProps) {
+	return (
+		<div className="grid grid-cols-2 border-t border-border bg-muted/40">
+			<FormHalf
+				team={home}
+				side="home"
+				sheetEnabled={sheetEnabled}
+				onOpenSheet={() => onOpenSheet('home')}
+			/>
+			<FormHalf
+				team={away}
+				side="away"
+				sheetEnabled={sheetEnabled}
+				onOpenSheet={() => onOpenSheet('away')}
+			/>
+		</div>
+	)
+}
+
+interface FormHalfProps {
+	team: FixtureTeamInfo
+	side: 'home' | 'away'
+	sheetEnabled: boolean
+	onOpenSheet: () => void
+}
+
+function FormHalf({ team, side, sheetEnabled, onOpenSheet }: FormHalfProps) {
+	const isHome = side === 'home'
+	const content = (
+		<>
+			{team.leaguePosition != null && !isHome && (
+				<span className="text-[10px] text-muted-foreground font-medium font-mono mr-2">
+					{ordinal(team.leaguePosition)}
+				</span>
+			)}
+			{team.form && team.form.length > 0 && <FormDots results={team.form} size="sm" />}
+			{team.leaguePosition != null && isHome && (
+				<span className="text-[10px] text-muted-foreground font-medium font-mono ml-2">
+					{ordinal(team.leaguePosition)}
+				</span>
+			)}
+			{sheetEnabled && (
+				<ChevronRight
+					className={cn(
+						'w-3 h-3 text-muted-foreground/60',
+						isHome ? 'mr-0.5' : 'ml-0.5 rotate-180',
+					)}
+					aria-hidden
+				/>
+			)}
+		</>
+	)
+
+	const baseCls = cn(
+		'flex items-center px-3 py-2 transition-colors',
+		isHome ? 'flex-row-reverse justify-start' : 'flex-row justify-start',
+	)
+
+	if (!sheetEnabled) {
+		return <div className={baseCls}>{content}</div>
+	}
+	return (
+		<button
+			type="button"
+			onClick={onOpenSheet}
+			className={cn(
+				baseCls,
+				'hover:bg-muted/70 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-inset',
+			)}
+			aria-label={`Open form details for ${team.name}`}
+		>
+			{content}
+		</button>
 	)
 }
 
@@ -151,11 +266,6 @@ function TeamPickButton({
 	const stateCls = sideClass(state)
 	const chip = sideChip(state)
 
-	/*
-	 * Layout goal: symmetric, badge nearest the centre "vs" divider.
-	 * Home:  [name / position+form — right aligned]  [BADGE]
-	 * Away:  [BADGE]  [name / position+form — left aligned]
-	 */
 	return (
 		<button
 			type="button"
@@ -173,34 +283,12 @@ function TeamPickButton({
 		>
 			<TeamBadge shortName={team.shortName} badgeUrl={team.badgeUrl} size="lg" responsive />
 			<div
-				className={cn('flex flex-col gap-1.5 min-w-0 flex-1', isHome ? 'items-end' : 'items-start')}
+				className={cn('flex flex-col gap-0.5 min-w-0 flex-1', isHome ? 'items-end' : 'items-start')}
 			>
-				{/* Country/long names truncate to first chars on narrow phones — show
-				 * the 3-letter shortName instead and switch to the full name from `sm`
-				 * upward. Keeps the touch target useful and avoids "Argen…" / "C". */}
 				<span className="font-semibold text-base leading-tight truncate w-full">
 					<span className="sm:hidden">{team.shortName}</span>
 					<span className="hidden sm:inline">{team.name}</span>
 				</span>
-				<div className="flex items-center gap-2">
-					{team.leaguePosition != null && (
-						<span className="text-xs text-muted-foreground font-medium">
-							{ordinal(team.leaguePosition)}
-						</span>
-					)}
-					{/* sm-and-up uses larger dots; below sm we shrink so the form guide
-					 * stays inside the row even when the team name is long. */}
-					{team.form && team.form.length > 0 && (
-						<>
-							<span className="sm:hidden">
-								<FormDots results={team.form} size="sm" />
-							</span>
-							<span className="hidden sm:inline">
-								<FormDots results={team.form} size="md" />
-							</span>
-						</>
-					)}
-				</div>
 				{chip && <div className={cn('flex', isHome ? 'justify-end' : 'justify-start')}>{chip}</div>}
 			</div>
 		</button>

--- a/src/components/picks/team-form-sheet.tsx
+++ b/src/components/picks/team-form-sheet.tsx
@@ -1,0 +1,194 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { loadTeamFormDetail } from '@/app/actions/team-form'
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import type { TeamFormDetail } from '@/lib/game/team-form-detail'
+import { cn } from '@/lib/utils'
+import { TeamBadge } from './team-badge'
+
+interface TeamFormSheetProps {
+	open: boolean
+	onOpenChange: (open: boolean) => void
+	teamId: string
+	competitionId: string
+	opponentTeamId?: string
+	beforeRoundNumber?: number
+	// Used for the loading-state header so the sheet doesn't pop in empty.
+	teamPreview: { name: string; shortName: string; badgeUrl?: string | null }
+	opponentPreview?: { shortName: string }
+}
+
+export function TeamFormSheet({
+	open,
+	onOpenChange,
+	teamId,
+	competitionId,
+	opponentTeamId,
+	beforeRoundNumber,
+	teamPreview,
+	opponentPreview,
+}: TeamFormSheetProps) {
+	const [detail, setDetail] = useState<TeamFormDetail | null>(null)
+	const [loading, setLoading] = useState(false)
+	const [error, setError] = useState<string | null>(null)
+
+	useEffect(() => {
+		if (!open) return
+		let cancelled = false
+		setLoading(true)
+		setError(null)
+		loadTeamFormDetail({ teamId, competitionId, opponentTeamId, beforeRoundNumber })
+			.then((result) => {
+				if (cancelled) return
+				if (!result) setError('Could not load team form')
+				else setDetail(result)
+			})
+			.catch(() => {
+				if (!cancelled) setError('Could not load team form')
+			})
+			.finally(() => {
+				if (!cancelled) setLoading(false)
+			})
+		return () => {
+			cancelled = true
+		}
+	}, [open, teamId, competitionId, opponentTeamId, beforeRoundNumber])
+
+	const display = detail?.team ?? {
+		id: teamId,
+		name: teamPreview.name,
+		shortName: teamPreview.shortName,
+		badgeUrl: teamPreview.badgeUrl ?? null,
+		leaguePosition: null,
+	}
+
+	return (
+		<Sheet open={open} onOpenChange={onOpenChange}>
+			<SheetContent
+				side="bottom"
+				className="rounded-t-2xl sm:max-w-lg sm:left-1/2 sm:right-auto sm:bottom-auto sm:top-1/2 sm:rounded-2xl sm:-translate-x-1/2 sm:-translate-y-1/2"
+			>
+				<SheetHeader className="text-left">
+					<div className="flex items-center gap-3">
+						<TeamBadge
+							shortName={display.shortName}
+							badgeUrl={display.badgeUrl ?? null}
+							size="lg"
+						/>
+						<div className="flex-1 min-w-0">
+							<SheetTitle className="text-base">{display.name}</SheetTitle>
+							{detail && (
+								<div className="text-xs text-muted-foreground mt-0.5">
+									{display.leaguePosition != null && `${ordinal(display.leaguePosition)} · `}
+									{detail.seasonRecord.wins}W {detail.seasonRecord.draws}D{' '}
+									{detail.seasonRecord.losses}L this season
+								</div>
+							)}
+						</div>
+					</div>
+				</SheetHeader>
+
+				<div className="px-4 pb-6 sm:px-0 sm:pb-2 mt-4 space-y-5">
+					{loading && <div className="text-sm text-muted-foreground">Loading…</div>}
+					{error && <div className="text-sm text-destructive">{error}</div>}
+					{detail && (
+						<>
+							<section>
+								<div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+									Last {detail.recent.length} matches
+								</div>
+								<ul className="space-y-1.5">
+									{detail.recent.map((r) => (
+										<li
+											key={`${r.roundNumber}-${r.opponentShortName}`}
+											className="flex items-center gap-3 text-sm"
+										>
+											<ResultPill result={r.result} />
+											<span className="text-xs text-muted-foreground w-16 font-mono">
+												{r.home ? 'vs' : '@'} {r.opponentShortName}
+											</span>
+											<span className="font-semibold tabular-nums">
+												{r.goalsFor}–{r.goalsAgainst}
+											</span>
+											<span className="ml-auto text-xs text-muted-foreground font-mono">
+												GW{r.roundNumber}
+											</span>
+										</li>
+									))}
+									{detail.recent.length === 0 && (
+										<li className="text-sm text-muted-foreground">No completed matches yet.</li>
+									)}
+								</ul>
+							</section>
+
+							{detail.headToHead && opponentPreview && (
+								<section className="border-t pt-4">
+									<div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+										vs {opponentPreview.shortName} · last {detail.headToHead.length} meetings
+									</div>
+									{detail.headToHead.length === 0 ? (
+										<p className="text-sm text-muted-foreground">
+											No previous meetings this season.
+										</p>
+									) : (
+										<ul className="space-y-1.5">
+											{detail.headToHead.map((r) => (
+												<li
+													key={r.roundNumber}
+													className="flex items-center gap-3 text-sm tabular-nums"
+												>
+													<span className="font-mono text-xs text-muted-foreground">
+														GW{r.roundNumber}
+													</span>
+													<span
+														className={cn(r.homeTeamShortName === display.shortName && 'font-bold')}
+													>
+														{r.homeTeamShortName}
+													</span>
+													<span className="font-semibold">
+														{r.homeScore}–{r.awayScore}
+													</span>
+													<span
+														className={cn(r.awayTeamShortName === display.shortName && 'font-bold')}
+													>
+														{r.awayTeamShortName}
+													</span>
+												</li>
+											))}
+										</ul>
+									)}
+								</section>
+							)}
+						</>
+					)}
+				</div>
+			</SheetContent>
+		</Sheet>
+	)
+}
+
+function ResultPill({ result }: { result: 'W' | 'D' | 'L' }) {
+	const cls =
+		result === 'W'
+			? 'bg-[var(--alive)]'
+			: result === 'L'
+				? 'bg-[var(--eliminated)]'
+				: 'bg-[var(--draw)]'
+	return (
+		<span
+			className={cn(
+				'inline-flex items-center justify-center w-5 h-5 rounded text-[0.65rem] font-bold text-white',
+				cls,
+			)}
+		>
+			{result}
+		</span>
+	)
+}
+
+function ordinal(n: number): string {
+	const s = ['th', 'st', 'nd', 'rd']
+	const v = n % 100
+	return n + (s[(v - 20) % 10] || s[v] || s[0])
+}

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -395,6 +395,8 @@ export async function getClassicPickData(gameId: string, roundId: string, gamePl
 
 	return {
 		roundName: roundData.name ?? `GW${roundData.number}`,
+		roundNumber: roundData.number,
+		competitionId: roundData.competitionId,
 		deadline: roundData.deadline,
 		fixtures,
 		usedTeamsByRound,
@@ -455,6 +457,8 @@ export async function getTurboPickData(gameId: string, roundId: string, gamePlay
 
 	return {
 		roundName: roundData.name ?? `GW${roundData.number}`,
+		roundNumber: roundData.number,
+		competitionId: roundData.competitionId,
 		deadline: roundData.deadline,
 		fixtures,
 		existingPicks: existingPicks.map((p) => ({

--- a/src/lib/game/team-form-detail.ts
+++ b/src/lib/game/team-form-detail.ts
@@ -1,0 +1,173 @@
+import { and, asc, desc, eq, inArray, lt, or } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { fixture, round, team } from '@/lib/schema/competition'
+
+export interface TeamFormResult {
+	roundNumber: number
+	opponentShortName: string
+	opponentName: string
+	opponentBadgeUrl: string | null
+	home: boolean
+	goalsFor: number
+	goalsAgainst: number
+	result: 'W' | 'D' | 'L'
+}
+
+export interface HeadToHeadResult {
+	roundNumber: number
+	homeTeamShortName: string
+	awayTeamShortName: string
+	homeScore: number
+	awayScore: number
+}
+
+export interface TeamFormDetail {
+	team: {
+		id: string
+		name: string
+		shortName: string
+		badgeUrl: string | null
+		leaguePosition: number | null
+	}
+	seasonRecord: { wins: number; draws: number; losses: number }
+	recent: TeamFormResult[]
+	headToHead: HeadToHeadResult[] | null
+}
+
+export async function getTeamFormDetail(
+	teamId: string,
+	competitionId: string,
+	opponentTeamId?: string,
+	beforeRoundNumber?: number,
+	lastN = 8,
+): Promise<TeamFormDetail | null> {
+	const teamRow = await db.query.team.findFirst({ where: eq(team.id, teamId) })
+	if (!teamRow) return null
+
+	const finishedRows = await db
+		.select({
+			homeTeamId: fixture.homeTeamId,
+			awayTeamId: fixture.awayTeamId,
+			homeScore: fixture.homeScore,
+			awayScore: fixture.awayScore,
+			roundNumber: round.number,
+		})
+		.from(fixture)
+		.innerJoin(round, eq(round.id, fixture.roundId))
+		.where(
+			and(
+				eq(round.competitionId, competitionId),
+				eq(fixture.status, 'finished'),
+				beforeRoundNumber != null ? lt(round.number, beforeRoundNumber) : undefined,
+				or(eq(fixture.homeTeamId, teamId), eq(fixture.awayTeamId, teamId)),
+			),
+		)
+		.orderBy(desc(round.number), desc(fixture.kickoff))
+
+	const opponentIds = new Set<string>()
+	for (const r of finishedRows) {
+		opponentIds.add(r.homeTeamId === teamId ? r.awayTeamId : r.homeTeamId)
+	}
+	const opponentRows = opponentIds.size
+		? await db.query.team.findMany({ where: inArray(team.id, Array.from(opponentIds)) })
+		: []
+	const opponentMap = new Map(opponentRows.map((t) => [t.id, t]))
+
+	let wins = 0
+	let draws = 0
+	let losses = 0
+	const recent: TeamFormResult[] = []
+	for (const row of finishedRows) {
+		if (row.homeScore == null || row.awayScore == null) continue
+		const isHome = row.homeTeamId === teamId
+		const goalsFor = isHome ? row.homeScore : row.awayScore
+		const goalsAgainst = isHome ? row.awayScore : row.homeScore
+		let result: 'W' | 'D' | 'L'
+		if (goalsFor > goalsAgainst) {
+			result = 'W'
+			wins++
+		} else if (goalsFor < goalsAgainst) {
+			result = 'L'
+			losses++
+		} else {
+			result = 'D'
+			draws++
+		}
+		if (recent.length < lastN) {
+			const opponentId = isHome ? row.awayTeamId : row.homeTeamId
+			const opponent = opponentMap.get(opponentId)
+			recent.push({
+				roundNumber: row.roundNumber,
+				opponentShortName: opponent?.shortName ?? '???',
+				opponentName: opponent?.name ?? 'Unknown',
+				opponentBadgeUrl: opponent?.badgeUrl ?? null,
+				home: isHome,
+				goalsFor,
+				goalsAgainst,
+				result,
+			})
+		}
+	}
+
+	let headToHead: HeadToHeadResult[] | null = null
+	if (opponentTeamId) {
+		const h2hRows = await db
+			.select({
+				homeTeamId: fixture.homeTeamId,
+				awayTeamId: fixture.awayTeamId,
+				homeScore: fixture.homeScore,
+				awayScore: fixture.awayScore,
+				roundNumber: round.number,
+			})
+			.from(fixture)
+			.innerJoin(round, eq(round.id, fixture.roundId))
+			.where(
+				and(
+					eq(round.competitionId, competitionId),
+					eq(fixture.status, 'finished'),
+					or(
+						and(eq(fixture.homeTeamId, teamId), eq(fixture.awayTeamId, opponentTeamId)),
+						and(eq(fixture.homeTeamId, opponentTeamId), eq(fixture.awayTeamId, teamId)),
+					),
+				),
+			)
+			.orderBy(desc(round.number))
+			.limit(5)
+
+		const teamShortNames = new Map<string, string>()
+		teamShortNames.set(teamRow.id, teamRow.shortName)
+		const opp = opponentMap.get(opponentTeamId)
+		if (opp) teamShortNames.set(opp.id, opp.shortName)
+		// Fallback for opponent not in the loaded set (unlikely but defensive).
+		if (!teamShortNames.has(opponentTeamId)) {
+			const oppRow = await db.query.team.findFirst({ where: eq(team.id, opponentTeamId) })
+			if (oppRow) teamShortNames.set(oppRow.id, oppRow.shortName)
+		}
+
+		headToHead = h2hRows
+			.filter((r) => r.homeScore != null && r.awayScore != null)
+			.map((r) => ({
+				roundNumber: r.roundNumber,
+				homeTeamShortName: teamShortNames.get(r.homeTeamId) ?? '???',
+				awayTeamShortName: teamShortNames.get(r.awayTeamId) ?? '???',
+				homeScore: r.homeScore as number,
+				awayScore: r.awayScore as number,
+			}))
+	}
+
+	// Suppress unused-var lint when ascending pulls aren't needed; asc imported for symmetry with detail-queries.ts patterns.
+	void asc
+
+	return {
+		team: {
+			id: teamRow.id,
+			name: teamRow.name,
+			shortName: teamRow.shortName,
+			badgeUrl: teamRow.badgeUrl,
+			leaguePosition: teamRow.leaguePosition,
+		},
+		seasonRecord: { wins, draws, losses },
+		recent,
+		headToHead,
+	}
+}


### PR DESCRIPTION
## Summary

The form guide had two compounding bugs on mobile:
- Only 4 of 6 W/D/L pills fit (overflow-hidden was clipping the form row)
- The home side showed results 3-6 instead of 0-3 because \`items-end\` pushed the row right and clipping cut from the left

This PR ports the **Option D mockup** ([form-guide-mockups.html](https://wsl.localhost/Ubuntu/tmp/form-guide-mockups.html)) — form moves to its own row below team identity, full-width, both teams visible. Each side of the new form bar is a button that opens a bottom sheet (mobile) / centred modal (desktop) with team detail.

## What you see

- **Top of card**: badge + name + vs + name + badge (clean team identity, picks still a single tap)
- **Form row below**: home form pills on the left, away form pills on the right, each with a tap-target chevron
- **Tap a form**: bottom sheet shows last 8 matches (opponent, score, GW), plus head-to-head record vs the opposite team in this fixture

## Files

- New: \`src/lib/game/team-form-detail.ts\` — query for last N matches + head-to-head
- New: \`src/app/actions/team-form.ts\` — server action wrapping the query
- New: \`src/components/picks/team-form-sheet.tsx\` — bottom-sheet UI
- Modified: \`src/components/picks/fixture-row.tsx\` — restructured into top row (team identity) + form bar (tappable)
- Threaded \`competitionId\` + \`roundNumber\` from server queries through ClassicPick / CupPickForm into FixtureRow

Turbo's UI doesn't use FixtureRow — its form display is unchanged here.

## Test plan

- [x] Typecheck clean
- [x] Tests pass (384/384)
- [ ] Smoke: open a classic game on mobile, confirm 6 pills visible both sides, tap each form to open the sheet, verify last-N + h2h
- [ ] Smoke desktop: same, sheet renders centred

🤖 Generated with [Claude Code](https://claude.com/claude-code)