### PR TITLE
fix(ui): render kickoffs and deadlines in user's local timezone

### DIFF
--- a/src/components/game/payments-panel.tsx
+++ b/src/components/game/payments-panel.tsx
@@ -162,5 +162,11 @@ function rowSubtitle(p: AdminPayment): string {
 }
 
 function formatDate(d: Date): string {
-	return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
+	// Admin-facing payment confirmations. Pinned to Europe/London for stability;
+	// admins are UK-based and the day/month label doesn't shift across most TZs.
+	return d.toLocaleDateString('en-GB', {
+		day: 'numeric',
+		month: 'short',
+		timeZone: 'Europe/London',
+	})
 }

--- a/src/components/game/rebuy-banner.tsx
+++ b/src/components/game/rebuy-banner.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { toast } from 'sonner'
+import { LocalDateTime } from '@/components/local-datetime'
 
 interface RebuyBannerProps {
 	gameId: string
@@ -50,12 +51,12 @@ export function RebuyBanner({
 		}
 	}
 
-	const deadlineStr = round2Deadline.toLocaleString('en-GB', {
-		day: 'numeric',
-		month: 'short',
-		hour: '2-digit',
-		minute: '2-digit',
-	})
+	const deadlineLabel = (
+		<LocalDateTime
+			date={round2Deadline}
+			options={{ day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' }}
+		/>
+	)
 
 	if (pendingPayment) {
 		return (
@@ -85,7 +86,7 @@ export function RebuyBanner({
 				You're out of round 1 — buy back in for £{entryFee}
 			</div>
 			<p className="mt-1 text-xs text-muted-foreground">
-				Rebuys close at the round 2 deadline ({deadlineStr}).
+				Rebuys close at the round 2 deadline ({deadlineLabel}).
 			</p>
 			<button
 				type="button"

--- a/src/components/local-datetime.test.ts
+++ b/src/components/local-datetime.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { formatLondon } from './local-datetime'
+
+describe('formatLondon', () => {
+	it('formats a UTC ISO string in Europe/London (BST in July)', () => {
+		// 2026-07-15T14:00:00Z is 15:00 BST in London.
+		const result = formatLondon('2026-07-15T14:00:00Z')
+		expect(result).toContain('15:00')
+		expect(result).toContain('Wed')
+	})
+
+	it('formats a UTC ISO string in Europe/London (GMT in January)', () => {
+		// 2026-01-15T14:00:00Z is 14:00 GMT in London (no DST).
+		const result = formatLondon('2026-01-15T14:00:00Z')
+		expect(result).toContain('14:00')
+		expect(result).toContain('Thu')
+	})
+
+	it('handles DST transitions deterministically', () => {
+		// Spring forward: 2026-03-29 01:00 GMT becomes 02:00 BST.
+		// A fixture at 2026-03-29T14:30:00Z is 15:30 BST (post-clock-change).
+		const result = formatLondon('2026-03-29T14:30:00Z')
+		expect(result).toContain('15:30')
+	})
+
+	it('accepts a Date object', () => {
+		const d = new Date('2026-07-15T14:00:00Z')
+		const result = formatLondon(d)
+		expect(result).toContain('15:00')
+	})
+
+	it('respects custom format options', () => {
+		const result = formatLondon('2026-07-15T14:00:00Z', {
+			day: 'numeric',
+			month: 'short',
+		})
+		// Should NOT contain time fields
+		expect(result).not.toContain('15:00')
+		expect(result).toContain('15')
+		expect(result).toContain('Jul')
+	})
+})

--- a/src/components/local-datetime.tsx
+++ b/src/components/local-datetime.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+/**
+ * SSR fallback timezone. The vast majority of users are UK-based, so we render
+ * UK time during the initial paint. After hydration, useEffect re-formats with
+ * the browser's actual timezone — UK users see no change, users abroad see a
+ * brief swap to their local time.
+ *
+ * This avoids both the "show UTC by default because Vercel runs in UTC" bug
+ * and the hydration-warning churn that comes from rendering different strings
+ * on server vs client.
+ */
+const SSR_TIMEZONE = 'Europe/London'
+
+const DEFAULT_OPTS: Intl.DateTimeFormatOptions = {
+	weekday: 'short',
+	day: 'numeric',
+	month: 'short',
+	hour: '2-digit',
+	minute: '2-digit',
+}
+
+interface LocalDateTimeProps {
+	/** ISO string or Date. Null/undefined renders the fallback. */
+	date: string | Date | null | undefined
+	options?: Intl.DateTimeFormatOptions
+	locale?: string
+	fallback?: React.ReactNode
+	className?: string
+}
+
+function toDate(date: string | Date): Date {
+	return date instanceof Date ? date : new Date(date)
+}
+
+function formatWithOpts(
+	date: Date,
+	opts: Intl.DateTimeFormatOptions,
+	locale: string,
+	timeZone?: string,
+): string {
+	const merged = timeZone ? { ...opts, timeZone } : opts
+	return new Intl.DateTimeFormat(locale, merged).format(date)
+}
+
+export function LocalDateTime({
+	date,
+	options,
+	locale = 'en-GB',
+	fallback = null,
+	className,
+}: LocalDateTimeProps) {
+	const opts = options ?? DEFAULT_OPTS
+	// Stable primitive key for the Date — treats `new Date(iso)` and the same
+	// `iso` string identically, so re-renders that pass a fresh Date don't
+	// retrigger the effect.
+	const isoKey = date == null ? null : date instanceof Date ? date.getTime() : date
+	const [browserText, setBrowserText] = useState<string | null>(null)
+
+	useEffect(() => {
+		if (isoKey == null) {
+			setBrowserText(null)
+			return
+		}
+		const d = typeof isoKey === 'number' ? new Date(isoKey) : new Date(isoKey)
+		setBrowserText(formatWithOpts(d, opts, locale))
+	}, [isoKey, opts, locale])
+
+	if (date == null) return <>{fallback}</>
+
+	const d = toDate(date)
+	const ssrText = formatWithOpts(d, opts, locale, SSR_TIMEZONE)
+
+	return (
+		<span suppressHydrationWarning className={className}>
+			{browserText ?? ssrText}
+		</span>
+	)
+}
+
+/**
+ * Server-side formatter for places where a React component can't render
+ * (e.g. share/OG image generation, cron logs). Always uses Europe/London —
+ * the same SSR fallback the client component uses, so output is consistent
+ * between server-only and client paths.
+ */
+export function formatLondon(
+	date: string | Date,
+	options: Intl.DateTimeFormatOptions = DEFAULT_OPTS,
+	locale = 'en-GB',
+): string {
+	return formatWithOpts(toDate(date), options, locale, SSR_TIMEZONE)
+}

--- a/src/components/picks/cup-pick.tsx
+++ b/src/components/picks/cup-pick.tsx
@@ -2,6 +2,7 @@
 
 import { ChevronDown, ChevronUp, X } from 'lucide-react'
 import { useMemo, useState } from 'react'
+import { LocalDateTime } from '@/components/local-datetime'
 import { cn } from '@/lib/utils'
 import { FixtureRow, type SideState } from './fixture-row'
 import { HeartIcon } from './heart-icon'
@@ -84,36 +85,6 @@ function computeProjectedGain(slots: CupPickSlot[], fixtures: CupPickFixture[]):
 		}
 	}
 	return total
-}
-
-function formatKickoff(kickoff: Date | null): string | undefined {
-	if (!kickoff) return undefined
-	try {
-		return kickoff.toLocaleString(undefined, {
-			weekday: 'short',
-			day: 'numeric',
-			month: 'short',
-			hour: '2-digit',
-			minute: '2-digit',
-		})
-	} catch {
-		return undefined
-	}
-}
-
-function formatDeadlineLabel(deadline: Date | null | undefined): string {
-	if (!deadline) return 'Deadline not set'
-	try {
-		return `Deadline ${deadline.toLocaleString(undefined, {
-			weekday: 'short',
-			day: 'numeric',
-			month: 'short',
-			hour: '2-digit',
-			minute: '2-digit',
-		})}`
-	} catch {
-		return 'Deadline not set'
-	}
 }
 
 export function CupPick({
@@ -208,7 +179,6 @@ export function CupPick({
 	}
 
 	const projectedGain = computeProjectedGain(slots, fixtures)
-	const deadlineLabel = formatDeadlineLabel(deadline ?? null)
 
 	return (
 		<div className="space-y-3">
@@ -218,7 +188,14 @@ export function CupPick({
 				projectedGain={projectedGain}
 			/>
 			<div className="rounded-lg bg-foreground text-background px-3 py-2 text-xs">
-				{deadlineLabel} · rank {numberOfPicks} picks
+				{deadline ? (
+					<>
+						Deadline <LocalDateTime date={deadline} />
+					</>
+				) : (
+					'Deadline not set'
+				)}{' '}
+				· rank {numberOfPicks} picks
 			</div>
 			<div className="grid gap-3 md:grid-cols-[1fr_320px]">
 				<div>
@@ -250,7 +227,7 @@ export function CupPick({
 										shortName: f.awayShort,
 										badgeUrl: f.awayBadgeUrl,
 									}}
-									kickoff={formatKickoff(f.kickoff)}
+									kickoff={f.kickoff}
 									selectedSide={slot?.pickedSide ?? null}
 									tierValue={tier.value}
 									tierMax={3}

--- a/src/components/picks/fixture-row.tsx
+++ b/src/components/picks/fixture-row.tsx
@@ -3,6 +3,7 @@
 import { ChevronRight } from 'lucide-react'
 import type React from 'react'
 import { useState } from 'react'
+import { LocalDateTime } from '@/components/local-datetime'
 import { cn } from '@/lib/utils'
 import { FormDots, type FormResult } from './form-dots'
 import { HeartIcon } from './heart-icon'
@@ -31,7 +32,8 @@ export type SideState =
 export interface FixtureRowProps {
 	home: FixtureTeamInfo
 	away: FixtureTeamInfo
-	kickoff?: string
+	/** ISO string. Rendered in the user's local timezone via <LocalDateTime />. */
+	kickoff?: string | Date | null
 	selectedSide?: 'home' | 'away' | null
 	usedSide?: 'home' | 'away' | 'both' | null
 	usedLabel?: string
@@ -85,7 +87,11 @@ export function FixtureRow({
 						<TierPips value={tierValue as 0 | 1 | 2 | 3 | 4 | 5} max={tierMax} />
 					)}
 					{plusN != null && <PlusNBadge value={plusN} />}
-					{kickoff && <span className="ml-auto">{kickoff}</span>}
+					{kickoff && (
+						<span className="ml-auto">
+							<LocalDateTime date={kickoff} />
+						</span>
+					)}
 				</div>
 			)}
 			<div className="rounded-lg border border-border bg-card overflow-hidden">
@@ -105,9 +111,10 @@ export function FixtureRow({
 							vs
 						</span>
 						{kickoff && !showTierStrip && (
-							<span className="text-[0.7rem] text-muted-foreground mt-1 text-center leading-tight">
-								{kickoff}
-							</span>
+							<LocalDateTime
+								date={kickoff}
+								className="text-[0.7rem] text-muted-foreground mt-1 text-center leading-tight"
+							/>
 						)}
 					</div>
 					<TeamPickButton

--- a/src/components/picks/planner-round.tsx
+++ b/src/components/picks/planner-round.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { LocalDateTime } from '@/components/local-datetime'
 import { cn } from '@/lib/utils'
 import { FixtureRow } from './fixture-row'
 
@@ -67,7 +68,11 @@ export function PlannerRound(props: PlannerRoundProps) {
 					</div>
 					{props.deadline && (
 						<div className="text-[11px] text-muted-foreground">
-							Deadline {formatDeadline(props.deadline)}
+							Deadline{' '}
+							<LocalDateTime
+								date={props.deadline}
+								options={{ weekday: 'short', day: 'numeric', month: 'short' }}
+							/>
 						</div>
 					)}
 				</div>
@@ -120,7 +125,7 @@ export function PlannerRound(props: PlannerRoundProps) {
 							name: f.awayTeam.name,
 							badgeUrl: f.awayTeam.badgeUrl,
 						}}
-						kickoff={f.kickoff ? formatKickoff(f.kickoff) : undefined}
+						kickoff={f.kickoff ?? undefined}
 						homeState={
 							homeIsPlan
 								? { kind: planKind }
@@ -159,18 +164,4 @@ export function PlannerRound(props: PlannerRoundProps) {
 			)}
 		</div>
 	)
-}
-
-function formatDeadline(d: Date): string {
-	return d.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' })
-}
-
-function formatKickoff(d: Date): string {
-	return d.toLocaleString('en-GB', {
-		weekday: 'short',
-		day: 'numeric',
-		month: 'short',
-		hour: '2-digit',
-		minute: '2-digit',
-	})
 }

--- a/src/components/standings/cup-ladder.tsx
+++ b/src/components/standings/cup-ladder.tsx
@@ -2,6 +2,7 @@
 
 import { AlertTriangle, CheckCircle2, Flame, Target, Zap } from 'lucide-react'
 import { useLiveGame } from '@/components/live/use-live-game'
+import { LocalDateTime } from '@/components/local-datetime'
 import { HeartIcon } from '@/components/picks/heart-icon'
 import { PlusNBadge } from '@/components/picks/plus-n-badge'
 import { TeamBadge } from '@/components/picks/team-badge'
@@ -221,13 +222,15 @@ function CupFixtureCard({
 								vs
 							</span>
 							{fixture.kickoff && (
-								<span className="text-[0.7rem] text-muted-foreground mt-1 text-center leading-tight">
-									{fixture.kickoff.toLocaleDateString('en-GB', { weekday: 'short' })}{' '}
-									{fixture.kickoff.toLocaleTimeString('en-GB', {
+								<LocalDateTime
+									date={fixture.kickoff}
+									options={{
+										weekday: 'short',
 										hour: '2-digit',
 										minute: '2-digit',
-									})}
-								</span>
+									}}
+									className="text-[0.7rem] text-muted-foreground mt-1 text-center leading-tight"
+								/>
 							)}
 						</>
 					)}

--- a/src/components/standings/cup-timeline.tsx
+++ b/src/components/standings/cup-timeline.tsx
@@ -2,6 +2,7 @@
 
 import { XCircle } from 'lucide-react'
 import { useLiveGame } from '@/components/live/use-live-game'
+import { LocalDateTime } from '@/components/local-datetime'
 import type { CupLadderData, CupLadderFixture } from '@/lib/game/cup-standings-queries'
 import { cn } from '@/lib/utils'
 
@@ -12,9 +13,8 @@ interface CupTimelineProps {
 // A "kickoff slot" is a unique kickoff time across the round's fixtures.
 interface KickoffSlot {
 	key: string
-	label: string // e.g. "Sat 15:00"
-	fullLabel: string // e.g. "Sat 17 Jan, 15:00"
-	time: number // epoch ms
+	kickoff: Date // header rendered via <LocalDateTime />
+	time: number // epoch ms — used for sorting only
 	fixtures: CupLadderFixture[]
 }
 
@@ -51,8 +51,7 @@ export function CupTimeline({ data }: CupTimelineProps) {
 		if (!slot) {
 			slot = {
 				key,
-				label: `${d.toLocaleDateString('en-GB', { weekday: 'short' })} ${d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })}`,
-				fullLabel: `${d.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' })}, ${d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })}`,
+				kickoff: d,
 				time: d.getTime(),
 				fixtures: [],
 			}
@@ -157,9 +156,11 @@ export function CupTimeline({ data }: CupTimelineProps) {
 				<div />
 				{slots.map((slot) => (
 					<div key={slot.key} className="rounded-md border border-border bg-card p-2.5 text-xs">
-						<div className="font-semibold uppercase tracking-wide text-[0.65rem] text-muted-foreground">
-							{slot.label}
-						</div>
+						<LocalDateTime
+							date={slot.kickoff}
+							options={{ weekday: 'short', hour: '2-digit', minute: '2-digit' }}
+							className="font-semibold uppercase tracking-wide text-[0.65rem] text-muted-foreground block"
+						/>
 						<div className="mt-1 text-foreground font-medium">
 							{slot.fixtures.length} {slot.fixtures.length === 1 ? 'fixture' : 'fixtures'}
 						</div>

--- a/src/components/standings/turbo-ladder.tsx
+++ b/src/components/standings/turbo-ladder.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { AlertTriangle, CheckCircle2, Flame, Target, XCircle, Zap } from 'lucide-react'
+import { LocalDateTime } from '@/components/local-datetime'
 import { TeamBadge } from '@/components/picks/team-badge'
 import { cn } from '@/lib/utils'
 
@@ -220,15 +221,15 @@ function FixtureRow({
 								vs
 							</span>
 							{fixture.kickoff && (
-								<span className="text-[0.7rem] text-muted-foreground mt-1 text-center leading-tight">
-									{fixture.kickoff.toLocaleDateString('en-GB', {
+								<LocalDateTime
+									date={fixture.kickoff}
+									options={{
 										weekday: 'short',
-									})}{' '}
-									{fixture.kickoff.toLocaleTimeString('en-GB', {
 										hour: '2-digit',
 										minute: '2-digit',
-									})}
-								</span>
+									}}
+									className="text-[0.7rem] text-muted-foreground mt-1 text-center leading-tight"
+								/>
 							)}
 						</>
 					)}

--- a/src/components/standings/turbo-timeline.tsx
+++ b/src/components/standings/turbo-timeline.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Flame, Hourglass, Target, XCircle } from 'lucide-react'
+import { LocalDateTime } from '@/components/local-datetime'
 import { cn } from '@/lib/utils'
 import type { LadderFixture, LadderPrediction } from './turbo-ladder'
 
@@ -18,9 +19,8 @@ interface TurboTimelineProps {
 // A "kickoff slot" is a unique kickoff time across the round's fixtures.
 interface KickoffSlot {
 	key: string
-	label: string // e.g. "Sat 15:00"
-	fullLabel: string // e.g. "Sat 17 Jan, 15:00"
-	time: number // epoch ms
+	kickoff: Date // header rendered via <LocalDateTime />
+	time: number // epoch ms — used for sorting only
 	fixtures: LadderFixture[]
 }
 
@@ -50,8 +50,7 @@ export function TurboTimeline({ fixtures, players }: TurboTimelineProps) {
 		if (!slot) {
 			slot = {
 				key,
-				label: `${d.toLocaleDateString('en-GB', { weekday: 'short' })} ${d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })}`,
-				fullLabel: `${d.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' })}, ${d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })}`,
+				kickoff: d,
 				time: d.getTime(),
 				fixtures: [],
 			}
@@ -209,9 +208,11 @@ export function TurboTimeline({ fixtures, players }: TurboTimelineProps) {
 								dropouts > 0 && 'border-[var(--eliminated)]/40',
 							)}
 						>
-							<div className="font-semibold uppercase tracking-wide text-[0.65rem] text-muted-foreground">
-								{slot.label}
-							</div>
+							<LocalDateTime
+								date={slot.kickoff}
+								options={{ weekday: 'short', hour: '2-digit', minute: '2-digit' }}
+								className="font-semibold uppercase tracking-wide text-[0.65rem] text-muted-foreground block"
+							/>
 							<div className="mt-1 text-foreground font-medium">
 								{slot.fixtures.length} {slot.fixtures.length === 1 ? 'fixture' : 'fixtures'}
 							</div>

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -400,7 +400,7 @@ export async function getClassicPickData(gameId: string, roundId: string, gamePl
 			badgeUrl: f.awayTeam.badgeUrl,
 			form: formMap.get(f.awayTeamId),
 		},
-		kickoff: f.kickoff ? formatKickoff(f.kickoff) : null,
+		kickoff: f.kickoff ? f.kickoff.toISOString() : null,
 	}))
 
 	return {
@@ -415,12 +415,21 @@ export async function getClassicPickData(gameId: string, roundId: string, gamePl
 	}
 }
 
+// Server-side label used only for places where a React component can't run
+// (currently just the AutoPickBanner kickoff line in getGameDetail). All other
+// surfaces render via <LocalDateTime /> in the user's timezone.
 function formatKickoff(date: Date): string {
-	// e.g. "Sat 17 Jan · 15:00"
-	const day = date.toLocaleDateString('en-GB', { weekday: 'short' })
-	const dayOfMonth = date.getDate()
-	const month = date.toLocaleDateString('en-GB', { month: 'short' })
-	const time = date.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })
+	const day = date.toLocaleDateString('en-GB', { weekday: 'short', timeZone: 'Europe/London' })
+	const dayOfMonth = new Intl.DateTimeFormat('en-GB', {
+		day: 'numeric',
+		timeZone: 'Europe/London',
+	}).format(date)
+	const month = date.toLocaleDateString('en-GB', { month: 'short', timeZone: 'Europe/London' })
+	const time = date.toLocaleTimeString('en-GB', {
+		hour: '2-digit',
+		minute: '2-digit',
+		timeZone: 'Europe/London',
+	})
 	return `${day} ${dayOfMonth} ${month} · ${time}`
 }
 
@@ -466,7 +475,7 @@ export async function getTurboPickData(gameId: string, roundId: string, gamePlay
 			badgeUrl: f.awayTeam.badgeUrl,
 			form: formMap.get(f.awayTeamId),
 		},
-		kickoff: f.kickoff ? formatKickoff(f.kickoff) : null,
+		kickoff: f.kickoff ? f.kickoff.toISOString() : null,
 	}))
 
 	return {

--- a/src/lib/share/shared.tsx
+++ b/src/lib/share/shared.tsx
@@ -119,11 +119,14 @@ export function Header({
 }
 
 export function Footer({ generatedAt }: { generatedAt: Date }): ReactElement {
-	const dateLabel = generatedAt.toLocaleDateString('en-GB', {
+	// Share/OG images render server-only — use Europe/London for deterministic
+	// output (matches the SSR fallback used by <LocalDateTime />).
+	const dateLabel = new Intl.DateTimeFormat('en-GB', {
 		day: 'numeric',
 		month: 'short',
 		year: 'numeric',
-	})
+		timeZone: 'Europe/London',
+	}).format(generatedAt)
 	return (
 		<div
 			style={{


### PR DESCRIPTION
## Summary

Kickoffs and deadlines were rendering in UTC (Vercel's runtime timezone), so UK users saw times 1h off during BST and any non-UTC user saw wrong times entirely.

This PR introduces a \`<LocalDateTime />\` client component that:
- Renders **Europe/London during SSR + first hydration** (deterministic, no warning, UK users see no flash)
- **\`useEffect\` re-formats with browser's timezone after mount** so users abroad get their actual local time
- Uses \`suppressHydrationWarning\` for the unavoidable SSR-vs-browser-timezone mismatch

## What was wrong

- Server-side formatters in \`detail-queries.ts\` ran in UTC (Vercel default)
- Client-component formatters using \`toLocaleString(undefined, ...)\` hit the same problem during SSR
- The audit found ~10 affected surfaces: pick interfaces, ladders, timelines, planner, banners

## Wired through

- **Pick interfaces**: classic, cup (kickoff + deadline)
- **Planner**: deadlines + per-fixture kickoffs
- **Ladders + timelines**: fixture kickoff columns and timeline header slots
- **Rebuy banner**: round 2 deadline
- **\`FixtureRow\`**: kickoff prop now \`string | Date | null\`
- **Server-only contexts** (share/OG, admin payment subtitles): pinned to \`Europe/London\` (same fallback as the client component)

## Tests

- 5 new \`formatLondon\` regression tests covering BST/GMT, DST transitions
- Full suite: 392/392 passing
- Typecheck clean

## Test plan

- [x] Tests + typecheck pass
- [ ] Smoke: open a game in Chrome with system tz set to America/New_York, confirm kickoffs show NY time after page settles
- [ ] Smoke UK user: kickoffs show BST/GMT correctly, no UTC flash on initial paint

🤖 Generated with [Claude Code](https://claude.com/claude-code)