### PR TITLE
fix(rounds): drive round status off game lifecycle, not 48h time window

### DIFF
--- a/src/app/api/cron/daily-sync/route.test.ts
+++ b/src/app/api/cron/daily-sync/route.test.ts
@@ -1,11 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/lib/db', () => ({
-	db: { query: { competition: { findMany: vi.fn() } } },
+	db: {
+		query: {
+			competition: { findMany: vi.fn() },
+			game: { findMany: vi.fn().mockResolvedValue([]) },
+		},
+	},
 }))
 
 vi.mock('@/lib/game/bootstrap-competitions', () => ({
-	syncCompetition: vi.fn().mockResolvedValue({ rounds: 0, fixtures: 0, transitionedRoundIds: [] }),
+	syncCompetition: vi
+		.fn()
+		.mockResolvedValue({ rounds: 0, fixtures: 0, deadlinePassedRoundIds: [] }),
 	mergeFootballDataIds: vi.fn().mockResolvedValue(undefined),
 	scheduleUpcomingFixturePolls: vi.fn().mockResolvedValue(undefined),
 }))
@@ -14,6 +21,14 @@ vi.mock('@/lib/game/no-pick-handler', () => ({
 	processDeadlineLock: vi
 		.fn()
 		.mockResolvedValue({ autoPicksInserted: 0, playersEliminated: 0, paymentsRefunded: 0 }),
+}))
+
+vi.mock('@/lib/game/process-round', () => ({
+	advanceGameIfReady: vi.fn().mockResolvedValue({ advanced: false, reason: 'not-active' }),
+}))
+
+vi.mock('@/lib/game/round-lifecycle', () => ({
+	openRoundForGame: vi.fn().mockResolvedValue(undefined),
 }))
 
 import { db } from '@/lib/db'
