### PR TITLE
fix(turbo): use FixtureRow for remaining-fixture cards

### DIFF
--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -213,6 +213,8 @@ export default async function GameDetailPage({
 					gameId={game.id}
 					roundId={game.currentRound.id}
 					roundName={turboPickData.roundName}
+					roundNumber={turboPickData.roundNumber}
+					competitionId={turboPickData.competitionId}
 					deadline={turboPickData.deadline}
 					fixtures={turboPickData.fixtures}
 					existingPicks={turboPickData.existingPicks}

--- a/src/components/picks/fixture-row.tsx
+++ b/src/components/picks/fixture-row.tsx
@@ -51,6 +51,12 @@ export interface FixtureRowProps {
 	// don't yet pass them — when omitted, the form row is non-tappable.
 	competitionId?: string
 	roundNumber?: number
+	/**
+	 * Extra content rendered inside the bordered card, below the form bar.
+	 * Used by turbo's pick interface to attach PredictionButtons to the
+	 * fixture without breaking visual grouping.
+	 */
+	children?: React.ReactNode
 }
 
 export function FixtureRow({
@@ -72,6 +78,7 @@ export function FixtureRow({
 	awayState,
 	competitionId,
 	roundNumber,
+	children,
 }: FixtureRowProps) {
 	const isFullyUsed = usedSide === 'both'
 	const showTierStrip = tierValue != null || plusN != null || showHeart
@@ -141,6 +148,7 @@ export function FixtureRow({
 						onOpenSheet={(side) => setSheetTeam(side)}
 					/>
 				)}
+				{children}
 			</div>
 
 			{sheetEnabled && competitionId && (

--- a/src/components/picks/turbo-pick.tsx
+++ b/src/components/picks/turbo-pick.tsx
@@ -6,12 +6,12 @@ import { useState } from 'react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { formatDeadline } from '@/lib/format'
 import { cn } from '@/lib/utils'
-import { FormDots, type FormResult } from './form-dots'
+import { FixtureRow } from './fixture-row'
+import type { FormResult } from './form-dots'
 import { PickConfirmBar } from './pick-confirm-bar'
 import { type Prediction, PredictionButtons } from './prediction-buttons'
 import type { RankedPick } from './ranked-item'
 import { RankingList } from './ranking-list'
-import { TeamBadge } from './team-badge'
 
 export interface TurboPickFixture {
 	id: string
@@ -38,6 +38,8 @@ interface TurboPickProps {
 	gameId: string
 	roundId: string
 	roundName: string
+	roundNumber: number
+	competitionId: string
 	deadline: Date | null
 	fixtures: TurboPickFixture[]
 	existingPicks: Array<{ fixtureId: string; confidenceRank: number; predictedResult: Prediction }>
@@ -46,16 +48,12 @@ interface TurboPickProps {
 	actingAs?: { gamePlayerId: string; userName: string }
 }
 
-function ordinal(n: number): string {
-	const s = ['th', 'st', 'nd', 'rd']
-	const v = n % 100
-	return n + (s[(v - 20) % 10] || s[v] || s[0])
-}
-
 export function TurboPick({
 	gameId,
 	roundId,
 	roundName,
+	roundNumber,
+	competitionId,
 	deadline,
 	fixtures,
 	existingPicks,
@@ -246,84 +244,28 @@ export function TurboPick({
 						{remaining.map((fix) => {
 							const hasPrediction = !!pendingPredictions[fix.id]
 							return (
-								<div
+								<FixtureRow
 									key={fix.id}
-									className="border border-border rounded-lg bg-card overflow-hidden"
+									home={{
+										id: fix.home.id,
+										name: fix.home.name,
+										shortName: fix.home.shortName,
+										badgeUrl: fix.home.badgeUrl,
+										form: fix.home.form,
+										leaguePosition: fix.home.leaguePosition,
+									}}
+									away={{
+										id: fix.away.id,
+										name: fix.away.name,
+										shortName: fix.away.shortName,
+										badgeUrl: fix.away.badgeUrl,
+										form: fix.away.form,
+										leaguePosition: fix.away.leaguePosition,
+									}}
+									kickoff={fix.kickoff}
+									competitionId={competitionId}
+									roundNumber={roundNumber}
 								>
-									<div className="flex items-stretch">
-										<div className="flex items-center gap-3 px-4 py-3 flex-1 min-w-0 flex-row-reverse">
-											<TeamBadge
-												shortName={fix.home.shortName}
-												badgeUrl={fix.home.badgeUrl}
-												size="lg"
-												responsive
-											/>
-											<div className="flex flex-col gap-1.5 min-w-0 flex-1 items-end">
-												<span className="font-semibold text-base leading-tight truncate w-full text-right">
-													<span className="sm:hidden">{fix.home.shortName}</span>
-													<span className="hidden sm:inline">{fix.home.name}</span>
-												</span>
-												<div className="flex items-center gap-2">
-													{fix.home.leaguePosition != null && (
-														<span className="text-xs text-muted-foreground font-medium">
-															{ordinal(fix.home.leaguePosition)}
-														</span>
-													)}
-													{fix.home.form && fix.home.form.length > 0 && (
-														<>
-															<span className="sm:hidden">
-																<FormDots results={fix.home.form} size="sm" />
-															</span>
-															<span className="hidden sm:inline">
-																<FormDots results={fix.home.form} size="md" />
-															</span>
-														</>
-													)}
-												</div>
-											</div>
-										</div>
-										<div className="flex flex-col items-center justify-center px-3 shrink-0 min-w-[64px] bg-muted/30 border-l border-r border-border">
-											<span className="text-xs text-muted-foreground font-semibold uppercase tracking-wide">
-												vs
-											</span>
-											{fix.kickoff && (
-												<span className="text-[0.7rem] text-muted-foreground mt-1 text-center leading-tight">
-													{fix.kickoff}
-												</span>
-											)}
-										</div>
-										<div className="flex items-center gap-3 px-4 py-3 flex-1 min-w-0">
-											<TeamBadge
-												shortName={fix.away.shortName}
-												badgeUrl={fix.away.badgeUrl}
-												size="lg"
-												responsive
-											/>
-											<div className="flex flex-col gap-1.5 min-w-0 flex-1 items-start">
-												<span className="font-semibold text-base leading-tight truncate w-full">
-													<span className="sm:hidden">{fix.away.shortName}</span>
-													<span className="hidden sm:inline">{fix.away.name}</span>
-												</span>
-												<div className="flex items-center gap-2">
-													{fix.away.leaguePosition != null && (
-														<span className="text-xs text-muted-foreground font-medium">
-															{ordinal(fix.away.leaguePosition)}
-														</span>
-													)}
-													{fix.away.form && fix.away.form.length > 0 && (
-														<>
-															<span className="sm:hidden">
-																<FormDots results={fix.away.form} size="sm" />
-															</span>
-															<span className="hidden sm:inline">
-																<FormDots results={fix.away.form} size="md" />
-															</span>
-														</>
-													)}
-												</div>
-											</div>
-										</div>
-									</div>
 									<div className="px-4 py-3 border-t border-border bg-muted/20">
 										<PredictionButtons
 											value={pendingPredictions[fix.id]}
@@ -339,7 +281,7 @@ export function TurboPick({
 											</button>
 										)}
 									</div>
-								</div>
+								</FixtureRow>
 							)
 						})}
 					</div>


### PR DESCRIPTION
## Summary

Two bugs in turbo's pick interface, both rooted in turbo using its own inline duplicated layout instead of \`FixtureRow\`:

1. **Form guide stuck at the pre-fix state** — only 2/4 of 6 pills visible, home side showed wrong slice. Never picked up #30's redesign.
2. **Kickoff rendered as raw ISO** — \`2026-05-09T14:00:00.000Z\` showing in the vs divider after #33 stopped pre-formatting kickoffs.

## Fix

- Adds \`children\` prop to \`FixtureRow\` (renders inside the bordered card, below the form bar)
- Refactors turbo's \"remaining fixtures\" section to use \`FixtureRow\` with PredictionButtons + add-to-rank as children
- Threads \`competitionId\` and \`roundNumber\` through TurboPick so the form-detail bottom sheet works in turbo too
- Drops ~80 lines of duplicated layout

Both bugs now fixed by the same change. Form pills shown by \`<LocalDateTime />\` for kickoff.

## Test plan

- [x] Typecheck clean
- [x] Full suite: 392/392 passing
- [ ] Smoke turbo: open round, confirm 6 form pills both teams, kickoff formatted as \"Sat 17:30\", tap form to open team-detail sheet, predict + add to ranked still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)