### PR TITLE
fix(grid): always include the game's current round even if 'upcoming'

### DIFF
--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -766,8 +766,14 @@ export async function getProgressGridData(
 		? gameData.players.find((p) => p.userId === viewerUserId)?.id
 		: undefined
 
+	// Include the game's current round even if its DB status is still
+	// 'upcoming' (deadline > 48h away — see OPEN_WINDOW_MS in
+	// bootstrap-competitions). For WC games this is the common case before the
+	// tournament kicks off: round.status stays 'upcoming' for weeks even though
+	// the game is created and players can pick. Without this, the progress
+	// grid renders zero columns until the deadline approaches.
 	const completedAndCurrentRounds = gameData.competition.rounds.filter(
-		(r) => r.status !== 'upcoming',
+		(r) => r.status !== 'upcoming' || r.id === gameData.currentRoundId,
 	)
 
 	const rounds: GridRound[] = completedAndCurrentRounds.map((r) => ({


### PR DESCRIPTION
## Smoking gun

The progress grid filter excluded any round whose DB status was \`'upcoming'\`. Rounds only transition from \`'upcoming'\` → \`'open'\` inside the 48h pre-deadline window (\`OPEN_WINDOW_MS\` in bootstrap-competitions). For PL test games, \`open\`/\`completed\` rounds populate the grid. For WC test games created weeks before the tournament, every round is still \`'upcoming'\` — so the grid renders zero columns. The player sees their name + \"Alive\" status badge and nothing else, even after making a pick.

## Fix

\`\`\`ts
const completedAndCurrentRounds = gameData.competition.rounds.filter(
  (r) => r.status !== 'upcoming' || r.id === gameData.currentRoundId,
)
\`\`\`

Includes the game's current round unconditionally. PL behaviour unchanged (its current round is typically already \`'open'\` so it was already included).

## Test plan

- [x] Tests + typecheck pass
- [ ] Smoke: open WC test classic game — confirm GW1 column appears with \`?\` for unpicked players and the picked team for the viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)