### PR TITLE
fix(cup): flip computeTierDifference sign — favourites were paying out as underdogs

### DIFF
--- a/src/lib/game-logic/cup-tier.test.ts
+++ b/src/lib/game-logic/cup-tier.test.ts
@@ -7,10 +7,14 @@ describe('computeTierDifference', () => {
 	const pot2 = { externalIds: { fifa_pot: 2 } }
 	const noPot = { externalIds: {} }
 
-	it('returns homePot - awayPot for group_knockout', () => {
-		expect(computeTierDifference(pot1, pot4, 'group_knockout')).toBe(-3)
-		expect(computeTierDifference(pot4, pot1, 'group_knockout')).toBe(3)
-		expect(computeTierDifference(pot1, pot2, 'group_knockout')).toBe(-1)
+	it('returns positive when home is the stronger side (lower pot number)', () => {
+		// pot 1 = strongest. Spain (pot 1) home vs Cape Verde (pot 4) away
+		// → home 3 tiers stronger → +3.
+		expect(computeTierDifference(pot1, pot4, 'group_knockout')).toBe(3)
+		// Inverse: away is much stronger → home is 3 tiers weaker → -3.
+		expect(computeTierDifference(pot4, pot1, 'group_knockout')).toBe(-3)
+		// Pot 1 home vs pot 2 away: home 1 tier stronger → +1.
+		expect(computeTierDifference(pot1, pot2, 'group_knockout')).toBe(1)
 	})
 
 	it('returns 0 when a pot is missing', () => {

--- a/src/lib/game-logic/cup-tier.ts
+++ b/src/lib/game-logic/cup-tier.ts
@@ -11,5 +11,10 @@ export function computeTierDifference(
 	const homePot = Number(home.externalIds?.fifa_pot)
 	const awayPot = Number(away.externalIds?.fifa_pot)
 	if (!Number.isFinite(homePot) || !Number.isFinite(awayPot)) return 0
-	return homePot - awayPot
+	// FIFA pots are inverted: pot 1 is strongest, pot 4 is weakest. cup.ts
+	// expects `tierDifference > 0` when home is the stronger side (higher
+	// tier), so flip the subtraction: a low-pot home vs high-pot away
+	// (e.g. Spain pot 1 vs Cape Verde pot 4) yields +3, meaning home is
+	// 3 tiers stronger.
+	return awayPot - homePot
 }


### PR DESCRIPTION
## Summary

Picking Spain on Spain vs Cape Verde Islands was awarding 3 lives — exactly inverted.

`cup.ts` documents `tierDifference` as **positive when home is the stronger side**, and every consumer (validator, evaluator, standings, planner UI) reads that way:
- `tierDiffFromPicked > 1` → picking a >1-tier favourite (restricted)
- `tierDiffFromPicked < 0` → picking an underdog (gains lives on win)

But `computeTierDifference` returned `homePot - awayPot`. FIFA pots number strongest → 1, weakest → 4. So Spain (pot 1) home vs Cape Verde (pot 4) away returned **-3**, marking Spain as the 3-tier underdog. Result: picking Spain handed out 3 lives on every win, while picking Cape Verde was blocked as a "huge favourite".

## Fix

One line in `src/lib/game-logic/cup-tier.ts`:

```diff
- return homePot - awayPot
+ return awayPot - homePot
```

Plus a doc comment explaining the inverted pot numbering, and a corrected test asserting `pot1 home vs pot4 away → +3`.

## Consumers verified

All consumers already use the "positive = home stronger" convention — no further changes:
- `src/lib/picks/validate.ts:107-114` — restriction check
- `src/lib/game-logic/cup.ts:30-89` — evaluator (lives + restricted + draw_success)
- `src/lib/game/cup-standings-queries.ts:151-152, 292` — standings projection
- `src/lib/game/process-round.ts:293` — result processing on round close
- `src/components/picks/cup-pick.tsx:63, 82, 373` — planner UI restriction + underdog highlighting

🤖 Generated with [Claude Code](https://claude.com/claude-code)