@@ -40,7 +55,7 @@ describe('daily-sync route', () => {
 		vi.mocked(syncCompetition).mockResolvedValue({
 			rounds: 0,
 			fixtures: 0,
-			transitionedRoundIds: [],
+			deadlinePassedRoundIds: [],
 		})
 		await POST(
 			new Request('http://x', {
@@ -56,7 +71,7 @@ describe('daily-sync route', () => {
 		vi.mocked(syncCompetition).mockResolvedValue({
 			rounds: 1,
 			fixtures: 10,
-			transitionedRoundIds: [],
+			deadlinePassedRoundIds: [],
 		})
 		await POST(
 			new Request('http://x', {
@@ -73,8 +88,8 @@ describe('daily-sync route', () => {
 			{ id: 'c2' },
 		] as never)
 		vi.mocked(syncCompetition)
-			.mockResolvedValueOnce({ rounds: 2, fixtures: 20, transitionedRoundIds: ['r1', 'r2'] })
-			.mockResolvedValueOnce({ rounds: 1, fixtures: 10, transitionedRoundIds: ['r3'] })
+			.mockResolvedValueOnce({ rounds: 2, fixtures: 20, deadlinePassedRoundIds: ['r1', 'r2'] })
+			.mockResolvedValueOnce({ rounds: 1, fixtures: 10, deadlinePassedRoundIds: ['r3'] })
 
 		const res = await POST(
 			new Request('http://x', {

--- a/src/app/api/cron/daily-sync/route.ts
+++ b/src/app/api/cron/daily-sync/route.ts
@@ -7,7 +7,10 @@ import {
 	syncCompetition,
 } from '@/lib/game/bootstrap-competitions'
 import { processDeadlineLock } from '@/lib/game/no-pick-handler'
+import { advanceGameIfReady } from '@/lib/game/process-round'
+import { openRoundForGame } from '@/lib/game/round-lifecycle'
 import { competition } from '@/lib/schema/competition'
+import { game } from '@/lib/schema/game'
 
 export async function POST(request: Request) {
 	const secret = process.env.CRON_SECRET
@@ -30,23 +33,46 @@ export async function POST(request: Request) {
 			rounds: summary.rounds,
 			fixtures: summary.fixtures,
 		})
-		if (summary.transitionedRoundIds?.length) {
-			deadlineLockedRoundIds.push(...summary.transitionedRoundIds)
+		if (summary.deadlinePassedRoundIds?.length) {
+			deadlineLockedRoundIds.push(...summary.deadlinePassedRoundIds)
 		}
 		// For FPL-bootstrapped competitions, merge football-data IDs onto fresh
 		// fixtures + teams so the live-score poll can match by external_ids.football_data.
-		// Was previously only run by the manual `scripts/bootstrap-competitions.ts`
-		// path; missing it here meant new fixtures (rescheduled / late-published)
-		// stayed invisible to live polling.
 		if (c.dataSource === 'fpl' && apiKey) {
 			await mergeFootballDataIds(c, apiKey)
 		}
 	}
 
+	// Reconciliation: any active game whose currentRoundId still points at an
+	// 'upcoming' round means the open transition didn't fire (e.g. a game
+	// created before the round-lifecycle fix shipped, or a future-round
+	// advance whose new round was upcoming when the game advanced into it).
+	// Heal here so the progress grid filter and processDeadlineLock both see
+	// the round as open.
+	const activeGames = await db.query.game.findMany({
+		where: eq(game.status, 'active'),
+		with: { currentRound: true },
+	})
+	const reconciledRoundIds: string[] = []
+	for (const g of activeGames) {
+		if (g.currentRound && g.currentRound.status === 'upcoming') {
+			await openRoundForGame(g.currentRound.id)
+			reconciledRoundIds.push(g.currentRound.id)
+		}
+	}
+
+	// Retry advancement for any games stuck on a completed round (next round
+	// was TBD when last processed — typically WC bracket pre-publication).
+	const advanced: string[] = []
+	for (const g of activeGames) {
+		if (!g.currentRoundId) continue
+		const r = await advanceGameIfReady(g.id)
+		if (r.advanced) advanced.push(g.id)
+	}
+
 	// Pre-schedule a poll-scores trigger for every upcoming fixture across all
-	// competitions. Solves the "GH Actions heartbeat missed the match window"
-	// gap: each fixture gets its own QStash trigger 10 min before kickoff,
-	// which starts the self-perpetuating chain reliably.
+	// competitions. Each fixture gets its own QStash trigger 10 min before
+	// kickoff, which starts the self-perpetuating chain reliably.
 	await scheduleUpcomingFixturePolls()
 	let deadlineLock: {
 		autoPicksInserted: number
@@ -56,5 +82,11 @@ export async function POST(request: Request) {
 	if (deadlineLockedRoundIds.length > 0) {
 		deadlineLock = await processDeadlineLock(deadlineLockedRoundIds)
 	}
-	return NextResponse.json({ competitions: results, deadlineLock })
+
+	return NextResponse.json({
+		competitions: results,
+		deadlineLock,
+		reconciledRoundIds,
+		advanced,
+	})
 }

--- a/src/app/api/cron/process-rounds/route.ts
+++ b/src/app/api/cron/process-rounds/route.ts
@@ -1,7 +1,7 @@
 import { eq } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import { db } from '@/lib/db'
-import { processGameRound } from '@/lib/game/process-round'
+import { advanceGameIfReady, processGameRound } from '@/lib/game/process-round'
 import { round } from '@/lib/schema/competition'
 import { game } from '@/lib/schema/game'
 
@@ -42,5 +42,15 @@ export async function POST(request: Request) {
 		results.push({ gameId: g.id, ...result })
 	}
 
-	return NextResponse.json({ processed: results })
+	// Retry advancement for games stuck pointing at a completed round —
+	// happens when the next round was TBD at process-time (e.g. WC bracket
+	// not yet published). Idempotent (no-op for healthy games).
+	const advanced: string[] = []
+	for (const g of activeGames) {
+		if (!g.currentRoundId) continue
+		const r = await advanceGameIfReady(g.id)
+		if (r.advanced) advanced.push(g.id)
+	}
+
+	return NextResponse.json({ processed: results, advanced })
 }

--- a/src/app/api/games/[id]/planned-picks/route.ts
+++ b/src/app/api/games/[id]/planned-picks/route.ts
@@ -7,6 +7,7 @@ import {
 	type PlannedPick as PPick,
 	validatePlannedPick,
 } from '@/lib/game/planned-picks'
+import { scheduleAutoSubmitForPlan } from '@/lib/game/round-lifecycle'
 import { round } from '@/lib/schema/competition'
 import { game, gamePlayer, pick, plannedPick } from '@/lib/schema/game'
 
@@ -99,6 +100,13 @@ export async function POST(request: Request, ctx: Ctx): Promise<Response> {
 			autoSubmit: body.autoSubmit,
 		})
 		.returning()
+
+	// If the player wants this auto-submitted, enqueue the QStash trigger
+	// for T-60s before the round's deadline. Idempotent via dedup ID, so
+	// re-saves of the same plan don't duplicate the schedule.
+	if (body.autoSubmit) {
+		await scheduleAutoSubmitForPlan(membership.id, body.roundId, body.teamId)
+	}
 
 	return NextResponse.json({ plan: created })
 }

--- a/src/app/api/games/route.ts
+++ b/src/app/api/games/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import { requireSession } from '@/lib/auth-helpers'
 import { db } from '@/lib/db'
 import { generateInviteCode } from '@/lib/game/invite-code'
+import { openRoundForGame } from '@/lib/game/round-lifecycle'
 import { competition, round } from '@/lib/schema/competition'
 import { game, gamePlayer } from '@/lib/schema/game'
 import { payment } from '@/lib/schema/payment'
@@ -117,6 +118,10 @@ export async function POST(request: Request) {
 			amount: entryFee,
 		})
 	}
+
+	// Round status follows game lifecycle: starting a game on this round
+	// flips it from 'upcoming' to 'open' if it isn't already.
+	await openRoundForGame(firstRound.id)
 
 	return NextResponse.json(newGame, { status: 201 })
 }

--- a/src/lib/game/bootstrap-competitions.test.ts
+++ b/src/lib/game/bootstrap-competitions.test.ts
@@ -222,7 +222,14 @@ describe('syncCompetition league-position persistence', () => {
 	})
 })
 
-describe('syncCompetition auto-submit enqueue', () => {
+// NOTE: auto-submit enqueueing previously fired from bootstrap when a round
+// transitioned from 'upcoming' → 'open' inside the 48h window. That window
+// has been removed (it was a regression from the predecessor app — round
+// status now follows game lifecycle, not wall-clock time). Auto-submit is
+// scheduled at game-creation / round-advance / plan-creation via
+// scheduleAutoSubmitForPlan / openRoundForGame in round-lifecycle.ts.
+
+describe('syncCompetition deadline-lock trigger (deadlinePassedRoundIds)', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
 		dbQueryTeamFindMany.mockResolvedValue([])
@@ -230,112 +237,7 @@ describe('syncCompetition auto-submit enqueue', () => {
 		dbQueryPlannedPickFindMany.mockResolvedValue([])
 	})
 
-	it('enqueues auto-submits when a round transitions from upcoming to open', async () => {
-		const deadline = new Date(Date.now() + 24 * 3600 * 1000) // 24h away → within 48h window → open
-		fplFetchTeams.mockResolvedValue([])
-		fplFetchRounds.mockResolvedValue([
-			{
-				number: 1,
-				name: 'Round 1',
-				deadline,
-				finished: false,
-				fixtures: [],
-			},
-		])
-		dbQueryRoundFindFirst.mockResolvedValue({
-			id: 'round-1',
-			status: 'upcoming',
-		})
-		dbQueryPlannedPickFindMany.mockResolvedValue([
-			{ id: 'pp-1', gamePlayerId: 'gp-1', roundId: 'round-1', teamId: 't-1', autoSubmit: true },
-			{ id: 'pp-2', gamePlayerId: 'gp-2', roundId: 'round-1', teamId: 't-2', autoSubmit: false },
-		])
-
-		await syncCompetition(
-			{
-				id: 'comp-1',
-				dataSource: 'fpl',
-				externalId: null,
-				season: '2025/26',
-			} as never,
-			{ footballDataApiKey: 'fd-key' },
-		)
-
-		expect(enqueueAutoSubmitMock).toHaveBeenCalledTimes(1)
-		expect(enqueueAutoSubmitMock).toHaveBeenCalledWith(
-			'gp-1',
-			'round-1',
-			't-1',
-			new Date(deadline.getTime() - 60_000),
-		)
-	})
-
-	it('does not re-enqueue when the round was already open', async () => {
-		const deadline = new Date(Date.now() + 24 * 3600 * 1000)
-		fplFetchTeams.mockResolvedValue([])
-		fplFetchRounds.mockResolvedValue([
-			{
-				number: 1,
-				name: 'Round 1',
-				deadline,
-				finished: false,
-				fixtures: [],
-			},
-		])
-		dbQueryRoundFindFirst.mockResolvedValue({
-			id: 'round-1',
-			status: 'open',
-		})
-		dbQueryPlannedPickFindMany.mockResolvedValue([
-			{ id: 'pp-1', gamePlayerId: 'gp-1', roundId: 'round-1', teamId: 't-1', autoSubmit: true },
-		])
-
-		await syncCompetition(
-			{ id: 'comp-1', dataSource: 'fpl', externalId: null, season: '2025/26' } as never,
-			{ footballDataApiKey: 'fd-key' },
-		)
-
-		expect(enqueueAutoSubmitMock).not.toHaveBeenCalled()
-	})
-
-	it('does not enqueue when the round remains upcoming (deadline still far away)', async () => {
-		const deadline = new Date(Date.now() + 10 * 24 * 3600 * 1000) // 10 days away
-		fplFetchTeams.mockResolvedValue([])
-		fplFetchRounds.mockResolvedValue([
-			{
-				number: 1,
-				name: 'Round 1',
-				deadline,
-				finished: false,
-				fixtures: [],
-			},
-		])
-		dbQueryRoundFindFirst.mockResolvedValue({
-			id: 'round-1',
-			status: 'upcoming',
-		})
-		dbQueryPlannedPickFindMany.mockResolvedValue([
-			{ id: 'pp-1', gamePlayerId: 'gp-1', roundId: 'round-1', teamId: 't-1', autoSubmit: true },
-		])
-
-		await syncCompetition(
-			{ id: 'comp-1', dataSource: 'fpl', externalId: null, season: '2025/26' } as never,
-			{ footballDataApiKey: 'fd-key' },
-		)
-
-		expect(enqueueAutoSubmitMock).not.toHaveBeenCalled()
-	})
-})
-
-describe('syncCompetition deadline-lock trigger (transitionedRoundIds)', () => {
-	beforeEach(() => {
-		vi.clearAllMocks()
-		dbQueryTeamFindMany.mockResolvedValue([])
-		dbQueryRoundFindMany.mockResolvedValue([])
-		dbQueryPlannedPickFindMany.mockResolvedValue([])
-	})
-
-	it('does NOT include the round in transitionedRoundIds on upcoming → open transitions (deadline still in future)', async () => {
+	it('does NOT include the round in deadlinePassedRoundIds on upcoming → open transitions (deadline still in future)', async () => {
 		// Deadline is 24h away — within the 48h OPEN_WINDOW so status flips to `open`,
 		// but the deadline itself has NOT passed yet.
 		const deadline = new Date(Date.now() + 24 * 3600 * 1000)
@@ -354,10 +256,10 @@ describe('syncCompetition deadline-lock trigger (transitionedRoundIds)', () => {
 			{ footballDataApiKey: 'fd-key' },
 		)
 
-		expect(result.transitionedRoundIds).toEqual([])
+		expect(result.deadlinePassedRoundIds).toEqual([])
 	})
 
-	it('DOES include the round in transitionedRoundIds when the deadline has actually passed', async () => {
+	it('DOES include the round in deadlinePassedRoundIds when the deadline has actually passed', async () => {
 		// Existing round is `open` (we previously flipped it at T-48h) with a
 		// deadline in the past — i.e. the actual lock moment has arrived.
 		const pastDeadline = new Date(Date.now() - 3600 * 1000) // 1h ago
@@ -376,7 +278,7 @@ describe('syncCompetition deadline-lock trigger (transitionedRoundIds)', () => {
 			{ footballDataApiKey: 'fd-key' },
 		)
 
-		expect(result.transitionedRoundIds).toEqual(['round-1'])
+		expect(result.deadlinePassedRoundIds).toEqual(['round-1'])
 	})
 
 	it('does NOT include the round when it is already completed (finished in adapter)', async () => {
@@ -397,7 +299,7 @@ describe('syncCompetition deadline-lock trigger (transitionedRoundIds)', () => {
 		)
 
 		// Finished rounds are not open anymore — no re-fire of the deadline lock.
-		expect(result.transitionedRoundIds).toEqual([])
+		expect(result.deadlinePassedRoundIds).toEqual([])
 	})
 })
 

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -1,19 +1,15 @@
 import { and, eq, gt, inArray, lt } from 'drizzle-orm'
 import { FootballDataAdapter } from '@/lib/data/football-data'
 import { FplAdapter } from '@/lib/data/fpl'
-import { enqueueAutoSubmit, enqueuePollScoresAt } from '@/lib/data/qstash'
+import { enqueuePollScoresAt } from '@/lib/data/qstash'
 import type { CompetitionAdapter } from '@/lib/data/types'
 import { WC_2026_POTS } from '@/lib/data/wc-pots'
 import { db } from '@/lib/db'
 import { competition, fixture, round, team } from '@/lib/schema/competition'
-import { plannedPick } from '@/lib/schema/game'
 
 export interface BootstrapOptions {
 	footballDataApiKey?: string
 }
-
-const OPEN_WINDOW_MS = 48 * 3600 * 1000
-const AUTO_SUBMIT_LEAD_MS = 60_000
 
 type CompetitionRow = typeof competition.$inferSelect
 
@@ -257,9 +253,9 @@ export async function mergeFootballDataIds(comp: CompetitionRow, apiKey: string)
 export async function syncCompetition(
 	comp: CompetitionRow,
 	opts: BootstrapOptions,
-): Promise<{ rounds: number; fixtures: number; transitionedRoundIds: string[] }> {
+): Promise<{ rounds: number; fixtures: number; deadlinePassedRoundIds: string[] }> {
 	const adapter = adapterFor(comp, opts)
-	if (!adapter) return { rounds: 0, fixtures: 0, transitionedRoundIds: [] }
+	if (!adapter) return { rounds: 0, fixtures: 0, deadlinePassedRoundIds: [] }
 
 	const key = comp.dataSource === 'fpl' ? 'fpl' : 'football_data'
 	const adapterTeams = await adapter.fetchTeams()
@@ -303,27 +299,25 @@ export async function syncCompetition(
 
 	const adapterRounds = await adapter.fetchRounds()
 	let totalFixtures = 0
-	const transitionedRoundIds: string[] = []
+	const deadlinePassedRoundIds: string[] = []
 	for (const ar of adapterRounds) {
 		const existingRound = await db.query.round.findFirst({
 			where: and(eq(round.competitionId, comp.id), eq(round.number, ar.number)),
 		})
+		// Round status now follows game lifecycle, not wall-clock time:
+		//   'upcoming' → 'open' on game creation / round advance (see api/games
+		//                and process-round.ts:advanceGameToNextRound)
+		//   'open' → 'completed' on processGameRound
+		// Bootstrap only mirrors the adapter's `finished` flag (all fixtures
+		// finished, so the round can be considered settled at the data layer)
+		// and otherwise preserves whatever state the game lifecycle has set.
 		const newStatus: 'upcoming' | 'open' | 'active' | 'completed' = ar.finished
 			? 'completed'
-			: ar.deadline && ar.deadline.getTime() - Date.now() < OPEN_WINDOW_MS
-				? 'open'
-				: (existingRound?.status ?? 'upcoming')
+			: (existingRound?.status ?? 'upcoming')
 		let roundId: string
-		// T-48h: pre-lock window opens. Used to enqueue the planned-pick auto-submit
-		// job (fires at T-60s). Does NOT signal the deadline has passed.
-		const transitioningToOpen =
-			!!existingRound && existingRound.status !== 'open' && newStatus === 'open'
-		// Actual deadline passed: the round is still `open` in the DB (we have not
-		// transitioned it to `active` yet) AND its deadline is in the past. This is
-		// what drives `processDeadlineLock` (rules 2 and 3) — firing earlier would
-		// elim/auto-pick players who still have time to submit. The handler is
-		// idempotent so it is safe to re-fire on subsequent sync runs until the
-		// round advances to `active`/`completed`.
+		// Detect deadlines that have just passed for an open round. Drives
+		// processDeadlineLock (no-pick handler) — idempotent, so safe to fire on
+		// subsequent sync runs until the round advances to 'completed'.
 		const nowForDeadline = new Date()
 		const deadlineHasPassed =
 			!!existingRound &&
@@ -354,19 +348,8 @@ export async function syncCompetition(
 			roundId = created.id
 		}
 
-		if (transitioningToOpen && ar.deadline) {
-			const plans = await db.query.plannedPick.findMany({
-				where: eq(plannedPick.roundId, roundId),
-			})
-			const autoPlans = plans.filter((p) => p.autoSubmit)
-			const notBefore = new Date(ar.deadline.getTime() - AUTO_SUBMIT_LEAD_MS)
-			for (const p of autoPlans) {
-				await enqueueAutoSubmit(p.gamePlayerId, p.roundId, p.teamId, notBefore)
-			}
-		}
-
 		if (deadlineHasPassed) {
-			transitionedRoundIds.push(roundId)
+			deadlinePassedRoundIds.push(roundId)
 		}
 
 		for (const af of ar.fixtures) {
@@ -416,7 +399,7 @@ export async function syncCompetition(
 		}
 	}
 
-	return { rounds: adapterRounds.length, fixtures: totalFixtures, transitionedRoundIds }
+	return { rounds: adapterRounds.length, fixtures: totalFixtures, deadlinePassedRoundIds }
 }
 
 export async function applyPotAssignments(

--- a/src/lib/game/process-round.ts
+++ b/src/lib/game/process-round.ts
@@ -6,6 +6,7 @@ import {
 	checkCupCompletion,
 	checkTurboCompletion,
 } from '@/lib/game/auto-complete'
+import { openRoundForGame } from '@/lib/game/round-lifecycle'
 import { processClassicRound } from '@/lib/game-logic/classic'
 import { evaluateCupPicks } from '@/lib/game-logic/cup'
 import { computeTierDifference } from '@/lib/game-logic/cup-tier'
@@ -20,24 +21,59 @@ import { game, gamePlayer, pick } from '@/lib/schema/game'
 
 /**
  * Advance the game's currentRoundId pointer to the next round in the
- * competition (or null if there are no further rounds). Called after
- * a round has been processed so that picks can begin on the next round
- * for this game. Round-state is per-game: each game advances independently
+ * competition. Round-state is per-game: each game advances independently
  * based on when its rounds complete, not on a global competition timeline.
+ *
+ * Refuses to advance to a round with no fixtures or no deadline (e.g. WC
+ * knockout pre-bracket-publication). In that case the game stays pointed at
+ * the just-completed round; advanceGameIfReady retries on subsequent cron
+ * ticks once the next round has been populated.
+ *
+ * On successful advance, marks the new currentRound as 'open' and schedules
+ * any auto-submit-flagged plans for it.
  */
 async function advanceGameToNextRound(
 	gameId: string,
 	competitionId: string,
 	completedRoundNumber: number,
-): Promise<void> {
+): Promise<{ advanced: boolean; reason?: 'no-next-round' | 'next-round-tbd' }> {
 	const nextRound = await db.query.round.findFirst({
 		where: and(eq(round.competitionId, competitionId), gt(round.number, completedRoundNumber)),
 		orderBy: [asc(round.number)],
+		with: { fixtures: true },
 	})
-	await db
-		.update(game)
-		.set({ currentRoundId: nextRound?.id ?? null })
-		.where(eq(game.id, gameId))
+	if (!nextRound) {
+		await db.update(game).set({ currentRoundId: null }).where(eq(game.id, gameId))
+		return { advanced: false, reason: 'no-next-round' }
+	}
+	if (nextRound.fixtures.length === 0 || nextRound.deadline == null) {
+		return { advanced: false, reason: 'next-round-tbd' }
+	}
+	await db.update(game).set({ currentRoundId: nextRound.id }).where(eq(game.id, gameId))
+	await openRoundForGame(nextRound.id)
+	return { advanced: true }
+}
+
+/**
+ * Retry advancement for games stuck pointing at a completed round. Used by
+ * the cron to pick up games whose next round was TBD at process-time and
+ * has since been populated by bootstrap.
+ */
+export async function advanceGameIfReady(
+	gameId: string,
+): Promise<{ advanced: boolean; reason: string }> {
+	const g = await db.query.game.findFirst({
+		where: eq(game.id, gameId),
+		with: { currentRound: true },
+	})
+	if (!g) return { advanced: false, reason: 'not-found' }
+	if (g.status !== 'active') return { advanced: false, reason: 'not-active' }
+	if (!g.currentRound) return { advanced: false, reason: 'no-current-round' }
+	if (g.currentRound.status !== 'completed') {
+		return { advanced: false, reason: 'round-not-completed' }
+	}
+	const result = await advanceGameToNextRound(g.id, g.competitionId, g.currentRound.number)
+	return { advanced: result.advanced, reason: result.reason ?? 'advanced' }
 }
 
 export async function processGameRound(gameId: string, roundId: string) {

--- a/src/lib/game/round-lifecycle.test.ts
+++ b/src/lib/game/round-lifecycle.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { dbMock, enqueueAutoSubmitMock } = vi.hoisted(() => {
+	const enqueueAutoSubmitMock = vi.fn().mockResolvedValue(undefined)
+	const updateSet = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }))
+	return {
+		enqueueAutoSubmitMock,
+		dbMock: {
+			query: {
+				round: { findFirst: vi.fn() },
+				plannedPick: { findMany: vi.fn().mockResolvedValue([]) },
+			},
+			update: vi.fn(() => ({ set: updateSet })),
+		},
+	}
+})
+
+vi.mock('@/lib/db', () => ({ db: dbMock }))
+vi.mock('@/lib/data/qstash', () => ({
+	enqueueAutoSubmit: enqueueAutoSubmitMock,
+}))
+
+import {
+	openRoundForGame,
+	scheduleAutoSubmitForPlan,
+	scheduleAutoSubmitsForRound,
+} from './round-lifecycle'
+
+describe('openRoundForGame', () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it('flips a round from upcoming → open and schedules autoSubmit plans', async () => {
+		const deadline = new Date(Date.now() + 7 * 24 * 3600 * 1000)
+		dbMock.query.round.findFirst.mockResolvedValue({
+			id: 'r1',
+			status: 'upcoming',
+			deadline,
+		} as never)
+		dbMock.query.plannedPick.findMany.mockResolvedValue([
+			{ gamePlayerId: 'gp1', roundId: 'r1', teamId: 't1', autoSubmit: true },
+			{ gamePlayerId: 'gp2', roundId: 'r1', teamId: 't2', autoSubmit: false },
+		] as never)
+
+		await openRoundForGame('r1')
+
+		// Round update: status = 'open'
+		expect(dbMock.update).toHaveBeenCalled()
+		// Only the autoSubmit=true plan gets enqueued
+		expect(enqueueAutoSubmitMock).toHaveBeenCalledTimes(1)
+		expect(enqueueAutoSubmitMock).toHaveBeenCalledWith(
+			'gp1',
+			'r1',
+			't1',
+			new Date(deadline.getTime() - 60_000),
+		)
+	})
+
+	it('does not flip a round that is already open', async () => {
+		dbMock.query.round.findFirst.mockResolvedValue({
+			id: 'r1',
+			status: 'open',
+			deadline: new Date(Date.now() + 24 * 3600 * 1000),
+		} as never)
+
+		await openRoundForGame('r1')
+
+		expect(dbMock.update).not.toHaveBeenCalled()
+	})
+
+	it('does not flip completed rounds and does not enqueue', async () => {
+		dbMock.query.round.findFirst.mockResolvedValue({
+			id: 'r1',
+			status: 'completed',
+			deadline: new Date(Date.now() - 24 * 3600 * 1000),
+		} as never)
+
+		await openRoundForGame('r1')
+
+		expect(dbMock.update).not.toHaveBeenCalled()
+		expect(enqueueAutoSubmitMock).not.toHaveBeenCalled()
+	})
+
+	it('skips enqueue when deadline is already past or within the lead window', async () => {
+		dbMock.query.round.findFirst.mockResolvedValue({
+			id: 'r1',
+			status: 'upcoming',
+			deadline: new Date(Date.now() + 30_000), // 30s in the future, less than 60s lead
+		} as never)
+		dbMock.query.plannedPick.findMany.mockResolvedValue([
+			{ gamePlayerId: 'gp1', roundId: 'r1', teamId: 't1', autoSubmit: true },
+		] as never)
+
+		await openRoundForGame('r1')
+
+		expect(enqueueAutoSubmitMock).not.toHaveBeenCalled()
+	})
+
+	it('returns silently when the round does not exist', async () => {
+		dbMock.query.round.findFirst.mockResolvedValue(undefined as never)
+		await openRoundForGame('missing')
+		expect(dbMock.update).not.toHaveBeenCalled()
+		expect(enqueueAutoSubmitMock).not.toHaveBeenCalled()
+	})
+})
+
+describe('scheduleAutoSubmitsForRound', () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it('enqueues only autoSubmit=true plans', async () => {
+		const deadline = new Date(Date.now() + 7 * 24 * 3600 * 1000)
+		dbMock.query.round.findFirst.mockResolvedValue({
+			id: 'r1',
+			status: 'open',
+			deadline,
+		} as never)
+		dbMock.query.plannedPick.findMany.mockResolvedValue([
+			{ gamePlayerId: 'gp1', roundId: 'r1', teamId: 't1', autoSubmit: true },
+			{ gamePlayerId: 'gp2', roundId: 'r1', teamId: 't2', autoSubmit: false },
+			{ gamePlayerId: 'gp3', roundId: 'r1', teamId: 't3', autoSubmit: true },
+		] as never)
+
+		await scheduleAutoSubmitsForRound('r1')
+
+		expect(enqueueAutoSubmitMock).toHaveBeenCalledTimes(2)
+	})
+})
+
+describe('scheduleAutoSubmitForPlan', () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it('enqueues for a single plan with deadline T-60s', async () => {
+		const deadline = new Date(Date.now() + 24 * 3600 * 1000)
+		dbMock.query.round.findFirst.mockResolvedValue({
+			id: 'r1',
+			deadline,
+		} as never)
+
+		await scheduleAutoSubmitForPlan('gp1', 'r1', 't1')
+
+		expect(enqueueAutoSubmitMock).toHaveBeenCalledWith(
+			'gp1',
+			'r1',
+			't1',
+			new Date(deadline.getTime() - 60_000),
+		)
+	})
+
+	it('skips if round has no deadline', async () => {
+		dbMock.query.round.findFirst.mockResolvedValue({ id: 'r1', deadline: null } as never)
+		await scheduleAutoSubmitForPlan('gp1', 'r1', 't1')
+		expect(enqueueAutoSubmitMock).not.toHaveBeenCalled()
+	})
+})

--- a/src/lib/game/round-lifecycle.ts
+++ b/src/lib/game/round-lifecycle.ts
@@ -1,0 +1,57 @@
+import { eq } from 'drizzle-orm'
+import { enqueueAutoSubmit } from '@/lib/data/qstash'
+import { db } from '@/lib/db'
+import { round } from '@/lib/schema/competition'
+import { plannedPick } from '@/lib/schema/game'
+
+const AUTO_SUBMIT_LEAD_MS = 60_000
+
+/**
+ * A round transitions from 'upcoming' → 'open' when a game starts using it
+ * (game creation OR advance after a previous round finishes). Bootstrap no
+ * longer drives this transition based on wall-clock time — that was a
+ * regression from the predecessor app.
+ *
+ * Idempotent: safe to call repeatedly; status flip is a no-op if already
+ * 'open' or beyond, and auto-submit enqueues use QStash dedup IDs.
+ */
+export async function openRoundForGame(roundId: string): Promise<void> {
+	const r = await db.query.round.findFirst({ where: eq(round.id, roundId) })
+	if (!r) return
+	if (r.status === 'upcoming') {
+		await db.update(round).set({ status: 'open' }).where(eq(round.id, roundId))
+	}
+	await scheduleAutoSubmitsForRound(roundId)
+}
+
+/**
+ * Find all auto-submit-marked planned picks for a round and enqueue their
+ * QStash triggers for T-60s before the deadline. Idempotent via dedup IDs.
+ */
+export async function scheduleAutoSubmitsForRound(roundId: string): Promise<void> {
+	const r = await db.query.round.findFirst({ where: eq(round.id, roundId) })
+	if (!r?.deadline) return
+	const plans = await db.query.plannedPick.findMany({ where: eq(plannedPick.roundId, roundId) })
+	const autoPlans = plans.filter((p) => p.autoSubmit)
+	if (autoPlans.length === 0) return
+	const notBefore = new Date(r.deadline.getTime() - AUTO_SUBMIT_LEAD_MS)
+	if (notBefore.getTime() <= Date.now()) return // deadline already very close or past
+	for (const p of autoPlans) {
+		await enqueueAutoSubmit(p.gamePlayerId, p.roundId, p.teamId, notBefore)
+	}
+}
+
+/**
+ * Schedule auto-submit for a single just-created/updated plan.
+ */
+export async function scheduleAutoSubmitForPlan(
+	gamePlayerId: string,
+	roundId: string,
+	teamId: string,
+): Promise<void> {
+	const r = await db.query.round.findFirst({ where: eq(round.id, roundId) })
+	if (!r?.deadline) return
+	const notBefore = new Date(r.deadline.getTime() - AUTO_SUBMIT_LEAD_MS)
+	if (notBefore.getTime() <= Date.now()) return
+	await enqueueAutoSubmit(gamePlayerId, roundId, teamId, notBefore)
+}


### PR DESCRIPTION
## Smoking gun (the regression we kept tripping over)

\`OPEN_WINDOW_MS = 48h\` in \`bootstrap-competitions.ts\` was a regression from the predecessor app. It made round status time-driven (\"flip to open at T-48h\") instead of game-lifecycle-driven (\"flip to open when a game starts using the round\"). That single heuristic was the root cause of multiple bugs:

- WC progress grid empty until 48h before deadline
- Planner showing wrong round states for fresh games
- Auto-submit triggers tied to wall-clock heuristics
- The PR #35 \`currentRoundId\` grid-filter hack was a workaround, not a fix

Confirmed not present in the old app.

## State machine — old vs new

| Transition | Old (broken) | New (matches old app) |
|------------|--------------|------------------------|
| upcoming → open | T-48h before deadline (bootstrap, time) | game creation / advanceGameToNextRound |
| open → completed | all fixtures finished (bootstrap) | processGameRound |

\`'active'\` continues to be a per-game *derived* state in \`round-status.ts\` (deadline + currentRoundId) — no need to store it in the DB.

## Auto-submit

Same firing time (T-60s before deadline). What changed is *when we schedule the QStash trigger*: now at game creation / round advance / plan creation, idempotent via dedup ID. User-visible behaviour unchanged.

## Folds in PR #25

PR #25 (empty-round advance guard + \`advanceGameIfReady\` cron retry) had the same stacking-PR bug as #31: it was merged into a feature branch, never reached main. Folded into this PR — \`advanceGameToNextRound\` now refuses to advance into a TBD/empty round, and the cron retries on subsequent ticks.

## Reconciliation

Daily-sync adds a heal pass: any active game whose currentRound is still 'upcoming' gets the round flipped to 'open'. Covers existing data and acts as a safety net.

## Files

- New: \`src/lib/game/round-lifecycle.ts\` + tests (8 new tests)
- \`api/games/route.ts\`: openRoundForGame on creation
- \`process-round.ts\`: advanceGameToNextRound flips new round, advanceGameIfReady retry
- \`api/games/[id]/planned-picks/route.ts\`: schedule auto-submit on plan creation
- \`bootstrap-competitions.ts\`: drop OPEN_WINDOW_MS, drop auto-submit logic, rename transitionedRoundIds → deadlinePassedRoundIds
- \`api/cron/daily-sync/route.ts\`: reconciliation + advance retry
- \`api/cron/process-rounds/route.ts\`: advance retry
- Bootstrap auto-submit-enqueue tests removed; daily-sync test mocks updated

## Supersedes

PR #35 — once the state machine is correct, the original \`r.status !== 'upcoming'\` grid filter works correctly. Recommend closing #35.

## Test plan

- [x] Tests + typecheck pass (397/397)
- [ ] Smoke: create new WC test game — confirm GW1 column appears in progress grid immediately, no 48h wait
- [ ] Smoke: existing WC test game (currentRound='upcoming') — confirm next daily-sync (or running daily-sync manually) heals it
- [ ] Smoke: PL game lifecycle — round advance from GW36 → GW37 marks GW37 as open; planned picks for GW37 with autoSubmit=true fire at T-60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)