### PR TITLE
fix(cup): WC cup mode entirely non-functional — five concrete bugs

### DIFF
--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -243,7 +243,7 @@ export default async function GameDetailPage({
 					maxLives={startingLives}
 					initialSlots={cupInitialSlots}
 					deadline={game.currentRound.deadline}
-					readonly={game.status !== 'open'}
+					readonly={game.status === 'completed'}
 					actingAs={actingAsForPickUI}
 					competitionId={game.competition.id}
 					roundNumber={game.currentRound.number}

--- a/src/app/api/games/[id]/join/route.ts
+++ b/src/app/api/games/[id]/join/route.ts
@@ -31,11 +31,19 @@ export async function POST(_request: Request, { params }: { params: Promise<{ id
 		return NextResponse.json({ error: 'Already a member of this game' }, { status: 400 })
 	}
 
+	// Cup mode players start with a configurable number of lives. Without this
+	// the cup mechanic is broken (the lives field stays at the schema default
+	// of 0 and players never earn the upset bonus). Other modes ignore the
+	// field; it's safe to set it universally.
+	const startingLives =
+		(gameData.modeConfig as { startingLives?: number } | null)?.startingLives ?? 0
+
 	const [player] = await db
 		.insert(gamePlayer)
 		.values({
 			gameId: id,
 			userId: session.user.id,
+			livesRemaining: startingLives,
 		})
 		.returning()
 

--- a/src/app/api/games/route.ts
+++ b/src/app/api/games/route.ts
@@ -104,10 +104,14 @@ export async function POST(request: Request) {
 		})
 		.returning()
 
-	// Creator automatically joins the game
+	// Creator automatically joins the game. Cup mode needs livesRemaining
+	// seeded from modeConfig.startingLives — the schema default of 0 leaves
+	// players with no lives and breaks the cup upset/save mechanic.
+	const creatorStartingLives = (modeConfig as { startingLives?: number } | null)?.startingLives ?? 0
 	await db.insert(gamePlayer).values({
 		gameId: newGame.id,
 		userId: session.user.id,
+		livesRemaining: creatorStartingLives,
 	})
 
 	// Create payment record if entry fee is set

--- a/src/app/api/picks/[gameId]/[roundId]/route.ts
+++ b/src/app/api/picks/[gameId]/[roundId]/route.ts
@@ -4,7 +4,7 @@ import { requireSession } from '@/lib/auth-helpers'
 import { db } from '@/lib/db'
 import { computeTierDifference } from '@/lib/game-logic/cup-tier'
 import { validateWcClassicPick, wcRoundStage } from '@/lib/game-logic/wc-classic'
-import { validateClassicPick, validateTurboPicks } from '@/lib/picks/validate'
+import { validateClassicPick, validateCupPicks, validateTurboPicks } from '@/lib/picks/validate'
 import { round } from '@/lib/schema/competition'
 import { game, gamePlayer, pick } from '@/lib/schema/game'
 
@@ -230,49 +230,52 @@ export async function POST(request: Request, { params }: { params: Params }) {
 		body.actingAs && targetGamePlayer.eliminatedReason === 'missed_rebuy_pick',
 	)
 
-	const validation = validateTurboPicks(
-		{
-			playerStatus: targetGamePlayer.status,
-			isCurrentRound: gameData.currentRoundId === roundId,
-			deadline: roundData.deadline,
-			now,
-			numberOfPicks,
-			fixtureIds: roundData.fixtures.map((f) => f.id),
-			picks: pickEntries,
-		},
-		{ allowEliminatedRebuy: allowEliminatedRebuyMulti },
-	)
-
-	if (!validation.valid) {
-		return NextResponse.json({ error: validation.reason }, { status: 400 })
-	}
-
-	// Cup mode: reject submissions that include any restricted pick (picking a team
-	// more than 1 tier below its opponent). The UI already hides these, but the API
-	// must enforce it defensively.
 	if (gameData.gameMode === 'cup') {
-		for (const entry of pickEntries as Array<{
-			fixtureId: string
-			predictedResult: string
-		}>) {
-			const fx = roundData.fixtures.find((f) => f.id === entry.fixtureId)
-			if (!fx) continue
-			if (entry.predictedResult !== 'home_win' && entry.predictedResult !== 'away_win') continue
-			const tierDiff = computeTierDifference(fx.homeTeam, fx.awayTeam, gameData.competition.type)
-			// A positive tierDiff means the home team is in a worse (higher-pot) tier.
-			// Picking the home side when tierDiff > 1 means picking a team > 1 tier below;
-			// picking the away side when tierDiff < -1 is the same case on the other side.
-			const tierFromPicked = entry.predictedResult === 'home_win' ? tierDiff : -tierDiff
-			if (tierFromPicked > 1) {
-				return NextResponse.json(
-					{
-						error: 'restricted',
-						fixtureId: entry.fixtureId,
-						predictedResult: entry.predictedResult,
-					},
-					{ status: 400 },
-				)
-			}
+		// Cup uses its own validator: partial rankings (1..numberOfPicks) allowed,
+		// plus the tier-restriction rule (no picking a team >1 tier below its
+		// opponent). Previously the API was routing cup submissions through
+		// validateTurboPicks which required the full count and never enforced
+		// the tier rule via the validator — restricted-pick check happened
+		// downstream which was the only thing keeping the rule alive.
+		const cupFixtures = roundData.fixtures.map((f) => ({
+			fixtureId: f.id,
+			tierDifference: computeTierDifference(f.homeTeam, f.awayTeam, gameData.competition.type),
+		}))
+		const cupValidation = validateCupPicks(
+			{
+				playerStatus: targetGamePlayer.status,
+				isCurrentRound: gameData.currentRoundId === roundId,
+				deadline: roundData.deadline,
+				now,
+				numberOfPicks,
+				fixtures: cupFixtures,
+				picks: pickEntries.map((p) => ({
+					fixtureId: p.fixtureId,
+					confidenceRank: p.confidenceRank,
+					predictedResult: p.predictedResult,
+					pickedTeam: p.predictedResult === 'away_win' ? 'away' : 'home',
+				})),
+			},
+			{ allowEliminatedRebuy: allowEliminatedRebuyMulti },
+		)
+		if (!cupValidation.valid) {
+			return NextResponse.json({ error: cupValidation.reason }, { status: 400 })
+		}
+	} else {
+		const validation = validateTurboPicks(
+			{
+				playerStatus: targetGamePlayer.status,
+				isCurrentRound: gameData.currentRoundId === roundId,
+				deadline: roundData.deadline,
+				now,
+				numberOfPicks,
+				fixtureIds: roundData.fixtures.map((f) => f.id),
+				picks: pickEntries,
+			},
+			{ allowEliminatedRebuy: allowEliminatedRebuyMulti },
+		)
+		if (!validation.valid) {
+			return NextResponse.json({ error: validation.reason }, { status: 400 })
 		}
 	}
 

--- a/src/components/game/create-game-form.tsx
+++ b/src/components/game/create-game-form.tsx
@@ -36,7 +36,10 @@ export function CreateGameForm({ competitions }: CreateGameFormProps) {
 	const [mode, setMode] = useState<GameMode | null>(null)
 	const [hasEntryFee, setHasEntryFee] = useState(true)
 	const [entryFee, setEntryFee] = useState(10)
-	const [startingLives, setStartingLives] = useState(0)
+	// Cup default: 3 lives. Matches downstream `modeConfig.startingLives ?? 3`
+	// fallback in game-detail page; setting it explicitly in the form means
+	// new cup games are playable out of the box.
+	const [startingLives, setStartingLives] = useState(3)
 	const [numberOfPicks, setNumberOfPicks] = useState(10)
 	const [allowRebuys, setAllowRebuys] = useState(true)
 	const [loading, setLoading] = useState(false)

--- a/src/components/picks/cup-pick.tsx
+++ b/src/components/picks/cup-pick.tsx
@@ -114,8 +114,11 @@ export function CupPick({
 	const [loading, setLoading] = useState(false)
 	const [error, setError] = useState<string | null>(null)
 
-	// Min picks to submit — default 60% of N, rounded up. Tunable later.
-	const minPicks = Math.ceil(numberOfPicks * 0.6)
+	// Predecessor app allowed any number of ranked picks (1..numberOfPicks).
+	// The previous 60% minimum was spec drift — restoring the predecessor's
+	// behaviour avoids the silent server/UI mismatch where the UI allowed 60%
+	// but the server demanded the full count.
+	const minPicks = 1
 
 	function handlePickTeam(fixtureId: string, side: 'home' | 'away') {
 		if (readonly) return
@@ -280,11 +283,6 @@ export function CupPick({
 							? 'Submitting...'
 							: (submitLabelOverride ?? `Submit ${slots.length} of ${numberOfPicks} picks`)}
 					</button>
-					{slots.length > 0 && slots.length < minPicks && (
-						<p className="mt-2 text-xs text-muted-foreground">
-							Rank at least {minPicks} picks before submitting.
-						</p>
-					)}
 					{error && (
 						<p className="mt-2 text-xs text-[var(--eliminated)]" role="alert">
 							{error}

--- a/src/lib/picks/validate.test.ts
+++ b/src/lib/picks/validate.test.ts
@@ -173,4 +173,51 @@ describe('validateCupPicks', () => {
 		})
 		expect(result).toEqual({ valid: true })
 	})
+
+	it('accepts a partial ranking (fewer than numberOfPicks)', () => {
+		const result = validateCupPicks({
+			...base,
+			numberOfPicks: 10,
+			fixtures: [
+				{ fixtureId: 'f1', tierDifference: 0 },
+				{ fixtureId: 'f2', tierDifference: 0 },
+			],
+			picks: [
+				{ fixtureId: 'f1', confidenceRank: 1, predictedResult: 'home_win', pickedTeam: 'home' },
+				{ fixtureId: 'f2', confidenceRank: 2, predictedResult: 'home_win', pickedTeam: 'home' },
+			],
+		})
+		expect(result).toEqual({ valid: true })
+	})
+
+	it('rejects zero picks', () => {
+		const result = validateCupPicks({ ...base, picks: [] })
+		expect(result).toEqual({ valid: false, reason: 'At least one pick required' })
+	})
+
+	it('rejects too many picks', () => {
+		const result = validateCupPicks({
+			...base,
+			numberOfPicks: 1,
+			picks: [
+				{ fixtureId: 'f1', confidenceRank: 1, predictedResult: 'home_win', pickedTeam: 'home' },
+				{ fixtureId: 'f2', confidenceRank: 2, predictedResult: 'home_win', pickedTeam: 'home' },
+			],
+		})
+		expect(result).toEqual({ valid: false, reason: 'Too many picks — maximum is 1' })
+	})
+
+	it('rejects ranks not starting from 1', () => {
+		const result = validateCupPicks({
+			...base,
+			picks: [
+				{ fixtureId: 'f1', confidenceRank: 2, predictedResult: 'away_win', pickedTeam: 'away' },
+				{ fixtureId: 'f2', confidenceRank: 3, predictedResult: 'home_win', pickedTeam: 'home' },
+			],
+		})
+		expect(result).toEqual({
+			valid: false,
+			reason: 'Confidence ranks must be unique sequential integers from 1',
+		})
+	})
 })

--- a/src/lib/picks/validate.ts
+++ b/src/lib/picks/validate.ts
@@ -78,18 +78,23 @@ export function validateCupPicks(
 	if (!input.isCurrentRound) return { valid: false, reason: 'Round is not open for picks' }
 	if (input.deadline && input.now > input.deadline)
 		return { valid: false, reason: 'Deadline has passed' }
-	if (input.picks.length !== input.numberOfPicks)
+	// Cup mode allows partial rankings — players can submit 1..numberOfPicks
+	// picks. Matches predecessor app behaviour. Turbo still requires the full
+	// count (see validateTurboPicks).
+	if (input.picks.length < 1) return { valid: false, reason: 'At least one pick required' }
+	if (input.picks.length > input.numberOfPicks)
 		return {
 			valid: false,
-			reason: `Expected ${input.numberOfPicks} picks, got ${input.picks.length}`,
+			reason: `Too many picks — maximum is ${input.numberOfPicks}`,
 		}
 
 	const fixtureSet = new Set(input.picks.map((p) => p.fixtureId))
 	if (fixtureSet.size !== input.picks.length)
 		return { valid: false, reason: 'Duplicate fixture in picks' }
 
+	// Ranks must be 1..picks.length contiguous starting from 1.
 	const ranks = input.picks.map((p) => p.confidenceRank).sort((a, b) => a - b)
-	const expected = Array.from({ length: input.numberOfPicks }, (_, i) => i + 1)
+	const expected = Array.from({ length: input.picks.length }, (_, i) => i + 1)
 	if (JSON.stringify(ranks) !== JSON.stringify(expected))
 		return { valid: false, reason: 'Confidence ranks must be unique sequential integers from 1' }
 


### PR DESCRIPTION
## Smoking gun

User reported they couldn't even *select* a pick in a fresh WC cup game, plus 0 lives for all players. Audit against the predecessor app found **five distinct bugs**, all from a single end-to-end test of cup mode that should have happened pre-launch:

1. **\`readonly={game.status !== 'open'}\`** — games are created with \`status: 'active'\`. The check was always true → every click was blocked at the FixtureRow level. **This was \"can't select any pick\".**

2. **\`livesRemaining\` never seeded** — game creation auto-join + player join routes both inserted \`gamePlayer\` without reading \`modeConfig.startingLives\`. Schema default = 0. The admin add-player route already did this correctly; same pattern now in both join paths.

3. **API used \`validateTurboPicks\` for cup mode** — turbo demands exact \`picks.length === numberOfPicks\`. Cup allows partial rankings per the predecessor. Cup-specific validator existed but was never called.

4. **\`validateCupPicks\` required full count** — relaxed to 1..N with contiguous ranks 1..picks.length.

5. **Form default \`startingLives = 0\`** — the form explicitly stored \`0\` in \`modeConfig\`, overriding the \`?? 3\` fallback downstream. Default now 3.

Bonus cleanup: removed undocumented 60% \`minPicks\` floor in the cup UI — it was spec drift from the predecessor and the silent server/UI mismatch (UI allowed 60%, server demanded 100%) was a separate hidden bug.

## Process note

The user has repeatedly asked for a full lifecycle audit of each game mode against the predecessor app. We did this for classic and turbo; cup was not. All five bugs would have surfaced from one end-to-end cup test pre-launch. Continuing this PR with the lifecycle audit the user has now explicitly asked for.

## Test plan

- [x] 4 new tests on \`validateCupPicks\` covering partial ranking, zero picks, too many, rank-from-1
- [x] Tests + typecheck pass (409/409)
- [ ] Smoke: create a WC cup game — confirm clicks work, lives show > 0, partial pick submission accepted
- [ ] Smoke: existing players: lives still 0 in DB (data migration not in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)