### PR TITLE
fix(picks): handle teams with multiple fixtures in a round (re-targeted to main)

### DIFF
--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -203,6 +203,7 @@ export default async function GameDetailPage({
 					fixtures={classicPickData.fixtures}
 					usedTeamsByRound={classicPickData.usedTeamsByRound}
 					existingPickTeamId={classicPickData.existingPickTeamId}
+					existingPickFixtureId={classicPickData.existingPickFixtureId}
 					chain={classicPlannerData?.chain}
 					futureRounds={classicPlannerData?.futureRounds}
 					actingAs={actingAsForPickUI}

--- a/src/app/api/picks/[gameId]/[roundId]/route.ts
+++ b/src/app/api/picks/[gameId]/[roundId]/route.ts
@@ -89,7 +89,7 @@ export async function POST(request: Request, { params }: { params: Params }) {
 	}
 
 	if (gameData.gameMode === 'classic') {
-		const { teamId } = body as { teamId: string }
+		const { teamId, fixtureId } = body as { teamId: string; fixtureId?: string }
 
 		// Get previously used teams (for the TARGET player, not the admin)
 		const previousPicks = await db.query.pick.findMany({
@@ -98,6 +98,25 @@ export async function POST(request: Request, { params }: { params: Params }) {
 		const usedTeamIds = previousPicks.filter((p) => p.roundId !== roundId).map((p) => p.teamId)
 
 		const fixtureTeamIds = roundData.fixtures.flatMap((f) => [f.homeTeamId, f.awayTeamId])
+
+		// If fixtureId provided, verify it's in this round and the team plays in
+		// it. Required for the multi-fixture-per-team case (e.g. PL rearrangements
+		// where Man City plays twice in GW36 — picking the team alone is ambiguous).
+		// Falls back to .find() for backwards compat with old clients (will pick
+		// the earliest fixture by kickoff because the query is now ordered).
+		let resolvedFixture = roundData.fixtures.find(
+			(f) => f.homeTeamId === teamId || f.awayTeamId === teamId,
+		)
+		if (fixtureId) {
+			const fx = roundData.fixtures.find((f) => f.id === fixtureId)
+			if (!fx) {
+				return NextResponse.json({ error: 'fixture-not-in-round' }, { status: 400 })
+			}
+			if (fx.homeTeamId !== teamId && fx.awayTeamId !== teamId) {
+				return NextResponse.json({ error: 'team-not-in-fixture' }, { status: 400 })
+			}
+			resolvedFixture = fx
+		}
 
 		const allowEliminatedRebuy = Boolean(
 			body.actingAs && targetGamePlayer.eliminatedReason === 'missed_rebuy_pick',
@@ -161,11 +180,6 @@ export async function POST(request: Request, { params }: { params: Params }) {
 			}
 		}
 
-		// Find the fixture this team is in
-		const teamFixture = roundData.fixtures.find(
-			(f) => f.homeTeamId === teamId || f.awayTeamId === teamId,
-		)
-
 		// Delete existing pick for this player+round if it exists, then insert new one.
 		// We cannot use onConflictDoUpdate because the unique index includes confidenceRank,
 		// which is null for classic picks, and PostgreSQL treats nulls as distinct.
@@ -185,7 +199,7 @@ export async function POST(request: Request, { params }: { params: Params }) {
 					gamePlayerId: targetGamePlayer.id,
 					roundId,
 					teamId,
-					fixtureId: teamFixture?.id,
+					fixtureId: resolvedFixture?.id,
 				})
 				.returning()
 			newPick = picks[0]

--- a/src/components/picks/classic-pick.tsx
+++ b/src/components/picks/classic-pick.tsx
@@ -34,11 +34,17 @@ interface ClassicPickProps {
 	fixtures: ClassicPickFixture[]
 	usedTeamsByRound: Record<string, string>
 	existingPickTeamId: string | null
+	existingPickFixtureId: string | null
 	chain?: { slots: ChainSlot[]; summary: ChainSummary }
 	futureRounds?: PlannerRoundInput[]
 	planHandlers?: ClassicPickPlanHandlers
 	/** When set, the admin is picking on behalf of this player. */
 	actingAs?: { gamePlayerId: string; userName: string }
+}
+
+interface PickSelection {
+	fixtureId: string
+	teamId: string
 }
 
 export function ClassicPick({
@@ -51,13 +57,18 @@ export function ClassicPick({
 	fixtures,
 	usedTeamsByRound,
 	existingPickTeamId,
+	existingPickFixtureId,
 	chain,
 	futureRounds,
 	planHandlers,
 	actingAs,
 }: ClassicPickProps) {
 	const router = useRouter()
-	const [selectedTeamId, setSelectedTeamId] = useState<string | null>(existingPickTeamId)
+	const initialSelection: PickSelection | null =
+		existingPickTeamId && existingPickFixtureId
+			? { fixtureId: existingPickFixtureId, teamId: existingPickTeamId }
+			: null
+	const [selection, setSelection] = useState<PickSelection | null>(initialSelection)
 	const [loading, setLoading] = useState(false)
 	const [error, setError] = useState<string | null>(null)
 	// Collapse fixtures by default if a pick is already locked in
@@ -66,19 +77,28 @@ export function ClassicPick({
 	function handlePick(fixture: ClassicPickFixture, side: 'home' | 'away') {
 		const teamId = side === 'home' ? fixture.home.id : fixture.away.id
 		if (usedTeamsByRound[teamId]) return
-		setSelectedTeamId(teamId === selectedTeamId ? null : teamId)
+		// Toggle off if clicking the same team in the same fixture; otherwise move
+		// the selection to (this fixture, this team). Picking a different fixture
+		// for the same team still moves the selection — the team isn't "used"
+		// against itself, just relocated.
+		if (selection?.fixtureId === fixture.id && selection?.teamId === teamId) {
+			setSelection(null)
+		} else {
+			setSelection({ fixtureId: fixture.id, teamId })
+		}
 		setError(null)
 	}
 
 	async function handleSubmit() {
-		if (!selectedTeamId) return
+		if (!selection) return
 		setLoading(true)
 		setError(null)
 		const res = await fetch(`/api/picks/${gameId}/${roundId}`, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({
-				teamId: selectedTeamId,
+				teamId: selection.teamId,
+				fixtureId: selection.fixtureId,
 				...(actingAs ? { actingAs: actingAs.gamePlayerId } : {}),
 			}),
 		})
@@ -93,16 +113,21 @@ export function ClassicPick({
 		router.refresh()
 	}
 
-	const selectedFixture = fixtures.find(
-		(f) => f.home.id === selectedTeamId || f.away.id === selectedTeamId,
-	)
-	const selectedTeam =
-		selectedFixture?.home.id === selectedTeamId ? selectedFixture?.home : selectedFixture?.away
-	const selectedSide = selectedFixture?.home.id === selectedTeamId ? 'home' : 'away'
+	const selectedFixture = selection ? fixtures.find((f) => f.id === selection.fixtureId) : null
+	const selectedTeam = selectedFixture
+		? selectedFixture.home.id === selection?.teamId
+			? selectedFixture.home
+			: selectedFixture.away
+		: null
+	const selectedSide: 'home' | 'away' | undefined = selectedFixture
+		? selectedFixture.home.id === selection?.teamId
+			? 'home'
+			: 'away'
+		: undefined
 
 	// Find the fixture for the existing (locked) pick
-	const lockedFixture = existingPickTeamId
-		? fixtures.find((f) => f.home.id === existingPickTeamId || f.away.id === existingPickTeamId)
+	const lockedFixture = existingPickFixtureId
+		? fixtures.find((f) => f.id === existingPickFixtureId)
 		: null
 	const lockedTeam = lockedFixture
 		? lockedFixture.home.id === existingPickTeamId
@@ -173,19 +198,29 @@ export function ClassicPick({
 				</div>
 
 				{fixtures.map((fixture) => {
-					const homeUsed = usedTeamsByRound[fixture.home.id]
-					const awayUsed = usedTeamsByRound[fixture.away.id]
+					const isSelectedFixture = fixture.id === selection?.fixtureId
+					// "Used in another fixture this round": the team has been clicked in a
+					// DIFFERENT fixture in this round. Treats Man City vs Brentford and Man
+					// City vs Crystal Palace as alternate slots for the same team, with one
+					// pick burning the team for the round (Option B + grey-out per UX call).
+					const homeUsedThisRound = !isSelectedFixture && selection?.teamId === fixture.home.id
+					const awayUsedThisRound = !isSelectedFixture && selection?.teamId === fixture.away.id
+					const homeUsedPriorRound = !!usedTeamsByRound[fixture.home.id]
+					const awayUsedPriorRound = !!usedTeamsByRound[fixture.away.id]
+
+					const homeUsed = homeUsedThisRound || homeUsedPriorRound
+					const awayUsed = awayUsedThisRound || awayUsedPriorRound
+
 					let usedSide: 'home' | 'away' | 'both' | null = null
 					if (homeUsed && awayUsed) usedSide = 'both'
 					else if (homeUsed) usedSide = 'home'
 					else if (awayUsed) usedSide = 'away'
 
-					const selected =
-						fixture.home.id === selectedTeamId
+					const selected = isSelectedFixture
+						? fixture.home.id === selection?.teamId
 							? 'home'
-							: fixture.away.id === selectedTeamId
-								? 'away'
-								: null
+							: 'away'
+						: null
 
 					return (
 						<FixtureRow
@@ -212,14 +247,18 @@ export function ClassicPick({
 							selectedSide === 'home' ? selectedFixture.away.name : selectedFixture.home.name
 						} (${selectedSide === 'home' ? 'H' : 'A'})`}
 						actionLabel={
-							existingPickTeamId === selectedTeamId
+							existingPickFixtureId === selection?.fixtureId &&
+							existingPickTeamId === selection?.teamId
 								? 'Already locked'
 								: actingAs
 									? `Submit as ${actingAs.userName}`
 									: 'Lock in pick'
 						}
 						onConfirm={handleSubmit}
-						disabled={existingPickTeamId === selectedTeamId}
+						disabled={
+							existingPickFixtureId === selection?.fixtureId &&
+							existingPickTeamId === selection?.teamId
+						}
 						loading={loading}
 					/>
 				)}

--- a/src/lib/game-logic/classic.test.ts
+++ b/src/lib/game-logic/classic.test.ts
@@ -128,4 +128,72 @@ describe('goals tracking on wins', () => {
 		const result = processClassicRound(input)
 		expect(result.results[0].goalsScored).toBe(0)
 	})
+
+	describe('multi-fixture-per-team', () => {
+		it('uses pickedFixtureId to disambiguate when team plays twice', () => {
+			// Man City plays both Brentford and Crystal Palace in GW36; player picked
+			// the Crystal Palace fixture and that one was a 0-2 loss while the
+			// Brentford fixture was a 4-0 win.
+			const cityVsBrentford = makeFixture('mci', 'bre', 4, 0)
+			const cityVsPalace = makeFixture('mci', 'cry', 0, 2)
+			const input: ClassicRoundInput = {
+				players: [
+					{
+						gamePlayerId: 'p1',
+						pickedTeamId: 'mci',
+						pickedFixtureId: cityVsPalace.id,
+					},
+				],
+				fixtures: [cityVsBrentford, cityVsPalace],
+			}
+			const result = processClassicRound(input)
+			// Should be evaluated against Palace fixture (loss), not Brentford (win).
+			expect(result.results[0].result).toBe('loss')
+			expect(result.results[0].eliminated).toBe(true)
+			expect(result.results[0].goalsScored).toBe(0)
+		})
+
+		it('falls back to first matching fixture when pickedFixtureId is missing (legacy picks)', () => {
+			// Older picks rows might not have a fixtureId stored; the resolver should
+			// pick the first fixture in the input array that features the team.
+			// Production callers sort fixtures by kickoff so this is deterministic.
+			const cityVsBrentford = makeFixture('mci', 'bre', 4, 0)
+			const cityVsPalace = makeFixture('mci', 'cry', 0, 2)
+			const input: ClassicRoundInput = {
+				players: [{ gamePlayerId: 'p1', pickedTeamId: 'mci' }],
+				fixtures: [cityVsBrentford, cityVsPalace],
+			}
+			const result = processClassicRound(input)
+			// Falls through to first fixture (Brentford win).
+			expect(result.results[0].result).toBe('win')
+			expect(result.results[0].goalsScored).toBe(4)
+		})
+
+		it('does not let one fixture overwrite another when team plays twice', () => {
+			// Regression for the previous fixturesByTeam Map bug: with the same team
+			// in two fixtures, the second write would overwrite the first, so a
+			// player who picked the first fixture would be evaluated against the
+			// second. With explicit pickedFixtureId this no longer happens.
+			const cityVsBrentford = makeFixture('mci', 'bre', 4, 0)
+			const cityVsPalace = makeFixture('mci', 'cry', 0, 2)
+			const input: ClassicRoundInput = {
+				players: [
+					{
+						gamePlayerId: 'p1',
+						pickedTeamId: 'mci',
+						pickedFixtureId: cityVsBrentford.id,
+					},
+					{
+						gamePlayerId: 'p2',
+						pickedTeamId: 'mci',
+						pickedFixtureId: cityVsPalace.id,
+					},
+				],
+				fixtures: [cityVsBrentford, cityVsPalace],
+			}
+			const result = processClassicRound(input)
+			expect(result.results[0].result).toBe('win')
+			expect(result.results[1].result).toBe('loss')
+		})
+	})
 })

--- a/src/lib/game-logic/classic.ts
+++ b/src/lib/game-logic/classic.ts
@@ -3,6 +3,15 @@ import { determinePickResult, type PickResult } from './common'
 export interface ClassicPlayerPick {
 	gamePlayerId: string
 	pickedTeamId: string
+	/**
+	 * The specific fixture the player picked. Required when a team has more
+	 * than one fixture in a round (e.g. PL rearrangements). When multiple
+	 * fixtures exist for the picked team and pickedFixtureId is null, falls
+	 * back to the first matching fixture in the input array — which is now
+	 * deterministic (kickoff-ordered) but legacy data may not have a stored
+	 * fixtureId, hence the defensive fallback.
+	 */
+	pickedFixtureId?: string | null
 }
 
 export interface ClassicFixture {
@@ -31,14 +40,28 @@ export interface ClassicRoundOutput {
 }
 
 export function processClassicRound(input: ClassicRoundInput): ClassicRoundOutput {
-	const fixturesByTeam = new Map<string, ClassicFixture>()
+	// Index by fixture id (unique) for explicit-fixture lookups.
+	const fixturesById = new Map<string, ClassicFixture>()
 	for (const f of input.fixtures) {
-		fixturesByTeam.set(f.homeTeamId, f)
-		fixturesByTeam.set(f.awayTeamId, f)
+		fixturesById.set(f.id, f)
+	}
+
+	function resolveFixture(player: ClassicPlayerPick): ClassicFixture | undefined {
+		// Explicit fixtureId wins. This is the path for any pick made post-fix.
+		if (player.pickedFixtureId) {
+			const explicit = fixturesById.get(player.pickedFixtureId)
+			if (explicit) return explicit
+		}
+		// Fallback for legacy picks (no fixtureId stored). Walk the input array
+		// in order, return the first fixture featuring the team. Caller controls
+		// the order — production callers sort by kickoff so this is deterministic.
+		return input.fixtures.find(
+			(f) => f.homeTeamId === player.pickedTeamId || f.awayTeamId === player.pickedTeamId,
+		)
 	}
 
 	const results: ClassicPlayerResult[] = input.players.map((player) => {
-		const fixture = fixturesByTeam.get(player.pickedTeamId)
+		const fixture = resolveFixture(player)
 		if (!fixture) {
 			return {
 				gamePlayerId: player.gamePlayerId,

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -411,6 +411,7 @@ export async function getClassicPickData(gameId: string, roundId: string, gamePl
 		fixtures,
 		usedTeamsByRound,
 		existingPickTeamId: currentPick?.teamId ?? null,
+		existingPickFixtureId: currentPick?.fixtureId ?? null,
 	}
 }
 

--- a/src/lib/game/process-round.ts
+++ b/src/lib/game/process-round.ts
@@ -84,6 +84,7 @@ export async function processGameRound(gameId: string, roundId: string) {
 			return {
 				gamePlayerId: p.id,
 				pickedTeamId: playerPick?.teamId ?? '',
+				pickedFixtureId: playerPick?.fixtureId ?? null,
 			}
 		})
 


### PR DESCRIPTION
## Summary

PR #31 was accidentally based on \`feat/form-guide-redesign\` instead of main, so when that branch's PR (#30) was squash-merged, this content stayed on the feature branch and never reached main. This PR cherry-picks the same commit onto main directly.

Same content as PR #31 — see that PR for full description.

## Test plan

- [x] Typecheck clean against main
- [x] Full suite passes (387/387)
- [ ] Smoke once deployed: in a round where a team has 2 fixtures, click both rows — only one stays selected, the other greys out

🤖 Generated with [Claude Code](https://claude.com/claude-code)