### PR TITLE
fix(grid): show only rounds the game has touched

### DIFF
--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -766,8 +766,18 @@ export async function getProgressGridData(
 		? gameData.players.find((p) => p.userId === viewerUserId)?.id
 		: undefined
 
-	const completedAndCurrentRounds = gameData.competition.rounds.filter(
-		(r) => r.status !== 'upcoming',
+	// Show only rounds the GAME has touched, not every round the competition
+	// happens to have completed in the wider world. A round counts as touched
+	// if any player has a pick on it OR it's the game's current round. This
+	// keeps a brand-new PL game and a brand-new WC game looking identical
+	// (one column for the current round) rather than diverging based on how
+	// much of each competition has already played out.
+	const touchedRoundIds = new Set<string>()
+	for (const p of gameData.picks) touchedRoundIds.add(p.roundId)
+	if (gameData.currentRoundId) touchedRoundIds.add(gameData.currentRoundId)
+
+	const completedAndCurrentRounds = gameData.competition.rounds.filter((r) =>
+		touchedRoundIds.has(r.id),
 	)
 
 	const rounds: GridRound[] = completedAndCurrentRounds.map((r) => ({


### PR DESCRIPTION
## Smoking gun (continued)

After the state-machine fix in #36, brand-new PL and WC games still rendered different grid widths. PL inherited every past completed competition round (35+ columns of picks the player wasn't part of). WC showed one column.

The filter was \"every round whose status isn't upcoming\" — competition-wide. That's wrong for the per-game grid.

## Fix

The grid now filters to rounds the **game** has touched:
- Any round with a pick from any player, OR
- The game's currentRoundId

A brand-new PL game and a brand-new WC game both render exactly one column. The grid grows column-by-column as players make picks. Matches the predecessor app's per-game grid scoping.

## Edge cases

- **Late joiner in an existing PL game**: rounds before they joined still appear (other players have picks on them); their own cells render as empty — already handled by the eliminated-player branch.
- **Round-1 special rules** (draw exemption when allowRebuys=false): unchanged. The \`isStartingRound\` flag is still based on round.number === 1, which is the competition's round 1 — that's the right semantic for the season-1 free-pass rule.

## Test plan

- [x] Tests + typecheck pass (397/397)
- [ ] Smoke: create a new PL classic game today (PL is at GW36) — confirm grid shows just GW36 immediately, not GW1-36
- [ ] Smoke: create a new WC classic game — same one-column behaviour
- [ ] Smoke: existing in-progress game — grid still shows historical rounds where picks have been made

🤖 Generated with [Claude Code](https://claude.com/claude-code)