### PR TITLE
fix(rounds): WC deadlines, round labels, deadline+status display

### DIFF
--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
 	getTurboPickData,
 	getTurboStandingsData,
 } from '@/lib/game/detail-queries'
+import { roundLabel, roundLabelLong } from '@/lib/game/round-label'
 import { computeTierDifference } from '@/lib/game-logic/cup-tier'
 import { user } from '@/lib/schema/auth'
 import { gamePlayer } from '@/lib/schema/game'
@@ -190,6 +191,17 @@ export default async function GameDetailPage({
 	const now = new Date()
 	const roundDeadlinePassed = !!game.currentRound?.deadline && now >= game.currentRound.deadline
 
+	const competitionType = game.competition.type as 'league' | 'knockout' | 'group_knockout'
+	const headerRoundInfo = game.currentRound
+		? {
+				label: roundLabel(competitionType, game.currentRound.number),
+				longLabel: roundLabelLong(competitionType, game.currentRound.number),
+				deadline: game.currentRound.deadline,
+				deadlinePassed: roundDeadlinePassed,
+				roundCompleted: game.currentRound.status === 'completed',
+			}
+		: null
+
 	const pickSection =
 		game.currentRound && isAlive && !roundDeadlinePassed ? (
 			game.gameMode === 'classic' && classicPickData ? (
@@ -274,6 +286,7 @@ export default async function GameDetailPage({
 				otherPayments: game.otherPayments,
 				adminPayments: game.adminPayments,
 				myCurrentRoundPick: game.myCurrentRoundPick,
+				currentRound: headerRoundInfo,
 				defaultShareVariant: game.defaultShareVariant,
 				liveShareAvailable: game.liveShareAvailable,
 				winnerShareAvailable: game.winnerShareAvailable,

--- a/src/components/game/game-detail-view.tsx
+++ b/src/components/game/game-detail-view.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { AdminPanel } from '@/components/game/admin-panel'
 import { AutoPickBanner } from '@/components/game/auto-pick-banner'
-import { GameHeader } from '@/components/game/game-header'
+import { GameHeader, type GameHeaderRoundInfo } from '@/components/game/game-header'
 import { MyPaymentStrip } from '@/components/game/my-payment-strip'
 import { OtherPlayersPayments } from '@/components/game/other-players-payments'
 import type { PaymentStatus } from '@/components/game/payment-status-chip'
@@ -43,6 +43,7 @@ interface GameDetailViewProps {
 			teamShortName: string
 			kickoffLabel: string
 		} | null
+		currentRound: GameHeaderRoundInfo | null
 		defaultShareVariant: 'standings' | 'live' | 'winner'
 		liveShareAvailable: boolean
 		winnerShareAvailable: boolean
@@ -100,6 +101,7 @@ export function GameDetailView({
 					aliveCount={game.aliveCount}
 					status={game.status}
 					inviteCode={game.inviteCode}
+					currentRound={game.currentRound}
 					onShare={() => setShareOpen(true)}
 				/>
 

--- a/src/components/game/game-header.tsx
+++ b/src/components/game/game-header.tsx
@@ -1,8 +1,17 @@
 'use client'
 
-import { Share2, Users } from 'lucide-react'
+import { Clock, Share2, Users } from 'lucide-react'
+import { LocalDateTime } from '@/components/local-datetime'
 import { Button } from '@/components/ui/button'
 import type { PotBreakdown } from '@/lib/game-logic/prizes'
+
+export interface GameHeaderRoundInfo {
+	label: string // short, e.g. "GW36" / "MD1" / "R16"
+	longLabel: string // long, e.g. "Gameweek 36" / "Matchday 1"
+	deadline: Date | null
+	deadlinePassed: boolean
+	roundCompleted: boolean
+}
 
 interface GameHeaderProps {
 	name: string
@@ -16,6 +25,7 @@ interface GameHeaderProps {
 	aliveCount: number
 	status: string
 	inviteCode: string
+	currentRound: GameHeaderRoundInfo | null
 	onShare: () => void
 }
 
@@ -29,7 +39,9 @@ export function GameHeader({
 	entryFee,
 	playerCount,
 	aliveCount,
+	status,
 	inviteCode,
+	currentRound,
 	onShare,
 }: GameHeaderProps) {
 	const hasPending = potBreakdown.pending !== '0.00'
@@ -71,6 +83,42 @@ export function GameHeader({
 				</div>
 			</div>
 
+			{currentRound && status !== 'completed' && (
+				<div className="border-t border-border bg-muted/20 px-5 py-3 flex items-center justify-between gap-3 flex-wrap">
+					<div className="flex items-center gap-3 min-w-0">
+						<RoundStatusPill
+							deadlinePassed={currentRound.deadlinePassed}
+							completed={currentRound.roundCompleted}
+						/>
+						<div className="min-w-0">
+							<div className="font-display text-sm font-semibold leading-tight">
+								{currentRound.longLabel}
+							</div>
+							<div className="text-xs text-muted-foreground mt-0.5 flex items-center gap-1">
+								<Clock className="h-3 w-3" />
+								{currentRound.deadline ? (
+									<>
+										Deadline{' '}
+										<LocalDateTime
+											date={currentRound.deadline}
+											options={{
+												weekday: 'short',
+												day: 'numeric',
+												month: 'short',
+												hour: '2-digit',
+												minute: '2-digit',
+											}}
+										/>
+									</>
+								) : (
+									<>Deadline TBC</>
+								)}
+							</div>
+						</div>
+					</div>
+				</div>
+			)}
+
 			<div className="border-t border-border bg-muted/30 px-5 py-2 flex items-center justify-between gap-3 flex-wrap">
 				<div className="text-xs text-muted-foreground">
 					Invite code: <span className="font-mono font-semibold text-foreground">{inviteCode}</span>
@@ -81,5 +129,33 @@ export function GameHeader({
 				</Button>
 			</div>
 		</div>
+	)
+}
+
+function RoundStatusPill({
+	deadlinePassed,
+	completed,
+}: {
+	deadlinePassed: boolean
+	completed: boolean
+}) {
+	if (completed) {
+		return (
+			<span className="text-[10px] uppercase tracking-wider font-bold px-2 py-1 rounded bg-muted text-muted-foreground">
+				Completed
+			</span>
+		)
+	}
+	if (deadlinePassed) {
+		return (
+			<span className="text-[10px] uppercase tracking-wider font-bold px-2 py-1 rounded bg-[var(--draw-bg)] text-[var(--draw)]">
+				Locked
+			</span>
+		)
+	}
+	return (
+		<span className="text-[10px] uppercase tracking-wider font-bold px-2 py-1 rounded bg-[var(--alive-bg)] text-[var(--alive)]">
+			Open
+		</span>
 	)
 }

--- a/src/components/picks/chain-ribbon.tsx
+++ b/src/components/picks/chain-ribbon.tsx
@@ -15,6 +15,7 @@ export type ChainSlotState =
 export interface ChainSlot {
 	roundId: string
 	roundNumber: number
+	roundLabel: string
 	state: ChainSlotState
 }
 
@@ -75,7 +76,7 @@ function Slot({ slot }: { slot: ChainSlot }) {
 	)
 	return (
 		<div className={wrapperClass}>
-			<div className="text-[9px] uppercase text-muted-foreground">GW{slot.roundNumber}</div>
+			<div className="text-[9px] uppercase text-muted-foreground">{slot.roundLabel}</div>
 			{'teamShort' in s && s.teamShort ? (
 				<div
 					className="mx-auto mt-1 h-7 w-7 rounded-full text-white text-[9px] font-bold flex items-center justify-center"

--- a/src/components/picks/classic-pick.tsx
+++ b/src/components/picks/classic-pick.tsx
@@ -402,6 +402,7 @@ function PlannerSection({
 							roundId={r.roundId}
 							roundNumber={r.roundNumber}
 							roundName={r.roundName}
+							roundLabel={r.roundLabel}
 							deadline={r.deadline}
 							fixturesTbc={r.fixturesTbc}
 							fixtures={r.fixtures}

--- a/src/components/picks/planner-round.tsx
+++ b/src/components/picks/planner-round.tsx
@@ -34,6 +34,7 @@ interface PlannerRoundProps {
 	roundId: string
 	roundNumber: number
 	roundName: string
+	roundLabel: string
 	deadline: Date | null
 	fixturesTbc: boolean
 	fixtures: PlannerFixture[]
@@ -51,7 +52,7 @@ export function PlannerRound(props: PlannerRoundProps) {
 		return (
 			<div className="rounded-xl border border-border bg-muted/30 px-3 py-3 opacity-55">
 				<div className="flex justify-between items-center">
-					<div className="font-semibold text-sm">GW{props.roundNumber} · Fixtures TBC</div>
+					<div className="font-semibold text-sm">{props.roundLabel} · Fixtures TBC</div>
 					<span className="text-[11px] text-muted-foreground">
 						Planner unlocks when fixtures are published
 					</span>
@@ -64,7 +65,7 @@ export function PlannerRound(props: PlannerRoundProps) {
 			<div className="flex justify-between items-center mb-2">
 				<div>
 					<div className="font-semibold text-sm">
-						GW{props.roundNumber} · {props.roundName}
+						{props.roundLabel} · {props.roundName}
 					</div>
 					{props.deadline && (
 						<div className="text-[11px] text-muted-foreground">

--- a/src/components/standings/progress-grid.tsx
+++ b/src/components/standings/progress-grid.tsx
@@ -23,6 +23,8 @@ export interface GridRound {
 	id: string
 	number: number
 	name: string
+	/** Short label for column headers, e.g. "GW1" / "MD1" / "R16". */
+	label: string
 	isStartingRound?: boolean
 }
 
@@ -50,6 +52,7 @@ export interface GridPlayer {
 	name: string
 	status: 'alive' | 'eliminated' | 'winner'
 	eliminatedRoundNumber?: number
+	eliminatedRoundLabel?: string
 	cellsByRoundId: Record<string, GridCell>
 }
 
@@ -208,7 +211,7 @@ export function ProgressGrid({
 										key={r.id}
 										className="font-medium text-muted-foreground text-center pb-3 px-1"
 									>
-										GW{r.number}
+										{r.label}
 									</th>
 								))}
 								<th className="pb-3 pl-4 min-w-[80px] text-right">Status</th>
@@ -279,7 +282,7 @@ export function ProgressGrid({
 												<td key={r.id} className="px-1 text-center align-middle">
 													<GridCellView
 														cell={cell}
-														roundNumber={r.number}
+														roundLabel={r.label}
 														showOpponents={showOpponents}
 														bump={bump}
 													/>
@@ -293,7 +296,7 @@ export function ProgressGrid({
 												</span>
 											) : player.status === 'eliminated' ? (
 												<span className="text-[0.7rem] font-semibold px-2 py-0.5 rounded bg-[var(--eliminated-bg)] text-[var(--eliminated)]">
-													GW{player.eliminatedRoundNumber}
+													{player.eliminatedRoundLabel ?? `GW${player.eliminatedRoundNumber}`}
 												</span>
 											) : (
 												<span className="text-[0.7rem] font-semibold px-2 py-0.5 rounded bg-yellow-100 text-yellow-900">
@@ -314,12 +317,12 @@ export function ProgressGrid({
 
 function GridCellView({
 	cell,
-	roundNumber,
+	roundLabel,
 	showOpponents,
 	bump,
 }: {
 	cell: GridCell
-	roundNumber: number
+	roundLabel: string
 	showOpponents: boolean
 	bump?: 'up' | 'down' | null
 }) {
@@ -430,8 +433,8 @@ function GridCellView({
 							: ' — Pending'
 	const autoPart = cell.isAuto ? ' (auto-pick)' : ''
 	const tooltipLabel = cell.teamShortName
-		? `${cell.teamShortName}${opponentPart}${scorePart}${resultPart}${autoPart} (GW${roundNumber})`
-		: `GW${roundNumber}`
+		? `${cell.teamShortName}${opponentPart}${scorePart}${resultPart}${autoPart} (${roundLabel})`
+		: roundLabel
 
 	return (
 		<Tooltip>

--- a/src/lib/data/football-data.test.ts
+++ b/src/lib/data/football-data.test.ts
@@ -89,10 +89,11 @@ describe('FootballDataAdapter', () => {
 		expect(rounds[0].fixtures).toHaveLength(2)
 	})
 
-	it('derives round deadline from earliest fixture kickoff', async () => {
+	it('derives round deadline from earliest fixture kickoff − 90 minutes', async () => {
 		const rounds = await adapter.fetchRounds()
-		// mockMatches earliest kickoff is 2025-08-16T15:00:00Z
-		expect(rounds[0].deadline).toEqual(new Date('2025-08-16T15:00:00Z'))
+		// mockMatches earliest kickoff is 2025-08-16T15:00:00Z, deadline is 90m
+		// before that to match FPL's deadline_time convention (team news release).
+		expect(rounds[0].deadline).toEqual(new Date('2025-08-16T13:30:00Z'))
 	})
 
 	it('returns null deadline when round has no playable fixtures (e.g. WC knockout pre-draw)', async () => {

--- a/src/lib/data/football-data.ts
+++ b/src/lib/data/football-data.ts
@@ -111,20 +111,22 @@ export class FootballDataAdapter implements CompetitionAdapter {
 			.sort(([a], [b]) => a - b)
 			.map(([matchday, matches]) => {
 				const playable = matches.filter((m) => m.homeTeam.id != null && m.awayTeam.id != null)
-				// Round deadline = earliest kickoff in the round. Picks lock when the
-				// first match starts. football-data doesn't supply a separate
-				// deadline concept (unlike FPL), so we derive from kickoffs. Knockout
-				// rounds with TBD fixtures have no kickoffs yet — deadline stays null
-				// until the bracket is published and the next bootstrap sync runs.
+				// Round deadline = earliest kickoff − 90 minutes. Matches the FPL
+				// convention (FPL's event.deadline_time is 90 min before the first
+				// match) and aligns with public team-news release. football-data
+				// doesn't supply a separate deadline concept, so we derive from
+				// kickoffs. Knockout rounds with TBD fixtures have no kickoffs yet
+				// — deadline stays null until the bracket is published.
 				const earliestKickoff = playable
 					.map((m) => new Date(m.utcDate).getTime())
 					.filter((t) => Number.isFinite(t))
 					.reduce((min, t) => (min === null || t < min ? t : min), null as number | null)
+				const deadline = earliestKickoff != null ? new Date(earliestKickoff - 90 * 60 * 1000) : null
 				return {
 					externalId: String(matchday),
 					number: matchday,
 					name: `Matchday ${matchday}`,
-					deadline: earliestKickoff != null ? new Date(earliestKickoff) : null,
+					deadline,
 					finished: matches.every((m) => m.status === 'FINISHED'),
 					fixtures: playable.map(
 						(m): AdapterFixture => ({

--- a/src/lib/game/classic-planner-view.ts
+++ b/src/lib/game/classic-planner-view.ts
@@ -20,6 +20,7 @@ export interface PlannerRoundInput {
 	roundId: string
 	roundNumber: number
 	roundName: string
+	roundLabel: string
 	deadline: Date | null
 	fixturesTbc: boolean
 	fixtures: PlannerFixture[]
@@ -32,6 +33,7 @@ export interface ChainRoundRow {
 	id: string
 	number: number
 	name: string | null
+	label: string
 	status: 'upcoming' | 'open' | 'active' | 'completed'
 }
 
@@ -81,6 +83,7 @@ export function buildChainSlots(input: BuildChainSlotsInput): {
 				return {
 					roundId: r.id,
 					roundNumber: r.number,
+					roundLabel: r.label,
 					state: plan.autoSubmit
 						? {
 								kind: 'planned-locked',
@@ -97,6 +100,7 @@ export function buildChainSlots(input: BuildChainSlotsInput): {
 			return {
 				roundId: r.id,
 				roundNumber: r.number,
+				roundLabel: r.label,
 				state: {
 					kind: 'current',
 					teamShort: input.currentPick?.teamShortName ?? null,
@@ -112,6 +116,7 @@ export function buildChainSlots(input: BuildChainSlotsInput): {
 				return {
 					roundId: r.id,
 					roundNumber: r.number,
+					roundLabel: r.label,
 					state: { kind: 'win', teamShort: past.teamShortName, teamColour: past.teamColour },
 				}
 			}
@@ -119,6 +124,7 @@ export function buildChainSlots(input: BuildChainSlotsInput): {
 				return {
 					roundId: r.id,
 					roundNumber: r.number,
+					roundLabel: r.label,
 					state: { kind: 'draw', teamShort: past.teamShortName, teamColour: past.teamColour },
 				}
 			}
@@ -126,6 +132,7 @@ export function buildChainSlots(input: BuildChainSlotsInput): {
 				return {
 					roundId: r.id,
 					roundNumber: r.number,
+					roundLabel: r.label,
 					state: { kind: 'loss', teamShort: past.teamShortName, teamColour: past.teamColour },
 				}
 			}
@@ -137,6 +144,7 @@ export function buildChainSlots(input: BuildChainSlotsInput): {
 			return {
 				roundId: r.id,
 				roundNumber: r.number,
+				roundLabel: r.label,
 				state: plan.autoSubmit
 					? {
 							kind: 'planned-locked',
@@ -152,10 +160,20 @@ export function buildChainSlots(input: BuildChainSlotsInput): {
 		}
 
 		if (input.upcomingRoundsFixturesTbc.has(r.id)) {
-			return { roundId: r.id, roundNumber: r.number, state: { kind: 'tbc' } }
+			return {
+				roundId: r.id,
+				roundNumber: r.number,
+				roundLabel: r.label,
+				state: { kind: 'tbc' },
+			}
 		}
 
-		return { roundId: r.id, roundNumber: r.number, state: { kind: 'empty' } }
+		return {
+			roundId: r.id,
+			roundNumber: r.number,
+			roundLabel: r.label,
+			state: { kind: 'empty' },
+		}
 	})
 
 	const played = input.pastPicks.length
@@ -176,6 +194,7 @@ export interface FutureRoundRow {
 	id: string
 	number: number
 	name: string | null
+	label: string
 	deadline: Date | null
 	fixtures: Array<{
 		id: string
@@ -259,7 +278,8 @@ export function buildPlannerRounds(input: BuildPlannerRoundsInput): PlannerRound
 		return {
 			roundId: r.id,
 			roundNumber: r.number,
-			roundName: r.name ?? `GW${r.number}`,
+			roundLabel: r.label,
+			roundName: r.name ?? r.label,
 			deadline: r.deadline,
 			fixturesTbc,
 			fixtures,

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -766,8 +766,18 @@ export async function getProgressGridData(
 		? gameData.players.find((p) => p.userId === viewerUserId)?.id
 		: undefined
 
-	const completedAndCurrentRounds = gameData.competition.rounds.filter(
-		(r) => r.status !== 'upcoming',
+	// Show only rounds the GAME has touched, not every round the competition
+	// happens to have completed in the wider world. A round counts as touched
+	// if any player has a pick on it OR it's the game's current round. This
+	// keeps a brand-new PL game and a brand-new WC game looking identical
+	// (one column for the current round) rather than diverging based on how
+	// much of each competition has already played out.
+	const touchedRoundIds = new Set<string>()
+	for (const p of gameData.picks) touchedRoundIds.add(p.roundId)
+	if (gameData.currentRoundId) touchedRoundIds.add(gameData.currentRoundId)
+
+	const completedAndCurrentRounds = gameData.competition.rounds.filter((r) =>
+		touchedRoundIds.has(r.id),
 	)
 
 	const rounds: GridRound[] = completedAndCurrentRounds.map((r) => ({

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -12,6 +12,7 @@ import {
 	type FutureRoundRow,
 } from '@/lib/game/classic-planner-view'
 import { isRebuyEligible } from '@/lib/game/rebuy'
+import { roundLabel, roundLabelLong } from '@/lib/game/round-label'
 import { deriveGameRoundStatus } from '@/lib/game/round-status'
 import { calculatePot } from '@/lib/game-logic/prizes'
 import { fixture, round, team } from '@/lib/schema/competition'
@@ -780,10 +781,12 @@ export async function getProgressGridData(
 		touchedRoundIds.has(r.id),
 	)
 
+	const competitionType = gameData.competition.type as 'league' | 'knockout' | 'group_knockout'
 	const rounds: GridRound[] = completedAndCurrentRounds.map((r) => ({
 		id: r.id,
 		number: r.number,
-		name: r.name ?? `GW${r.number}`,
+		name: r.name ?? roundLabelLong(competitionType, r.number),
+		label: roundLabel(competitionType, r.number),
 		isStartingRound: r.number === 1,
 	}))
 
@@ -875,13 +878,18 @@ export async function getProgressGridData(
 			}
 		}
 
+		const eliminatedRoundNumber = p.eliminatedRoundId
+			? gameData.competition.rounds.find((r) => r.id === p.eliminatedRoundId)?.number
+			: undefined
 		return {
 			id: p.id,
 			name: userNames.get(p.userId) ?? 'Player',
 			status: p.status,
-			eliminatedRoundNumber: p.eliminatedRoundId
-				? gameData.competition.rounds.find((r) => r.id === p.eliminatedRoundId)?.number
-				: undefined,
+			eliminatedRoundNumber,
+			eliminatedRoundLabel:
+				eliminatedRoundNumber != null
+					? roundLabel(competitionType, eliminatedRoundNumber)
+					: undefined,
 			cellsByRoundId,
 		}
 	})
@@ -999,10 +1007,12 @@ export async function getClassicPlannerData(
 	const currentRoundNumber = currentRoundId
 		? (gameData.competition.rounds.find((r) => r.id === currentRoundId)?.number ?? null)
 		: null
+	const competitionType = gameData.competition.type as 'league' | 'knockout' | 'group_knockout'
 	const rounds: ChainRoundRow[] = gameData.competition.rounds.map((r) => ({
 		id: r.id,
 		number: r.number,
 		name: r.name,
+		label: roundLabel(competitionType, r.number),
 		status: deriveGameRoundStatus({
 			round: { id: r.id, number: r.number, status: r.status, deadline: r.deadline },
 			game: { currentRoundId, currentRoundNumber },
@@ -1078,6 +1088,7 @@ export async function getClassicPlannerData(
 			id: r.id,
 			number: r.number,
 			name: r.name,
+			label: roundLabel(competitionType, r.number),
 			deadline: r.deadline,
 			fixtures: r.fixtures.map((f) => ({
 				id: f.id,

--- a/src/lib/game/round-label.test.ts
+++ b/src/lib/game/round-label.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { roundLabel, roundLabelLong } from './round-label'
+
+describe('roundLabel', () => {
+	it('formats league rounds as GW{n}', () => {
+		expect(roundLabel('league', 1)).toBe('GW1')
+		expect(roundLabel('league', 38)).toBe('GW38')
+	})
+
+	it('formats group_knockout group rounds as MD{n}', () => {
+		expect(roundLabel('group_knockout', 1)).toBe('MD1')
+		expect(roundLabel('group_knockout', 2)).toBe('MD2')
+		expect(roundLabel('group_knockout', 3)).toBe('MD3')
+	})
+
+	it('formats group_knockout knockout rounds with stage names', () => {
+		expect(roundLabel('group_knockout', 4)).toBe('R16')
+		expect(roundLabel('group_knockout', 5)).toBe('QF')
+		expect(roundLabel('group_knockout', 6)).toBe('SF')
+		expect(roundLabel('group_knockout', 7)).toBe('F')
+	})
+
+	it('formats single-elim knockout rounds as R{n}', () => {
+		expect(roundLabel('knockout', 1)).toBe('R1')
+		expect(roundLabel('knockout', 2)).toBe('R2')
+	})
+
+	it('falls back to R{n} for out-of-range group_knockout rounds', () => {
+		expect(roundLabel('group_knockout', 8)).toBe('R8')
+	})
+})
+
+describe('roundLabelLong', () => {
+	it('formats league rounds with full Gameweek prefix', () => {
+		expect(roundLabelLong('league', 12)).toBe('Gameweek 12')
+	})
+
+	it('formats group_knockout group rounds as Matchday {n}', () => {
+		expect(roundLabelLong('group_knockout', 1)).toBe('Matchday 1')
+	})
+
+	it('formats group_knockout knockout rounds with full stage names', () => {
+		expect(roundLabelLong('group_knockout', 4)).toBe('Round of 16')
+		expect(roundLabelLong('group_knockout', 5)).toBe('Quarter-final')
+		expect(roundLabelLong('group_knockout', 6)).toBe('Semi-final')
+		expect(roundLabelLong('group_knockout', 7)).toBe('Final')
+	})
+})

--- a/src/lib/game/round-label.ts
+++ b/src/lib/game/round-label.ts
@@ -1,0 +1,39 @@
+/**
+ * Competition-aware round labels.
+ *
+ * - 'league' (PL): GW{n} short, "Gameweek {n}" long.
+ * - 'group_knockout' (WC): MD{n} for group stages (rounds 1-3), then R16,
+ *   QF, SF, F for knockouts. Long form: "Matchday {n}", "Round of 16", etc.
+ * - 'knockout' (single-elim cups): R{n} short, "Round {n}" long.
+ */
+export type CompetitionType = 'league' | 'knockout' | 'group_knockout'
+
+export function roundLabel(competitionType: CompetitionType, roundNumber: number): string {
+	if (competitionType === 'group_knockout') {
+		if (roundNumber <= 3) return `MD${roundNumber}`
+		if (roundNumber === 4) return 'R16'
+		if (roundNumber === 5) return 'QF'
+		if (roundNumber === 6) return 'SF'
+		if (roundNumber === 7) return 'F'
+		return `R${roundNumber}`
+	}
+	if (competitionType === 'knockout') {
+		return `R${roundNumber}`
+	}
+	return `GW${roundNumber}`
+}
+
+export function roundLabelLong(competitionType: CompetitionType, roundNumber: number): string {
+	if (competitionType === 'group_knockout') {
+		if (roundNumber <= 3) return `Matchday ${roundNumber}`
+		if (roundNumber === 4) return 'Round of 16'
+		if (roundNumber === 5) return 'Quarter-final'
+		if (roundNumber === 6) return 'Semi-final'
+		if (roundNumber === 7) return 'Final'
+		return `Round ${roundNumber}`
+	}
+	if (competitionType === 'knockout') {
+		return `Round ${roundNumber}`
+	}
+	return `Gameweek ${roundNumber}`
+}


### PR DESCRIPTION
## Three connected fixes

After #37 landed, the WC test classic still showed differently from PL. Three concrete causes, all addressed here:

### 1. WC R1 had no visible deadline (likely null in DB)

The football-data adapter was setting deadline = earliest fixture kickoff. PL's FPL convention is **90 minutes before** the first match (matches public team-news release). Adopt the same for football-data competitions:

\`\`\`diff
- deadline: earliest kickoff
+ deadline: earliest kickoff − 90 min
\`\`\`

Existing WC rounds will be re-deadlined on the next bootstrap run (4am UTC daily-sync).

### 2. Round labels hardcoded as \`GW{n}\`

14 callsites used \`GW{r.number}\`, which is wrong for WC (Round of 16 ≠ "GW4"). New \`round-label.ts\` helper:

| Type | Short | Long |
|------|-------|------|
| league (PL) | GW1, GW36 | Gameweek 1, Gameweek 36 |
| group_knockout (WC) | MD1/MD2/MD3 then R16/QF/SF/F | Matchday 1, Round of 16, Quarter-final, … |
| knockout | R1, R2 | Round 1, Round 2 |

\`GridRound\`, \`GridPlayer\`, \`ChainSlot\`, \`ChainRoundRow\`, \`FutureRoundRow\`, \`PlannerRoundInput\` carry a \`label\` field. The progress grid, chain ribbon, planner row and eliminated-badge render that label instead of computing GW{n}. Cup-grid / turbo-standings / share-layouts still hardcoded — follow-up PR.

### 3. Deadline + game status missing from header

The \`GameHeader\` component received \`status\` as a prop but never rendered it, and there was no deadline anywhere on the game page outside the pick interface. New round-info row in the header:

- **Status pill**: Open / Locked (deadline passed) / Completed
- **Long round label**: \"Matchday 1\", \"Gameweek 36\", etc.
- **Deadline** rendered via \`<LocalDateTime />\` (or \"Deadline TBC\" if null)

## Tests

- 8 new for \`round-label.ts\`
- Football-data adapter test updated for the −90 min deadline
- 405/405 total passing

## Test plan

- [x] Tests + typecheck pass
- [ ] Smoke: open a WC test classic — confirm \"Matchday 1\" + deadline visible in header (post-bootstrap)
- [ ] Smoke: open a PL test classic — confirm \"Gameweek 36\" + deadline visible
- [ ] Smoke: progress grid columns show MD1/R16/etc. for WC, GW{n} for PL

🤖 Generated with [Claude Code](https://claude.com/claude-code)