### PR TITLE
fix(cup): more lifecycle gaps + block cup mode on non-WC competitions

### DIFF
--- a/src/app/(app)/game/create/page.tsx
+++ b/src/app/(app)/game/create/page.tsx
@@ -3,5 +3,9 @@ import { getActiveCompetitions } from '@/lib/game/competitions-query'
 
 export default async function CreateGamePage() {
 	const competitions = await getActiveCompetitions()
-	return <CreateGameForm competitions={competitions.map((c) => ({ id: c.id, name: c.name }))} />
+	return (
+		<CreateGameForm
+			competitions={competitions.map((c) => ({ id: c.id, name: c.name, type: c.type }))}
+		/>
+	)
 }

--- a/src/app/api/games/[id]/admin/add-player/route.ts
+++ b/src/app/api/games/[id]/admin/add-player/route.ts
@@ -37,8 +37,11 @@ export async function POST(
 		return NextResponse.json({ error: 'already-in-game' }, { status: 409 })
 	}
 
-	const startingLives =
-		(gameRow.modeConfig as { startingLives?: number } | null)?.startingLives ?? 1
+	// Lives only matter in cup mode. Other modes ignore the field, so 0 is the
+	// right default. For cup, fall back to 3 if modeConfig somehow missing
+	// startingLives (matches form default + downstream `?? 3` fallbacks).
+	const configLives = (gameRow.modeConfig as { startingLives?: number } | null)?.startingLives
+	const startingLives = configLives ?? (gameRow.gameMode === 'cup' ? 3 : 0)
 	const [inserted] = await db
 		.insert(gamePlayer)
 		.values({

--- a/src/app/api/games/[id]/join/route.ts
+++ b/src/app/api/games/[id]/join/route.ts
@@ -18,7 +18,12 @@ export async function POST(_request: Request, { params }: { params: Promise<{ id
 		return NextResponse.json({ error: 'Game not found' }, { status: 404 })
 	}
 
-	if (gameData.status !== 'open') {
+	// Allow joining 'open' and 'active' games. Games are created in 'active'
+	// state directly (the 'open' enum value is currently unused by the
+	// creation flow), so requiring 'open' here would reject every invite-code
+	// join. Only 'completed' (game ended) and 'setup' (admin still configuring)
+	// are blocked.
+	if (gameData.status === 'completed' || gameData.status === 'setup') {
 		return NextResponse.json({ error: 'Game is not accepting new players' }, { status: 400 })
 	}
 
@@ -34,9 +39,9 @@ export async function POST(_request: Request, { params }: { params: Promise<{ id
 	// Cup mode players start with a configurable number of lives. Without this
 	// the cup mechanic is broken (the lives field stays at the schema default
 	// of 0 and players never earn the upset bonus). Other modes ignore the
-	// field; it's safe to set it universally.
-	const startingLives =
-		(gameData.modeConfig as { startingLives?: number } | null)?.startingLives ?? 0
+	// field; defaults match the form (cup → 3, other modes → 0).
+	const configLives = (gameData.modeConfig as { startingLives?: number } | null)?.startingLives
+	const startingLives = configLives ?? (gameData.gameMode === 'cup' ? 3 : 0)
 
 	const [player] = await db
 		.insert(gamePlayer)

--- a/src/app/api/games/route.ts
+++ b/src/app/api/games/route.ts
@@ -107,7 +107,9 @@ export async function POST(request: Request) {
 	// Creator automatically joins the game. Cup mode needs livesRemaining
 	// seeded from modeConfig.startingLives — the schema default of 0 leaves
 	// players with no lives and breaks the cup upset/save mechanic.
-	const creatorStartingLives = (modeConfig as { startingLives?: number } | null)?.startingLives ?? 0
+	// Defaults match the form: cup → 3, other modes → 0 (field ignored).
+	const configLives = (modeConfig as { startingLives?: number } | null)?.startingLives
+	const creatorStartingLives = configLives ?? (gameMode === 'cup' ? 3 : 0)
 	await db.insert(gamePlayer).values({
 		gameId: newGame.id,
 		userId: session.user.id,

--- a/src/app/api/games/route.ts
+++ b/src/app/api/games/route.ts
@@ -58,6 +58,21 @@ export async function POST(request: Request) {
 		return NextResponse.json({ error: 'Competition not found' }, { status: 404 })
 	}
 
+	// Cup mode requires FIFA pot tier differences, which only exist for
+	// group_knockout competitions. On league competitions there's no source
+	// of truth for tiers — cup-tier.ts silently returns 0, breaking the
+	// lives/upset mechanic. Reject at the API boundary so the UI gate can't
+	// be bypassed.
+	if (gameMode === 'cup' && comp.type !== 'group_knockout') {
+		return NextResponse.json(
+			{
+				error: 'cup-mode-requires-group-knockout',
+				message: 'Cup mode is only available for tournaments with tier-based seeding.',
+			},
+			{ status: 400 },
+		)
+	}
+
 	const inviteCode = generateInviteCode()
 
 	// Link to the competition's earliest still-pickable round. A round is

--- a/src/components/game/create-game-form.tsx
+++ b/src/components/game/create-game-form.tsx
@@ -18,7 +18,7 @@ import { Switch } from '@/components/ui/switch'
 import { cn } from '@/lib/utils'
 
 interface CreateGameFormProps {
-	competitions: Array<{ id: string; name: string }>
+	competitions: Array<{ id: string; name: string; type: string }>
 }
 
 type GameMode = 'classic' | 'turbo' | 'cup'
@@ -123,22 +123,43 @@ export function CreateGameForm({ competitions }: CreateGameFormProps) {
 					<div>
 						<Label>Game mode</Label>
 						<div className="grid gap-2 mt-2">
-							{(['classic', 'turbo', 'cup'] as const).map((m) => (
-								<button
-									key={m}
-									type="button"
-									onClick={() => setMode(m)}
-									className={cn(
-										'text-left p-3 rounded-lg border-2 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
-										mode === m
-											? 'border-[var(--alive)] bg-[var(--alive-bg)]'
-											: 'border-border hover:border-muted-foreground bg-card',
-									)}
-								>
-									<div className="font-display font-semibold capitalize">{m}</div>
-									<div className="text-xs text-muted-foreground mt-0.5">{MODE_DESCRIPTIONS[m]}</div>
-								</button>
-							))}
+							{(['classic', 'turbo', 'cup'] as const).map((m) => {
+								// Cup mode relies on FIFA pot tier differences, which only exist
+								// for group_knockout competitions (currently just WC 2026). On
+								// the PL the tier system has no source of truth and silently
+								// flattens — so the mode is disabled there entirely.
+								const selectedCompetition = competitions.find((c) => c.id === competitionId)
+								const isCupOnUnsupported =
+									m === 'cup' && selectedCompetition?.type !== 'group_knockout'
+								return (
+									<button
+										key={m}
+										type="button"
+										onClick={() => {
+											if (isCupOnUnsupported) return
+											setMode(m)
+										}}
+										disabled={isCupOnUnsupported}
+										className={cn(
+											'text-left p-3 rounded-lg border-2 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+											mode === m
+												? 'border-[var(--alive)] bg-[var(--alive-bg)]'
+												: 'border-border hover:border-muted-foreground bg-card',
+											isCupOnUnsupported && 'opacity-50 cursor-not-allowed hover:border-border',
+										)}
+									>
+										<div className="font-display font-semibold capitalize">{m}</div>
+										<div className="text-xs text-muted-foreground mt-0.5">
+											{MODE_DESCRIPTIONS[m]}
+											{isCupOnUnsupported && (
+												<span className="block mt-1 text-[var(--eliminated)] font-medium">
+													Cup mode requires a tournament with tier-based seeding (e.g. World Cup).
+												</span>
+											)}
+										</div>
+									</button>
+								)
+							})}
 						</div>
 					</div>
 				)}


### PR DESCRIPTION
## Why a second PR

PR #40 was already merged; the extra commits from the lifecycle audit need their own PR. Re-targeting them onto a fresh branch off main.

## What's in here

### Bug fixes from the full-flow audit

After PR #40, ran the complete open → close cup lifecycle audit against the predecessor app. Three more gaps surfaced:

1. **Invite-code joining broken for ALL game modes** — \`POST /api/games/[id]/join\` rejected anything where \`status !== 'open'\`. Games are created in \`'active'\`. Affects classic + turbo too, not just cup. Now blocks only 'completed' / 'setup'.

2. **Game-creation lives fallback was \`?? 0\`** — if the form somehow didn't include \`startingLives\`, creator was inserted with 0 lives. Now defaults to 3 for \`gameMode === 'cup'\`, 0 otherwise.

3. **Admin add-player used hardcoded \`?? 1\`** — different from the join path. Same fallback logic now applied.

### Design call: cup mode disabled on non-WC competitions

Per your follow-up: cup mode's tier mechanic relies on FIFA pot tier differences, which only exist for \`group_knockout\` competitions. On the PL the tier system has no source of truth and silently flattens — every tier diff is 0, players can never earn lives.

Two-layer guard:
- **UI**: cup mode button disabled in the create-game form when the chosen competition isn't \`group_knockout\`, with a helper note explaining why.
- **API**: server rejects \`POST /api/games\` with cup + non-group_knockout combination so the UI gate can't be bypassed.

## Test plan

- [x] Tests + typecheck pass (409/409)
- [ ] Smoke: create a new PL game, confirm cup mode is disabled with the helper text
- [ ] Smoke: create a new WC game, confirm cup mode is selectable
- [ ] Smoke: try a direct \`POST /api/games\` with \`gameMode=cup, competitionId=<PL>\` — confirm 400 \`cup-mode-requires-group-knockout\`
- [ ] Smoke: invite-link join into an existing active game — confirm now succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)