### PR TITLE
feat(cancellation): per-mode fixture cancellation handling

### DIFF
--- a/docs/game-modes/classic.md
+++ b/docs/game-modes/classic.md
@@ -91,6 +91,20 @@ For `group_knockout` comps, also `validateWcClassicPick`: blocks picks of teams 
 }
 ```
 
+## Cancellation
+
+When a fixture's status flips to `cancelled` (or `postponed` — auto-cancelled), `settleFixture` routes to the void path. For classic:
+
+- **Per-pick void.** `pick.result = 'void'`, `pick.cancellation_reason = 'cancelled'`. Player stays alive. Team usage stays — the team can't be re-picked later. UI renders a distinct void cell.
+- **Round-void threshold.** If, after settling a cancellation, >50% of the round's fixtures are cancelled OR >5 absolute, `voidWholeRound` fires:
+  - `round.voided_at = now`, `round.status = 'completed'`.
+  - Every pick on the round → `result='void'`, `cancellation_reason='round-voided'`, even previously-settled wins/losses/draws.
+  - Players eliminated by this round are reinstated to `'alive'`.
+  - Team usage for `round-voided` picks is filtered out at validation time — teams are released.
+  - All games on this round advance via the standard flow.
+
+See [`docs/superpowers/specs/2026-05-12-fixture-cancellation-handling-design.md`](../superpowers/specs/2026-05-12-fixture-cancellation-handling-design.md).
+
 ## Smoke coverage
 
 `scripts/smoke/lifecycle.smoke.test.ts`, `lifecycle: classic-PL` + `lifecycle: classic-WC`:

--- a/docs/game-modes/cup.md
+++ b/docs/game-modes/cup.md
@@ -123,6 +123,14 @@ Cup mode on `group_knockout` competitions requires every team to carry an `exter
 }
 ```
 
+## Cancellation
+
+When a cup pick's fixture is cancelled, `pick.result = 'void'`, `life_gained=0`, `life_spent=false`. The whole-game re-eval (`reevaluateCupGame`) iterates rank-ordered and explicitly skips voided picks. Streak/lives state at the next rank picks up from the previous non-voided rank — voided picks contribute nothing positive or negative.
+
+No automatic round-void in cup; admin refunds via the existing endpoint if needed.
+
+See [`docs/superpowers/specs/2026-05-12-fixture-cancellation-handling-design.md`](../superpowers/specs/2026-05-12-fixture-cancellation-handling-design.md).
+
 ## Smoke coverage
 
 `scripts/smoke/lifecycle.smoke.test.ts`, `lifecycle: cup-WC`:

--- a/docs/game-modes/turbo.md
+++ b/docs/game-modes/turbo.md
@@ -77,6 +77,14 @@ For an in-progress fixture:
 }
 ```
 
+## Cancellation
+
+When a turbo pick's fixture is cancelled, `pick.result = 'void'` and the streak evaluator walks past it as if it weren't in the input. A 10-pick turbo with one cancelled fixture effectively becomes a 9-pick game — the streak counts ranks 1..(k-1) plus rank (k+1)..N, skipping the voided rank entirely.
+
+No automatic round-void in turbo; admin refunds via the existing endpoint if the situation calls for it.
+
+See [`docs/superpowers/specs/2026-05-12-fixture-cancellation-handling-design.md`](../superpowers/specs/2026-05-12-fixture-cancellation-handling-design.md).
+
 ## Smoke coverage
 
 `scripts/smoke/lifecycle.smoke.test.ts`, `lifecycle: turbo-PL`:

--- a/docs/superpowers/specs/2026-05-12-fixture-cancellation-handling-design.md
+++ b/docs/superpowers/specs/2026-05-12-fixture-cancellation-handling-design.md
@@ -1,0 +1,206 @@
+# Fixture cancellation handling
+
+**Status:** Designed 2026-05-12. Implementation queued as a follow-up PR to PR #45.
+**Author:** Claude, paired with Sean.
+**Cross-references:** `docs/superpowers/specs/2026-05-12-per-fixture-settlement-and-live-projection-design.md` (the per-fixture settlement architecture this builds on).
+
+---
+
+## tl;dr
+
+Per-fixture settlement (PR #45) lands picks on `pending → win/loss/draw/saved_by_life` whenever a fixture flips to `finished`. Cancelled and postponed fixtures never reach `finished`, so picks on them get stuck `pending` forever. This doc specifies how to settle picks on fixtures that never play — including the threshold logic for voiding a whole round.
+
+---
+
+## Scope: what counts as "cancellation"
+
+football-data's `status` enum covers more than just "cancelled":
+
+| football-data status | Treatment |
+| --- | --- |
+| `POSTPONED` | **Auto-cancel.** Postponed PL fixtures get rescheduled to other matchdays anyway; survivor games need to roll over rather than block. |
+| `CANCELLED` | Cancel. Fixture won't be played. |
+| `SUSPENDED` | Treat as `live` for now; if it ends as `AWARDED` or `CANCELLED` later, that settles it. |
+| `AWARDED` | **Normal settle.** Federation-decided result still has a winner. Pick.result = win/loss based on awarded winner; goals counted at face value (typically 3-0 by convention). |
+
+So in this design, "cancellation" means any fixture that ends in `CANCELLED` or `POSTPONED` (because postpone → auto-cancel). Awarded matches are not cancellations.
+
+---
+
+## Schema changes
+
+### `pick.result` gains `'void'`
+
+```sql
+ALTER TYPE pick_result ADD VALUE 'void';
+```
+
+Distinct semantic state. Queries that count "settled" picks should use `result IN ('win', 'loss', 'draw', 'saved_by_life')` — voids are deliberately excluded.
+
+### `fixture.status` gains `'cancelled'`
+
+```sql
+ALTER TYPE fixture_status ADD VALUE 'cancelled';
+```
+
+Replaces `'postponed'` for the operational state after settlement decides postponement = cancellation. `'postponed'` enum value stays for backwards compat with adapter intermediates but the settlement pipeline normalises both to `'cancelled'`.
+
+### `round` gains an optional voided marker
+
+Add `round.voided_at: timestamp | null`. Set when the round-void threshold (below) fires. Doesn't change `round.status` — that still flips to `'completed'`, but the void timestamp lets the UI render the prominent "round voided" treatment without inferring it.
+
+### `pick` gains `cancellation_reason: text | null`
+
+For the timeline + audit trail. Free text — typically `'postponed'` / `'cancelled'` / `'round-voided'`.
+
+---
+
+## Per-mode policy
+
+### Classic
+
+A classic pick whose fixture is cancelled:
+
+1. `pick.result = 'void'`.
+2. `pick.cancellation_reason = 'postponed' | 'cancelled'`.
+3. Player **stays alive**. No elimination.
+4. **Team is marked as used** (consumed). Player can't re-pick that team in a later round.
+
+Rationale: player committed to the team strategically. Releasing the team would let them bank stronger teams for harder rounds with hindsight — gameable.
+
+### Turbo
+
+A turbo pick whose fixture is cancelled:
+
+1. `pick.result = 'void'`.
+2. `pick.cancellation_reason` populated.
+3. Streak evaluation walks past voided picks as if they weren't there. Ranks 1–4 plus rank 6 settle normally; rank 5 contributes 0 to streak and 0 goals.
+4. Effectively the player plays a 9-pick game (for a single cancellation).
+
+Rationale: no result to predict means no skill to credit or debit. Skip is the only mathematically clean answer.
+
+### Cup
+
+A cup pick whose fixture is cancelled:
+
+1. `pick.result = 'void'`.
+2. `pick.cancellation_reason` populated.
+3. `pick.life_gained = 0`, `pick.life_spent = false`.
+4. `reevaluateCupGame` iterates rank-ordered and skips voided picks. Streak/lives state at the next rank is whatever it was at the previous non-voided rank.
+
+Same rationale as turbo.
+
+---
+
+## Round-void threshold (classic only)
+
+When the cancellations in a round are too widespread, void the whole round.
+
+### Trigger
+
+Fires when, after settling a cancellation, EITHER of:
+
+- More than **50%** of the round's fixtures are voided (status = `'cancelled'`); OR
+- More than **5** fixtures in the round are voided (absolute count, covers cases where 50% wouldn't fire on a small round).
+
+A 10-fixture PL gameweek triggers at 6 cancellations (60% > 50%, also > 5).
+An 8-fixture WC matchday triggers at 5 (62.5% > 50%).
+A 4-fixture knockout round triggers at 3 (75% > 50%; absolute count never reaches 6 but percentage suffices).
+
+### Behaviour
+
+1. `round.voided_at = NOW()`.
+2. `round.status = 'completed'` (so game advancement fires).
+3. Every pick on the round, including any already-settled ones (win/loss/draw): `pick.result = 'void'`, `pick.cancellation_reason = 'round-voided'`, team usage **released**. The round effectively didn't happen — including for picks that had real outcomes.
+4. All alive players carry forward — no eliminations from this round.
+5. Game advances to next round per the standard `advanceGameToNextRound` flow.
+
+### Turbo / cup equivalents
+
+No automatic round-void. If a real situation calls for one, admin intervenes via the existing `/api/games/[id]/admin/refund-payments` endpoint and (where appropriate) marks the game `completed` with no winner. The user's call: the per-mode mechanics in turbo/cup make a clean carry-forward harder to define, and admin judgement is sufficient given the rarity.
+
+---
+
+## Trigger surface
+
+Settlement logic extended:
+
+- `settleFixture(fixtureId)` checks the new fixture status. If `cancelled` (or `postponed` normalised to cancelled), call `voidFixture(fixtureId)` instead of the existing settle paths.
+- `voidFixture(fixtureId)` is the new helper — applies the per-mode void policy, persists `pick.result = 'void'`, marks teams consumed (classic), then:
+  - Checks the round-void threshold for classic competitions.
+  - If threshold crossed: `voidWholeRound(roundId)` — iterates every pick on the round, voids them all, releases teams, sets `round.voided_at`, advances games on that round.
+
+Same set of call sites as existing settle: live-poll observation, syncCompetition mirror, reconcile sweep.
+
+---
+
+## UI surface
+
+### Per-pick voided picks
+
+- **Progress grid / cup grid / turbo cells:** voided picks render with a dedicated visual — a soft blue tile with a "VOID" or "—" label. Distinct from `pending` (which is neutral grey), distinct from win/loss/draw colours. The one cell-state where we deliberately diverge from the "settled-style visual" rule, because there's no settled equivalent.
+- **Banner on game-detail page:** when the viewer has a voided pick on the current or most recent round, show a dismissible banner at the top. Content varies by mode:
+  - Classic: "Brighton vs Wolves was cancelled. Your pick has been voided — you stay alive and the team is locked from re-use."
+  - Turbo: "Brighton vs Wolves was cancelled. Your rank-5 pick is voided and doesn't count towards your streak."
+  - Cup: "Brighton vs Wolves was cancelled. Your rank-5 pick is voided — no life gained or spent."
+- **Timeline event:** every void writes an event row for audit + future history view.
+
+### Round-void (classic only)
+
+More prominent than per-pick:
+
+- The voided round's column in the progress grid renders with a striped background and a "ROUND VOIDED" header above the round label.
+- All cells in that column render as void (regardless of whether the underlying picks settled before the threshold fired).
+- Banner is non-dismissible until acknowledged: "Round X was voided — too many fixtures cancelled. All players carry forward to Round X+1."
+
+---
+
+## Edge cases
+
+1. **Cancellation arrives after the round already advanced.** Late `CANCELLED` status on a fixture in a `completed` round. Picks on that fixture have already been settled (win/loss/draw). Decision: **do not retroactively void.** Late cancellations are logged as a warning but don't reverse settled state — too disruptive once players have seen the result. Surface as ops alert.
+
+2. **Cancellation in a round that's not the game's current round.** Possible during bulk-sync after a long outage. Same as above: only void picks whose round hasn't completed yet.
+
+3. **Threshold crossed mid-fixture sequence.** If 5 fixtures finish normally and the 6th cancels, pushing the round over the threshold, the 5 already-settled picks get retroactively voided (per the "void the whole round" rule). This IS a behaviour change for the settled picks. Justified because the round outcome is now meaningless — no winner can be fairly determined.
+
+4. **Race: cancellation + live-poll both writing the fixture.** Idempotent guards apply: `voidFixture` checks `pick.result === 'pending'` before voiding (don't overwrite a settled pick). Order-of-operations: if a fixture flips finished and then cancelled (unusual but possible — corrected adapter data), settled state wins.
+
+5. **Mass-cancellation at game-creation time.** If a competition has historical voids when a new game is created, the picks created on those voided fixtures inherit `'void'` immediately. UI shows them as such from the start.
+
+---
+
+## Implementation plan
+
+Single PR after #45 merges. Internal ordering:
+
+1. Schema: add `'void'` to `pickResultEnum`, `'cancelled'` to `fixtureStatusEnum`, `round.voided_at` column, `pick.cancellation_reason` column.
+2. `voidFixture(fixtureId)` helper in `src/lib/game/settle.ts`. Per-mode dispatch.
+3. `voidWholeRound(roundId)` helper. Threshold check.
+4. Wire into `settleFixture` (route by fixture status: finished → existing settle path; cancelled/postponed → void path).
+5. Update `getLivePayload` projection: voided picks return `projectedOutcome: 'void'`. Player aggregates exclude voided picks from streak math.
+6. UI: add `void` cell variant to progress-grid + cup-grid + turbo-ladder. Banner component for voided picks. Round-voided column treatment.
+7. Smoke scenarios:
+   - Classic: single voided pick → player alive + team consumed.
+   - Classic: 6 voided fixtures in a 10-fixture round → round voided, all alive carry forward, teams released.
+   - Turbo: voided rank-5 pick → streak walks past, ranks 1-4 + 6-10 count normally.
+   - Cup: voided rank-3 pick → re-eval skips it, lives state at rank 4 matches rank 2 state.
+   - Awarded match settles normally with face-value goals.
+8. Update `docs/game-modes/{classic,turbo,cup}.md` cancellation sections.
+
+---
+
+## Decisions captured
+
+| Question | Decision |
+| --- | --- |
+| Postponed fixtures | Auto-cancel (don't wait for reschedule) |
+| Awarded matches | Normal settle (face-value goals) |
+| Schema representation | New `'void'` enum value on `pickResultEnum` |
+| Classic policy | Free pass, team consumed |
+| Turbo policy | Auto-skip (streak walks past) |
+| Cup policy | Auto-skip (re-eval walks past) |
+| Refunds | Out of scope (admin operation) |
+| Round-void threshold (classic) | >50% OR >5 absolute → whole round voided, all alive carry forward, teams released |
+| Round-void (turbo / cup) | Admin refunds; no automatic round-void |
+| UI per-pick | Distinct "void" cell visual + dismissible banner on game page + timeline event |
+| UI round-void | Prominent column treatment + non-dismissible banner until acknowledged |

--- a/drizzle/0005_add_cancellation_state.sql
+++ b/drizzle/0005_add_cancellation_state.sql
@@ -1,0 +1,4 @@
+ALTER TYPE "public"."fixture_status" ADD VALUE 'cancelled';--> statement-breakpoint
+ALTER TYPE "public"."pick_result" ADD VALUE 'void';--> statement-breakpoint
+ALTER TABLE "round" ADD COLUMN "voided_at" timestamp;--> statement-breakpoint
+ALTER TABLE "pick" ADD COLUMN "cancellation_reason" text;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1615 @@
+{
+  "id": "bccac251-1114-479a-8fef-037f5d50be2d",
+  "prevId": "e2c9fc13-80f1-4420-ad48-c67b957ec784",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition": {
+      "name": "competition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "competition_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_source": {
+          "name": "data_source",
+          "type": "competition_data_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "season": {
+          "name": "season",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fixture": {
+      "name": "fixture",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_team_id": {
+          "name": "home_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "away_team_id": {
+          "name": "away_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kickoff": {
+          "name": "kickoff",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_score": {
+          "name": "home_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "away_score": {
+          "name": "away_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "fixture_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ids": {
+          "name": "external_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fixture_round_id_round_id_fk": {
+          "name": "fixture_round_id_round_id_fk",
+          "tableFrom": "fixture",
+          "tableTo": "round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fixture_home_team_id_team_id_fk": {
+          "name": "fixture_home_team_id_team_id_fk",
+          "tableFrom": "fixture",
+          "tableTo": "team",
+          "columnsFrom": [
+            "home_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fixture_away_team_id_team_id_fk": {
+          "name": "fixture_away_team_id_team_id_fk",
+          "tableFrom": "fixture",
+          "tableTo": "team",
+          "columnsFrom": [
+            "away_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.round": {
+      "name": "round",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "round_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upcoming'"
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "round_competition_id_competition_id_fk": {
+          "name": "round_competition_id_competition_id_fk",
+          "tableFrom": "round",
+          "tableTo": "competition",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team": {
+      "name": "team",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_url": {
+          "name": "badge_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_color": {
+          "name": "primary_color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ids": {
+          "name": "external_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "league_position": {
+          "name": "league_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_form": {
+      "name": "team_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recent_results": {
+          "name": "recent_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "home_form": {
+          "name": "home_form",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "away_form": {
+          "name": "away_form",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "league_position": {
+          "name": "league_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_form_team_comp_idx": {
+          "name": "team_form_team_comp_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_form_team_id_team_id_fk": {
+          "name": "team_form_team_id_team_id_fk",
+          "tableFrom": "team_form",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_form_competition_id_competition_id_fk": {
+          "name": "team_form_competition_id_competition_id_fk",
+          "tableFrom": "team_form",
+          "tableTo": "competition",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game": {
+      "name": "game",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "game_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'setup'"
+        },
+        "game_mode": {
+          "name": "game_mode",
+          "type": "game_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode_config": {
+          "name": "mode_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_players": {
+          "name": "max_players",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_round_id": {
+          "name": "current_round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_competition_id_competition_id_fk": {
+          "name": "game_competition_id_competition_id_fk",
+          "tableFrom": "game",
+          "tableTo": "competition",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_current_round_id_round_id_fk": {
+          "name": "game_current_round_id_round_id_fk",
+          "tableFrom": "game",
+          "tableTo": "round",
+          "columnsFrom": [
+            "current_round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "game_invite_code_unique": {
+          "name": "game_invite_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_player": {
+      "name": "game_player",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "player_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'alive'"
+        },
+        "eliminated_round_id": {
+          "name": "eliminated_round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eliminated_reason": {
+          "name": "eliminated_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lives_remaining": {
+          "name": "lives_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_player_unique_idx": {
+          "name": "game_player_unique_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_player_game_id_game_id_fk": {
+          "name": "game_player_game_id_game_id_fk",
+          "tableFrom": "game_player",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_player_eliminated_round_id_round_id_fk": {
+          "name": "game_player_eliminated_round_id_round_id_fk",
+          "tableFrom": "game_player",
+          "tableTo": "round",
+          "columnsFrom": [
+            "eliminated_round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pick": {
+      "name": "pick",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_player_id": {
+          "name": "game_player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fixture_id": {
+          "name": "fixture_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_rank": {
+          "name": "confidence_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "predicted_result": {
+          "name": "predicted_result",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "pick_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "goals_scored": {
+          "name": "goals_scored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "life_gained": {
+          "name": "life_gained",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "life_spent": {
+          "name": "life_spent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_submitted": {
+          "name": "auto_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_auto": {
+          "name": "is_auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pick_player_round_idx": {
+          "name": "pick_player_round_idx",
+          "columns": [
+            {
+              "expression": "game_player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "round_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "confidence_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pick_game_id_game_id_fk": {
+          "name": "pick_game_id_game_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_game_player_id_game_player_id_fk": {
+          "name": "pick_game_player_id_game_player_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "game_player",
+          "columnsFrom": [
+            "game_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_round_id_round_id_fk": {
+          "name": "pick_round_id_round_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_team_id_team_id_fk": {
+          "name": "pick_team_id_team_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_fixture_id_fixture_id_fk": {
+          "name": "pick_fixture_id_fixture_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "fixture",
+          "columnsFrom": [
+            "fixture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planned_pick": {
+      "name": "planned_pick",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_player_id": {
+          "name": "game_player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_submit": {
+          "name": "auto_submit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "planned_pick_unique_idx": {
+          "name": "planned_pick_unique_idx",
+          "columns": [
+            {
+              "expression": "game_player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "round_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "planned_pick_game_player_id_game_player_id_fk": {
+          "name": "planned_pick_game_player_id_game_player_id_fk",
+          "tableFrom": "planned_pick",
+          "tableTo": "game_player",
+          "columnsFrom": [
+            "game_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "planned_pick_round_id_round_id_fk": {
+          "name": "planned_pick_round_id_round_id_fk",
+          "tableFrom": "planned_pick",
+          "tableTo": "round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "planned_pick_team_id_team_id_fk": {
+          "name": "planned_pick_team_id_team_id_fk",
+          "tableFrom": "planned_pick",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment": {
+      "name": "payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payment_game_id_game_id_fk": {
+          "name": "payment_game_id_game_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payout": {
+      "name": "payout",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_split": {
+          "name": "is_split",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "payout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payout_game_id_game_id_fk": {
+          "name": "payout_game_id_game_id_fk",
+          "tableFrom": "payout",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.competition_data_source": {
+      "name": "competition_data_source",
+      "schema": "public",
+      "values": [
+        "fpl",
+        "football_data",
+        "manual"
+      ]
+    },
+    "public.competition_type": {
+      "name": "competition_type",
+      "schema": "public",
+      "values": [
+        "league",
+        "knockout",
+        "group_knockout"
+      ]
+    },
+    "public.fixture_status": {
+      "name": "fixture_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "live",
+        "finished",
+        "postponed",
+        "cancelled"
+      ]
+    },
+    "public.round_status": {
+      "name": "round_status",
+      "schema": "public",
+      "values": [
+        "upcoming",
+        "open",
+        "active",
+        "completed"
+      ]
+    },
+    "public.game_mode": {
+      "name": "game_mode",
+      "schema": "public",
+      "values": [
+        "classic",
+        "turbo",
+        "cup"
+      ]
+    },
+    "public.game_status": {
+      "name": "game_status",
+      "schema": "public",
+      "values": [
+        "setup",
+        "open",
+        "active",
+        "completed"
+      ]
+    },
+    "public.pick_result": {
+      "name": "pick_result",
+      "schema": "public",
+      "values": [
+        "pending",
+        "win",
+        "loss",
+        "draw",
+        "saved_by_life",
+        "void"
+      ]
+    },
+    "public.player_status": {
+      "name": "player_status",
+      "schema": "public",
+      "values": [
+        "alive",
+        "eliminated",
+        "winner"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "manual",
+        "mangopay"
+      ]
+    },
+    "public.payment_status": {
+      "name": "payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "claimed",
+        "paid",
+        "refunded"
+      ]
+    },
+    "public.payout_status": {
+      "name": "payout_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1778591718698,
       "tag": "0004_add_pick_life_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1778598565917,
+      "tag": "0005_add_cancellation_state",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/smoke/cancellation.smoke.test.ts
+++ b/scripts/smoke/cancellation.smoke.test.ts
@@ -1,0 +1,456 @@
+/**
+ * Cancellation smoke tests — exercise the void path for each game mode.
+ *
+ * See:
+ *  - docs/superpowers/specs/2026-05-12-fixture-cancellation-handling-design.md
+ *  - src/lib/game/settle.ts (voidFixtureInternal + voidWholeRound + threshold)
+ */
+import { eq, sql } from 'drizzle-orm'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { db } from '@/lib/db'
+import { settleFixture } from '@/lib/game/settle'
+import { fixture, round as roundTable } from '@/lib/schema/competition'
+import { game, gamePlayer, pick } from '@/lib/schema/game'
+import {
+	finishFixture,
+	makeCompetition,
+	makeFixture,
+	makeGame,
+	makePick,
+	makePlayer,
+	makeRound,
+	makeTeam,
+	resetDb,
+} from './helpers'
+
+async function cancelFixture(fixtureId: string): Promise<void> {
+	await db
+		.update(fixture)
+		.set({ status: 'cancelled', homeScore: null, awayScore: null })
+		.where(sql`${fixture.id} = ${fixtureId}`)
+}
+
+beforeEach(async () => {
+	await resetDb()
+})
+
+afterAll(async () => {
+	await resetDb()
+})
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Classic — per-fixture void                                              */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe('cancellation: classic single-fixture void', () => {
+	it("voids the pick, leaves player alive, marks team as 'used'", async () => {
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const a = await makeTeam({ name: 'A', shortName: 'A' })
+		const b = await makeTeam({ name: 'B', shortName: 'B' })
+		const c = await makeTeam({ name: 'C', shortName: 'C' })
+		const d = await makeTeam({ name: 'D', shortName: 'D' })
+		const r2 = await makeRound(compId, { number: 2, status: 'open' })
+		const r3 = await makeRound(compId, {
+			number: 3,
+			status: 'upcoming',
+			deadline: new Date(Date.now() + 86_400_000),
+		})
+		const fxAB = await makeFixture({ roundId: r2, homeTeamId: a, awayTeamId: b })
+		const fxCD = await makeFixture({ roundId: r2, homeTeamId: c, awayTeamId: d })
+		await makeFixture({ roundId: r3, homeTeamId: a, awayTeamId: b })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r2,
+			modeConfig: { allowRebuys: false },
+		})
+		const gp = await makePlayer({ gameId, userId: 'u' })
+		const filler = await makePlayer({ gameId, userId: 'filler' })
+		const pickId = await makePick({
+			gameId,
+			gamePlayerId: gp,
+			roundId: r2,
+			teamId: a,
+			fixtureId: fxAB,
+		})
+		// Filler picks team C on the other fixture so when that finishes
+		// the round can complete + advance.
+		await makePick({ gameId, gamePlayerId: filler, roundId: r2, teamId: c, fixtureId: fxCD })
+
+		await cancelFixture(fxAB)
+		await settleFixture(fxAB)
+
+		const voided = await db.query.pick.findFirst({ where: eq(pick.id, pickId) })
+		expect(voided?.result).toBe('void')
+		expect(voided?.cancellationReason).toBe('cancelled')
+
+		const player = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gp) })
+		expect(player?.status).toBe('alive')
+
+		// Round can advance once the other fixture finishes — the cancelled
+		// fixture doesn't block round completion.
+		await finishFixture(fxCD, 1, 0)
+		await settleFixture(fxCD)
+		const r2After = await db.query.round.findFirst({ where: eq(roundTable.id, r2) })
+		expect(r2After?.status).toBe('completed')
+		const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+		expect(g?.currentRoundId).toBe(r3)
+	})
+})
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Classic — round-void threshold                                          */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe('cancellation: classic round-void threshold', () => {
+	it('voids the whole round when >50% of fixtures are cancelled', async () => {
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const teams: string[] = []
+		for (let i = 0; i < 8; i++) {
+			teams.push(await makeTeam({ name: `T${i}`, shortName: `T${i}` }))
+		}
+		const r2 = await makeRound(compId, { number: 2, status: 'open' })
+		const r3 = await makeRound(compId, {
+			number: 3,
+			status: 'upcoming',
+			deadline: new Date(Date.now() + 86_400_000),
+		})
+		// 4 fixtures in r2.
+		const fxIds: string[] = []
+		for (let i = 0; i < 4; i++) {
+			fxIds.push(
+				await makeFixture({ roundId: r2, homeTeamId: teams[i * 2], awayTeamId: teams[i * 2 + 1] }),
+			)
+		}
+		// One r3 fixture so advance has somewhere to go.
+		await makeFixture({ roundId: r3, homeTeamId: teams[0], awayTeamId: teams[1] })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r2,
+			modeConfig: { allowRebuys: false },
+		})
+		const gp1 = await makePlayer({ gameId, userId: 'u1' })
+		const gp2 = await makePlayer({ gameId, userId: 'u2' })
+		// Third player keeps alive count >1 so eliminating gp1 doesn't
+		// auto-complete the game before the cancellations land.
+		const gp3 = await makePlayer({ gameId, userId: 'u3' })
+		// gp1 picked team T0 (home) on fx0. Fixture finishes 0-2 → T0 lost,
+		// gp1 would normally be eliminated. The round void should reinstate.
+		await makePick({
+			gameId,
+			gamePlayerId: gp1,
+			roundId: r2,
+			teamId: teams[0],
+			fixtureId: fxIds[0],
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gp2,
+			roundId: r2,
+			teamId: teams[3],
+			fixtureId: fxIds[1],
+		})
+		// gp3 picks the away side of fx0 — wins when fx0 settles 0-2.
+		await makePick({
+			gameId,
+			gamePlayerId: gp3,
+			roundId: r2,
+			teamId: teams[1],
+			fixtureId: fxIds[0],
+		})
+
+		// Settle one fixture as a loss to eliminate gp1 first.
+		await finishFixture(fxIds[0], 0, 2)
+		await settleFixture(fxIds[0])
+		const eliminatedFirst = await db.query.gamePlayer.findFirst({
+			where: eq(gamePlayer.id, gp1),
+		})
+		expect(eliminatedFirst?.status).toBe('eliminated')
+
+		// Now cancel 3 out of 4 fixtures (>50%). One settled, three cancelled
+		// → 3/4 = 75% cancelled, threshold crossed.
+		await cancelFixture(fxIds[1])
+		await settleFixture(fxIds[1])
+		await cancelFixture(fxIds[2])
+		await settleFixture(fxIds[2])
+		await cancelFixture(fxIds[3])
+		await settleFixture(fxIds[3])
+
+		// All picks on the round should now be 'void' with reason
+		// 'round-voided', including the previously-settled gp1 pick.
+		const allPicks = await db.query.pick.findMany({
+			where: eq(pick.roundId, r2),
+		})
+		for (const p of allPicks) {
+			expect(p.result).toBe('void')
+			expect(p.cancellationReason).toBe('round-voided')
+		}
+
+		// gp1 should be reinstated as 'alive' (eliminated by the voided round).
+		const reinstated = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gp1) })
+		expect(reinstated?.status).toBe('alive')
+		expect(reinstated?.eliminatedRoundId).toBeNull()
+
+		// Round flagged voided.
+		const r2After = await db.query.round.findFirst({ where: eq(roundTable.id, r2) })
+		expect(r2After?.voidedAt).not.toBeNull()
+		expect(r2After?.status).toBe('completed')
+
+		// Game advanced.
+		const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+		expect(g?.currentRoundId).toBe(r3)
+	})
+})
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Turbo — void skips in the streak                                        */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe('cancellation: turbo auto-skip', () => {
+	it("streak walks past a voided rank as if it weren't there", async () => {
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const teams: string[] = []
+		for (let i = 0; i < 6; i++) {
+			teams.push(await makeTeam({ name: `T${i}`, shortName: `T${i}` }))
+		}
+		const r1 = await makeRound(compId, { number: 1, status: 'open' })
+		const fx1 = await makeFixture({ roundId: r1, homeTeamId: teams[0], awayTeamId: teams[1] })
+		const fx2 = await makeFixture({ roundId: r1, homeTeamId: teams[2], awayTeamId: teams[3] })
+		const fx3 = await makeFixture({ roundId: r1, homeTeamId: teams[4], awayTeamId: teams[5] })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'turbo',
+			currentRoundId: r1,
+			modeConfig: { numberOfPicks: 3 },
+		})
+		const gp = await makePlayer({ gameId, userId: 'u' })
+		await makePick({
+			gameId,
+			gamePlayerId: gp,
+			roundId: r1,
+			teamId: teams[0],
+			fixtureId: fx1,
+			confidenceRank: 1,
+			predictedResult: 'home_win',
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gp,
+			roundId: r1,
+			teamId: teams[2],
+			fixtureId: fx2,
+			confidenceRank: 2,
+			predictedResult: 'home_win',
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gp,
+			roundId: r1,
+			teamId: teams[4],
+			fixtureId: fx3,
+			confidenceRank: 3,
+			predictedResult: 'home_win',
+		})
+
+		// Rank 1: correct (home win). Rank 2: cancelled. Rank 3: correct.
+		await finishFixture(fx1, 1, 0)
+		await settleFixture(fx1)
+		await cancelFixture(fx2)
+		await settleFixture(fx2)
+		await finishFixture(fx3, 1, 0)
+		await settleFixture(fx3)
+
+		// Game auto-completes (single-round mode). Player should be 'winner'
+		// since they're the only player.
+		const player = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gp) })
+		expect(player?.status).toBe('winner') // turboTiebreaker picks the sole survivor
+
+		// Picks: rank 2 voided, others win.
+		const allPicks = await db.query.pick.findMany({ where: eq(pick.gameId, gameId) })
+		const ranked = allPicks.sort((a, b) => (a.confidenceRank ?? 0) - (b.confidenceRank ?? 0))
+		expect(ranked[0].result).toBe('win')
+		expect(ranked[1].result).toBe('void')
+		expect(ranked[2].result).toBe('win')
+	})
+})
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Cup — re-eval walks past voids in rank order                            */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe('cancellation: cup auto-skip', () => {
+	it('re-eval ignores voided picks; lives state continues from prior rank', async () => {
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		const spain = await makeTeam({ name: 'Spain', shortName: 'ESP', fifaPot: 1 })
+		const cv = await makeTeam({ name: 'Cape Verde', shortName: 'CPV', fifaPot: 4 })
+		const eng = await makeTeam({ name: 'England', shortName: 'ENG', fifaPot: 1 })
+		const aus = await makeTeam({ name: 'Australia', shortName: 'AUS', fifaPot: 2 })
+		const r1 = await makeRound(compId, { number: 1, status: 'open' })
+		await makeRound(compId, {
+			number: 2,
+			status: 'upcoming',
+			deadline: new Date(Date.now() + 86_400_000),
+		})
+		const fx1 = await makeFixture({ roundId: r1, homeTeamId: spain, awayTeamId: cv })
+		const fx2 = await makeFixture({ roundId: r1, homeTeamId: eng, awayTeamId: aus })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'cup',
+			currentRoundId: r1,
+			modeConfig: { numberOfPicks: 2, startingLives: 0 },
+		})
+		const gpHero = await makePlayer({ gameId, userId: 'u-hero', livesRemaining: 0 })
+		const gpFiller = await makePlayer({ gameId, userId: 'u-filler', livesRemaining: 0 })
+		// Hero rank 1: 3-tier underdog Cape Verde. Rank 2: even-tier ENG (pot 1) vs AUS (pot 2).
+		await makePick({
+			gameId,
+			gamePlayerId: gpHero,
+			roundId: r1,
+			teamId: cv,
+			fixtureId: fx1,
+			confidenceRank: 1,
+			predictedResult: 'away_win',
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpHero,
+			roundId: r1,
+			teamId: eng,
+			fixtureId: fx2,
+			confidenceRank: 2,
+			predictedResult: 'home_win',
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpFiller,
+			roundId: r1,
+			teamId: cv,
+			fixtureId: fx1,
+			confidenceRank: 1,
+			predictedResult: 'away_win',
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpFiller,
+			roundId: r1,
+			teamId: eng,
+			fixtureId: fx2,
+			confidenceRank: 2,
+			predictedResult: 'home_win',
+		})
+
+		// Cancel rank 1's fixture. Rank 2 plays and home wins.
+		await cancelFixture(fx1)
+		await settleFixture(fx1)
+		await finishFixture(fx2, 2, 0)
+		await settleFixture(fx2)
+
+		const heroPicks = await db.query.pick.findMany({
+			where: eq(pick.gamePlayerId, gpHero),
+		})
+		const rank1 = heroPicks.find((p) => p.confidenceRank === 1)
+		const rank2 = heroPicks.find((p) => p.confidenceRank === 2)
+		expect(rank1?.result).toBe('void')
+		expect(rank1?.lifeGained).toBe(0)
+		expect(rank2?.result).toBe('win')
+
+		// Hero starts with 0 lives, rank 1 voided, rank 2 even-tier win → no lives gained.
+		const hero = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gpHero) })
+		expect(hero?.livesRemaining).toBe(0)
+		expect(hero?.status).toBe('alive')
+	})
+})
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Postponed → cancelled normalisation                                     */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe('cancellation: postponed status auto-cancels', () => {
+	it('settleFixture normalises postponed → cancelled and runs the void path', async () => {
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const a = await makeTeam({ name: 'A', shortName: 'A' })
+		const b = await makeTeam({ name: 'B', shortName: 'B' })
+		const c = await makeTeam({ name: 'C', shortName: 'C' })
+		const d = await makeTeam({ name: 'D', shortName: 'D' })
+		const r2 = await makeRound(compId, { number: 2, status: 'open' })
+		await makeRound(compId, {
+			number: 3,
+			status: 'upcoming',
+			deadline: new Date(Date.now() + 86_400_000),
+		})
+		const fxAB = await makeFixture({ roundId: r2, homeTeamId: a, awayTeamId: b })
+		const fxCD = await makeFixture({ roundId: r2, homeTeamId: c, awayTeamId: d })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r2,
+			modeConfig: { allowRebuys: false },
+		})
+		const gp = await makePlayer({ gameId, userId: 'u' })
+		await makePick({
+			gameId,
+			gamePlayerId: gp,
+			roundId: r2,
+			teamId: a,
+			fixtureId: fxAB,
+		})
+
+		// Write a postponed status directly (mimicking syncCompetition's mirror).
+		await db.update(fixture).set({ status: 'postponed' }).where(sql`${fixture.id} = ${fxAB}`)
+		await settleFixture(fxAB)
+
+		const after = await db.query.fixture.findFirst({ where: eq(fixture.id, fxAB) })
+		expect(after?.status).toBe('cancelled') // normalised
+
+		const voided = await db.query.pick.findFirst({
+			where: eq(pick.gamePlayerId, gp),
+		})
+		expect(voided?.result).toBe('void')
+		// Reference fxCD to silence unused.
+		expect(fxCD).toBeTruthy()
+	})
+})
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Idempotency: re-settle a cancelled fixture                              */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe('cancellation: idempotent', () => {
+	it('re-settling the same cancelled fixture does not change state', async () => {
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const a = await makeTeam({ name: 'A', shortName: 'A' })
+		const b = await makeTeam({ name: 'B', shortName: 'B' })
+		const r2 = await makeRound(compId, { number: 2, status: 'open' })
+		await makeRound(compId, {
+			number: 3,
+			status: 'upcoming',
+			deadline: new Date(Date.now() + 86_400_000),
+		})
+		const fx = await makeFixture({ roundId: r2, homeTeamId: a, awayTeamId: b })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r2,
+			modeConfig: { allowRebuys: false },
+		})
+		const gp = await makePlayer({ gameId, userId: 'u' })
+		await makePick({ gameId, gamePlayerId: gp, roundId: r2, teamId: a, fixtureId: fx })
+
+		await cancelFixture(fx)
+		await settleFixture(fx)
+		const firstPass = await db.query.pick.findFirst({ where: eq(pick.gamePlayerId, gp) })
+
+		await settleFixture(fx) // second call
+		const secondPass = await db.query.pick.findFirst({ where: eq(pick.gamePlayerId, gp) })
+
+		expect(secondPass?.result).toBe('void')
+		expect(secondPass?.cancellationReason).toBe(firstPass?.cancellationReason)
+	})
+})

--- a/src/app/api/cron/poll-scores/route.ts
+++ b/src/app/api/cron/poll-scores/route.ts
@@ -94,7 +94,12 @@ export async function POST(request: Request) {
 					})
 					.where(eq(fixture.id, existing.id))
 
-				if (existing.status !== 'finished' && score.status === 'finished') {
+				// Capture any transition into a terminal state (finished or
+				// cancelled). settleFixture internally dispatches to the void
+				// path when the new status is cancelled.
+				const wasTerminal = existing.status === 'finished' || existing.status === 'cancelled'
+				const nowTerminal = score.status === 'finished' || score.status === 'cancelled'
+				if (!wasTerminal && nowTerminal) {
 					transitionedFixtureIds.push(existing.id)
 				}
 				totalUpdated++

--- a/src/app/api/picks/[gameId]/[roundId]/route.ts
+++ b/src/app/api/picks/[gameId]/[roundId]/route.ts
@@ -91,11 +91,17 @@ export async function POST(request: Request, { params }: { params: Params }) {
 	if (gameData.gameMode === 'classic') {
 		const { teamId, fixtureId } = body as { teamId: string; fixtureId?: string }
 
-		// Get previously used teams (for the TARGET player, not the admin)
+		// Get previously used teams (for the TARGET player, not the admin).
+		// Round-voided picks are excluded — the round didn't happen and the
+		// team is released. Per-fixture cancellations stay in the list
+		// (team consumed per the design).
 		const previousPicks = await db.query.pick.findMany({
 			where: and(eq(pick.gamePlayerId, targetGamePlayer.id), eq(pick.gameId, gameId)),
 		})
-		const usedTeamIds = previousPicks.filter((p) => p.roundId !== roundId).map((p) => p.teamId)
+		const usedTeamIds = previousPicks
+			.filter((p) => p.roundId !== roundId)
+			.filter((p) => p.cancellationReason !== 'round-voided')
+			.map((p) => p.teamId)
 
 		const fixtureTeamIds = roundData.fixtures.flatMap((f) => [f.homeTeamId, f.awayTeamId])
 

--- a/src/components/game/game-detail-view.tsx
+++ b/src/components/game/game-detail-view.tsx
@@ -10,6 +10,7 @@ import { OtherPlayersPayments } from '@/components/game/other-players-payments'
 import type { PaymentStatus } from '@/components/game/payment-status-chip'
 import { type AdminPayment, PaymentsPanel } from '@/components/game/payments-panel'
 import { ShareDialog } from '@/components/game/share-dialog'
+import { VoidedPickBanner } from '@/components/game/voided-pick-banner'
 import { LiveProvider } from '@/components/live/live-provider'
 import { LiveScoreTicker } from '@/components/live/live-score-ticker'
 import { CupStandings } from '@/components/standings/cup-standings'
@@ -88,6 +89,11 @@ export function GameDetailView({
 						kickoffLabel={game.myCurrentRoundPick.kickoffLabel}
 					/>
 				)}
+
+				<VoidedPickBanner
+					gameId={game.id}
+					gameMode={game.gameMode as 'classic' | 'turbo' | 'cup'}
+				/>
 
 				<GameHeader
 					name={game.name}

--- a/src/components/game/voided-pick-banner.tsx
+++ b/src/components/game/voided-pick-banner.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { X } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { useLiveGame } from '@/components/live/use-live-game'
+
+/**
+ * Notifies the viewer when one of their picks has been voided (fixture
+ * cancelled or whole round voided). Per the cancellation design:
+ * dismissible per-pick void banner; round-voided banner is also
+ * dismissible but more visually prominent.
+ *
+ * Renders nothing if the viewer has no voided picks on the current or
+ * most recent round. Dismissal is persisted in localStorage keyed by
+ * (gameId + pickId) so the banner doesn't reappear on every poll.
+ *
+ * See docs/superpowers/specs/2026-05-12-fixture-cancellation-handling-design.md.
+ */
+export function VoidedPickBanner({
+	gameId,
+	gameMode,
+}: {
+	gameId: string
+	gameMode: 'classic' | 'turbo' | 'cup'
+}) {
+	const { payload } = useLiveGame()
+	const [dismissedKeys, setDismissedKeys] = useState<Set<string>>(new Set())
+
+	useEffect(() => {
+		// Hydrate dismissals from localStorage once.
+		try {
+			const raw = window.localStorage.getItem(`voided-banner-dismiss:${gameId}`)
+			if (raw) setDismissedKeys(new Set(JSON.parse(raw) as string[]))
+		} catch {
+			// localStorage unavailable — fall through; banner re-shows on
+			// every visit, no harm done.
+		}
+	}, [gameId])
+
+	if (!payload) return null
+	const viewerUserId = payload.viewerUserId
+	const viewerGp = payload.players.find((p) => p.userId === viewerUserId)
+	if (!viewerGp) return null
+
+	const voidedPicks = payload.picks.filter(
+		(p) => p.gamePlayerId === viewerGp.id && p.result === 'void',
+	)
+	if (voidedPicks.length === 0) return null
+
+	const visiblePicks = voidedPicks.filter((p) => !dismissedKeys.has(pickKey(p.fixtureId)))
+	if (visiblePicks.length === 0) return null
+
+	function dismiss(fixtureId: string | null) {
+		const key = pickKey(fixtureId)
+		const next = new Set(dismissedKeys)
+		next.add(key)
+		setDismissedKeys(next)
+		try {
+			window.localStorage.setItem(`voided-banner-dismiss:${gameId}`, JSON.stringify([...next]))
+		} catch {
+			// noop
+		}
+	}
+
+	return (
+		<div className="mb-4 space-y-2">
+			{visiblePicks.map((p) => (
+				<div
+					key={pickKey(p.fixtureId)}
+					className="flex items-start gap-3 rounded-lg border border-sky-200 bg-sky-50 px-4 py-3 text-sm dark:border-sky-800/50 dark:bg-sky-900/30"
+				>
+					<div className="flex-1">
+						<p className="font-semibold text-sky-900 dark:text-sky-100">Pick voided</p>
+						<p className="mt-0.5 text-sky-800 dark:text-sky-200">
+							{messageFor(gameMode, p.fixtureId)}
+						</p>
+					</div>
+					<button
+						type="button"
+						aria-label="Dismiss"
+						onClick={() => dismiss(p.fixtureId)}
+						className="text-sky-700 hover:text-sky-900 dark:text-sky-300 dark:hover:text-sky-100"
+					>
+						<X className="h-4 w-4" />
+					</button>
+				</div>
+			))}
+		</div>
+	)
+}
+
+function pickKey(fixtureId: string | null): string {
+	return fixtureId ?? 'unknown'
+}
+
+function messageFor(mode: 'classic' | 'turbo' | 'cup', _fixtureId: string | null): string {
+	switch (mode) {
+		case 'classic':
+			return 'A fixture you picked was cancelled. Your pick is voided — you stay alive, and the team is locked from re-use.'
+		case 'turbo':
+			return 'A fixture you ranked was cancelled. That rank is voided and doesn’t count towards your streak.'
+		case 'cup':
+			return 'A fixture you ranked was cancelled. That rank is voided — no life gained or spent.'
+	}
+}

--- a/src/components/standings/progress-grid.tsx
+++ b/src/components/standings/progress-grid.tsx
@@ -26,6 +26,12 @@ export interface GridRound {
 	/** Short label for column headers, e.g. "GW1" / "MD1" / "R16". */
 	label: string
 	isStartingRound?: boolean
+	/**
+	 * Non-null when this round was voided (classic threshold crossed —
+	 * see cancellation design doc). UI renders the column with prominent
+	 * "round voided" treatment.
+	 */
+	voidedAt?: Date | string | null
 }
 
 export interface GridCell {
@@ -40,6 +46,8 @@ export interface GridCell {
 		| 'skull'
 		| 'empty'
 		| 'no_pick'
+		/** Pick on a cancelled fixture (or pick in a voided round). */
+		| 'void'
 	teamShortName?: string
 	opponentShortName?: string
 	homeAway?: 'H' | 'A'
@@ -209,9 +217,19 @@ export function ProgressGrid({
 								{visibleRounds.map((r) => (
 									<th
 										key={r.id}
-										className="font-medium text-muted-foreground text-center pb-3 px-1"
+										className={cn(
+											'font-medium text-muted-foreground text-center pb-3 px-1',
+											r.voidedAt && 'bg-sky-100/60 dark:bg-sky-900/30 border-x border-sky-300/40',
+										)}
 									>
-										{r.label}
+										<div className="flex flex-col items-center leading-tight">
+											{r.voidedAt && (
+												<span className="text-[0.55rem] font-semibold uppercase tracking-wider text-sky-700 dark:text-sky-300">
+													Voided
+												</span>
+											)}
+											<span>{r.label}</span>
+										</div>
 									</th>
 								))}
 								<th className="pb-3 pl-4 min-w-[80px] text-right">Status</th>
@@ -279,7 +297,14 @@ export function ProgressGrid({
 											const cell = player.cellsByRoundId[r.id] ?? { result: 'empty' }
 											const bump = rowBump && r.id === bumpRoundId ? rowBump : null
 											return (
-												<td key={r.id} className="px-1 text-center align-middle">
+												<td
+													key={r.id}
+													className={cn(
+														'px-1 text-center align-middle',
+														r.voidedAt &&
+															'bg-sky-100/30 dark:bg-sky-900/20 border-x border-sky-300/40',
+													)}
+												>
 													<GridCellView
 														cell={cell}
 														roundLabel={r.label}
@@ -363,6 +388,35 @@ function GridCellView({
 				</TooltipTrigger>
 				<TooltipContent>
 					<p className="text-xs">No pick yet</p>
+				</TooltipContent>
+			</Tooltip>
+		)
+	}
+	if (cell.result === 'void') {
+		// Fixture cancelled (or round voided). Distinct visual — soft blue
+		// tile with VOID label — so the absence of a result is clear vs
+		// the neutral 'pending'. The only cell-state where we deliberately
+		// diverge from "settled-style visual" because there's no settled
+		// equivalent.
+		return (
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<span
+						className={cn(
+							'relative inline-flex flex-col items-center justify-center rounded bg-sky-100 text-sky-700 font-semibold leading-tight cursor-help dark:bg-sky-900/40 dark:text-sky-300',
+							width,
+							height,
+						)}
+					>
+						<span className="text-[0.6rem] uppercase tracking-wider">Void</span>
+						{cell.teamShortName && (
+							<span className="text-[0.55rem] font-medium opacity-80">{cell.teamShortName}</span>
+						)}
+						{bump && <BumpBadge kind={bump} />}
+					</span>
+				</TooltipTrigger>
+				<TooltipContent>
+					<p className="text-xs">Fixture cancelled — pick voided, you stay alive.</p>
 				</TooltipContent>
 			</Tooltip>
 		)

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -36,7 +36,7 @@ export interface AdapterFixture {
 	homeTeamExternalId: string
 	awayTeamExternalId: string
 	kickoff: Date | null
-	status: 'scheduled' | 'live' | 'finished' | 'postponed'
+	status: 'scheduled' | 'live' | 'finished' | 'postponed' | 'cancelled'
 	homeScore: number | null
 	awayScore: number | null
 }
@@ -45,5 +45,5 @@ export interface AdapterFixtureScore {
 	externalId: string
 	homeScore: number
 	awayScore: number
-	status: 'live' | 'finished'
+	status: 'live' | 'finished' | 'cancelled'
 }

--- a/src/lib/game-logic/wc-classic.test.ts
+++ b/src/lib/game-logic/wc-classic.test.ts
@@ -12,7 +12,7 @@ interface F {
 	awayTeamId: string
 	homeScore: number | null
 	awayScore: number | null
-	status: 'scheduled' | 'live' | 'finished' | 'postponed'
+	status: 'scheduled' | 'live' | 'finished' | 'postponed' | 'cancelled'
 	stage: 'group' | 'knockout'
 }
 

--- a/src/lib/game-logic/wc-classic.ts
+++ b/src/lib/game-logic/wc-classic.ts
@@ -9,7 +9,7 @@ export interface WcFixture {
 	awayTeamId: string
 	homeScore: number | null
 	awayScore: number | null
-	status: 'scheduled' | 'live' | 'finished' | 'postponed'
+	status: 'scheduled' | 'live' | 'finished' | 'postponed' | 'cancelled'
 	stage: 'group' | 'knockout'
 }
 

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -393,9 +393,15 @@ export async function syncCompetition(
 						},
 					})
 					.where(eq(fixture.id, existingFixture.id))
-				// Capture transition for post-loop settlement. Same logic as
-				// live-poll: only fires once per transition.
-				if (existingFixture.status !== 'finished' && af.status === 'finished') {
+				// Capture transition for post-loop settlement. Settlement covers
+				// both happy-path (finished with scores) and cancellation
+				// (cancelled / postponed → cancelled). settleFixture routes
+				// internally to the void path when status is cancelled.
+				const wasTerminal =
+					existingFixture.status === 'finished' || existingFixture.status === 'cancelled'
+				const nowTerminal =
+					af.status === 'finished' || af.status === 'cancelled' || af.status === 'postponed'
+				if (!wasTerminal && nowTerminal) {
 					transitionedToFinishedIds.push(existingFixture.id)
 				}
 			} else {

--- a/src/lib/game/classic-planner-view.ts
+++ b/src/lib/game/classic-planner-view.ts
@@ -40,7 +40,7 @@ export interface ChainRoundRow {
 export interface ChainPastPickRow {
 	roundId: string
 	teamId: string
-	result: 'pending' | 'win' | 'loss' | 'draw' | 'saved_by_life'
+	result: 'pending' | 'win' | 'loss' | 'draw' | 'saved_by_life' | 'void'
 	teamShortName: string
 	teamColour: string | null
 }

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -827,6 +827,7 @@ export async function getProgressGridData(
 		name: r.name ?? roundLabelLong(competitionType, r.number),
 		label: roundLabel(competitionType, r.number),
 		isStartingRound: r.number === 1,
+		voidedAt: r.voidedAt ?? null,
 	}))
 
 	// Get user names for players
@@ -890,8 +891,12 @@ export async function getProgressGridData(
 			// is that an in-progress pick renders with the same treatment as the
 			// settled equivalent. Fixture status (live ticker / kickoff time)
 			// conveys "in progress" to the viewer.
+			//
+			// Voided picks (fixture cancelled or whole round voided) get the
+			// distinct 'void' cell — no settled equivalent exists.
 			let resultForCell: GridCell['result']
-			if (thePick.result === 'win') resultForCell = 'win'
+			if (thePick.result === 'void') resultForCell = 'void'
+			else if (thePick.result === 'win') resultForCell = 'win'
 			else if (thePick.result === 'loss') resultForCell = 'loss'
 			else if (thePick.result === 'draw') resultForCell = r.number === 1 ? 'draw_exempt' : 'loss'
 			else if (thePick.result === 'saved_by_life') resultForCell = 'saved'
@@ -1080,7 +1085,7 @@ function computeLiveProjection(input: {
 		awayTeamId: string
 		homeScore: number | null
 		awayScore: number | null
-		status: 'scheduled' | 'live' | 'finished' | 'postponed'
+		status: 'scheduled' | 'live' | 'finished' | 'postponed' | 'cancelled'
 		homeTeam: { id: string; externalIds: Record<string, string | number> | null }
 		awayTeam: { id: string; externalIds: Record<string, string | number> | null }
 	}>
@@ -1131,6 +1136,7 @@ type LiveProjectedOutcome =
 	| 'settled-win'
 	| 'settled-loss'
 	| 'pending'
+	| 'void'
 
 function projectOutcomeForPick(
 	p: typeof pick.$inferSelect,
@@ -1144,6 +1150,7 @@ function projectOutcomeForPick(
 		  }
 		| undefined,
 ): LiveProjectedOutcome {
+	if (p.result === 'void') return 'void'
 	if (p.result === 'saved_by_life') return 'saved-by-life'
 	if (p.result === 'win') return 'settled-win'
 	if (p.result === 'loss') return 'settled-loss'
@@ -1152,6 +1159,9 @@ function projectOutcomeForPick(
 		// settled-win-equivalent for visual parity.
 		return 'settled-win'
 	}
+	// Fixture cancelled but pick.result not yet persisted as 'void' (race
+	// during settlement) — surface as void anyway.
+	if (fx?.status === 'cancelled') return 'void'
 	if (!fx || fx.homeScore == null || fx.awayScore == null) return 'pending'
 	const isFinished = fx.status === 'finished'
 	const pickedHome = p.teamId === fx.homeTeamId
@@ -1197,10 +1207,13 @@ function projectClassicPlayer(
 	const allowRebuys = input.modeConfig?.allowRebuys === true
 	const isStartingRound = input.roundNumber === 1 && !allowRebuys
 	// Classic has one pick per round; project elimination if any in-progress
-	// pick is losing/drawing AND not in starting round.
+	// pick is losing/drawing AND not in starting round. Voided picks don't
+	// count — player stays alive on them per the cancellation design.
 	for (const p of playerPicks) {
+		if (p.result === 'void') continue
 		const fx = p.fixtureId ? fixtureById.get(p.fixtureId) : undefined
-		if (!fx || fx.homeScore == null || fx.awayScore == null) continue
+		if (!fx || fx.status === 'cancelled') continue
+		if (fx.homeScore == null || fx.awayScore == null) continue
 		const pickedHome = p.teamId === fx.homeTeamId
 		const pickedScore = pickedHome ? fx.homeScore : fx.awayScore
 		const otherScore = pickedHome ? fx.awayScore : fx.homeScore
@@ -1228,11 +1241,15 @@ function projectTurboPlayer(
 		return { streak: 0, lives: 0, status: 'eliminated' }
 	}
 	// Project streak through rank order, treating in-progress fixtures by
-	// current score. Stops at the first projected loss.
+	// current score. Stops at the first projected loss. Voided picks are
+	// skipped (streak walks past them as if they weren't in the input).
 	let streak = 0
 	for (const p of playerPicks) {
+		if (p.result === 'void') continue
 		const fx = p.fixtureId ? fixtureById.get(p.fixtureId) : undefined
-		if (!fx || fx.homeScore == null || fx.awayScore == null) break
+		if (!fx) break
+		if (fx.status === 'cancelled') continue
+		if (fx.homeScore == null || fx.awayScore == null) break
 		const actualOutcome =
 			fx.homeScore > fx.awayScore ? 'home_win' : fx.awayScore > fx.homeScore ? 'away_win' : 'draw'
 		if (p.predictedResult === actualOutcome) streak++
@@ -1272,8 +1289,11 @@ function projectCupPlayer(
 		tierDifference: number
 	}> = []
 	for (const p of playerPicks) {
+		if (p.result === 'void') continue
 		const fx = p.fixtureId ? fixtureById.get(p.fixtureId) : undefined
-		if (!fx || fx.homeScore == null || fx.awayScore == null) continue
+		if (!fx) continue
+		if (fx.status === 'cancelled') continue
+		if (fx.homeScore == null || fx.awayScore == null) continue
 		const pickedTeam: 'home' | 'away' = p.teamId === fx.homeTeamId ? 'home' : 'away'
 		const tierDiff = computeTierDifference(
 			fx.homeTeam,

--- a/src/lib/game/settle.ts
+++ b/src/lib/game/settle.ts
@@ -49,6 +49,8 @@ export interface SettleResult {
 	classicEliminated: number
 	turboSettled: number
 	cupGamesReevaluated: number
+	picksVoided: number
+	roundsVoided: string[]
 	gamesCompleted: string[]
 	gamesAdvanced: string[]
 	roundsCompleted: string[]
@@ -61,6 +63,8 @@ function emptyResult(fixtureId: string): SettleResult {
 		classicEliminated: 0,
 		turboSettled: 0,
 		cupGamesReevaluated: 0,
+		picksVoided: 0,
+		roundsVoided: [],
 		gamesCompleted: [],
 		gamesAdvanced: [],
 		roundsCompleted: [],
@@ -79,6 +83,20 @@ export async function settleFixture(fixtureId: string): Promise<SettleResult> {
 		},
 	})
 	if (!fx) return result
+
+	// Normalise postponed → cancelled at the boundary. Per the cancellation
+	// design, postponed PL fixtures are typically moved to other matchdays
+	// and the survivor game has to roll over rather than block — so any
+	// postponed status counts as cancellation for settlement purposes.
+	if (fx.status === 'postponed') {
+		await db.update(fixture).set({ status: 'cancelled' }).where(eq(fixture.id, fixtureId))
+		fx.status = 'cancelled'
+	}
+
+	if (fx.status === 'cancelled') {
+		return voidFixtureInternal(fx, result)
+	}
+
 	if (fx.status !== 'finished') return result
 	if (fx.homeScore == null || fx.awayScore == null) return result
 
@@ -264,14 +282,18 @@ export async function reevaluateCupGame(gameId: string): Promise<boolean> {
 
 		// Build the input list for evaluateCupPicks — only picks whose fixture
 		// has both scores (`pending` fixtures are excluded; their pick.result
-		// stays `'pending'`).
+		// stays `'pending'`). Cancelled fixtures are skipped — the pick's
+		// `'void'` row was already persisted by voidFixtureInternal; the
+		// streak math walks past it naturally because it's not in the input.
 		const settleable: Array<{
 			pickRow: (typeof existingPicks)[number]
 			fixture: (typeof g.currentRound.fixtures)[number]
 		}> = []
 		for (const p of playerPicks) {
+			if (p.result === 'void') continue
 			const fx = g.currentRound.fixtures.find((f) => f.id === p.fixtureId)
 			if (!fx) continue
+			if (fx.status === 'cancelled') continue
 			if (fx.homeScore == null || fx.awayScore == null) continue
 			settleable.push({ pickRow: p, fixture: fx })
 		}
@@ -369,10 +391,15 @@ async function checkAndMaybeCompleteOrAdvance(
 	const allRoundFixtures = await db.query.fixture.findMany({
 		where: eq(fixture.roundId, roundId),
 	})
+	// A round is "all done" when every fixture has reached a terminal
+	// state — either finished with scores OR cancelled. Cancelled
+	// fixtures don't block round advancement.
 	const allFinished =
 		allRoundFixtures.length > 0 &&
 		allRoundFixtures.every(
-			(f) => f.status === 'finished' && f.homeScore != null && f.awayScore != null,
+			(f) =>
+				(f.status === 'finished' && f.homeScore != null && f.awayScore != null) ||
+				f.status === 'cancelled',
 		)
 
 	// Per-mode completion check. Classic + cup check after every pick
@@ -428,8 +455,12 @@ async function collectTurboPlayerResults(gameId: string, roundId: string) {
 		with: { fixture: true },
 	})
 	return players.map((p) => {
+		// Skip void picks — the streak evaluator walks past as if they
+		// weren't in the input. Equivalent to a 9-pick game when one
+		// fixture was cancelled.
 		const playerPicks = picks
 			.filter((pk) => pk.gamePlayerId === p.id)
+			.filter((pk) => pk.result !== 'void')
 			.map((pk) => ({
 				confidenceRank: pk.confidenceRank ?? 0,
 				predictedResult: (pk.predictedResult ?? 'draw') as 'home_win' | 'draw' | 'away_win',
@@ -545,7 +576,11 @@ export async function sweepGameSettlement(gameId: string): Promise<SettleResult[
 	})
 	if (!g || g.status !== 'active' || !g.currentRound) return []
 	const fixtureIds = g.currentRound.fixtures
-		.filter((f) => f.status === 'finished' && f.homeScore != null && f.awayScore != null)
+		.filter(
+			(f) =>
+				(f.status === 'finished' && f.homeScore != null && f.awayScore != null) ||
+				f.status === 'cancelled',
+		)
 		.map((f) => f.id)
 	const results: SettleResult[] = []
 	for (const fid of fixtureIds) {
@@ -573,6 +608,167 @@ export async function sweepAllActiveGames(): Promise<{
 		fixturesSettled += results.length
 	}
 	return { gamesChecked: activeGames.length, fixturesSettled }
+}
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Cancellation / void                                                     */
+/* ────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Per-mode void handler — called when a fixture's status becomes
+ * `'cancelled'` (or `'postponed'` is normalised to cancelled by the
+ * caller). Persists `pick.result = 'void'` for every still-pending
+ * pick on the fixture, marks the cancellation reason, then dispatches
+ * mode-specific cleanup:
+ *
+ *   - **Classic:** pick is voided; player stays alive; team usage
+ *     stays consumed (validation reads pick.teamId regardless of
+ *     result, so the team remains in `usedTeamIds`). The exception is
+ *     when the whole round is voided — see `voidWholeRound`.
+ *   - **Turbo:** pick is voided; the streak evaluator (when the round
+ *     fully settles) walks past void picks.
+ *   - **Cup:** pick is voided; `reevaluateCupGame` is re-run, which
+ *     iterates rank-ordered and naturally skips voids.
+ *
+ * Then checks the classic round-void threshold and the standard
+ * completion-or-advance flow.
+ *
+ * See docs/superpowers/specs/2026-05-12-fixture-cancellation-handling-design.md.
+ */
+async function voidFixtureInternal(
+	fx: FixtureWithRound,
+	result: SettleResult,
+): Promise<SettleResult> {
+	const picks = await db.query.pick.findMany({
+		where: eq(pick.fixtureId, fx.id),
+		with: { game: { with: { competition: true } } },
+	})
+
+	// Per-pick void for any picks directly on this fixture. Guard on
+	// `result === 'pending'` so already-settled rows aren't retroactively
+	// overwritten by a late cancellation; the round-void path is the only
+	// place that retroactively overwrites settled picks.
+	for (const p of picks) {
+		if (p.result !== 'pending') continue
+		await db
+			.update(pick)
+			.set({
+				result: 'void',
+				cancellationReason: 'cancelled',
+				goalsScored: 0,
+				lifeGained: 0,
+				lifeSpent: false,
+			})
+			.where(eq(pick.id, p.id))
+		result.picksVoided++
+	}
+
+	// Find every game whose currentRoundId points at this fixture's round.
+	// A cancellation can void the whole round even when the cancelled
+	// fixture itself had no picks (the threshold is a property of the
+	// round's fixtures, not the picks on this specific cancellation).
+	const gamesOnRound = await db.query.game.findMany({
+		where: and(eq(game.currentRoundId, fx.round.id), eq(game.status, 'active')),
+	})
+
+	for (const g of gamesOnRound) {
+		// Cup mode: re-run whole-game evaluation. Picks-of-this-fixture were
+		// already voided above; re-eval recomputes streak/lives accordingly.
+		if (g.gameMode === 'cup') {
+			const changed = await reevaluateCupGame(g.id)
+			if (changed) result.cupGamesReevaluated++
+		}
+
+		// Classic only: check the round-void threshold. If crossed, void
+		// the whole round (releases teams, reinstates same-round
+		// eliminations, advances games).
+		if (g.gameMode === 'classic') {
+			const threshold = await classicVoidThresholdCrossed(fx.round.id)
+			if (threshold && !result.roundsVoided.includes(fx.round.id)) {
+				await voidWholeRound(fx.round.id, result)
+			}
+		}
+
+		// Standard completion / advance flow. checkAndMaybeCompleteOrAdvance
+		// already treats cancelled fixtures as terminal — they don't block
+		// round completion.
+		await checkAndMaybeCompleteOrAdvance(g.id, fx.round.id, fx.round.number, result)
+	}
+
+	return result
+}
+
+/**
+ * Has the classic round-void threshold been crossed? Fires when:
+ *   - >50% of the round's fixtures have status='cancelled', OR
+ *   - >5 fixtures absolute (catches 7-fixture rounds where 4 cancellations
+ *     are <50% but still represent enough disruption to void).
+ */
+async function classicVoidThresholdCrossed(roundId: string): Promise<boolean> {
+	const fixtures = await db.query.fixture.findMany({ where: eq(fixture.roundId, roundId) })
+	if (fixtures.length === 0) return false
+	const cancelled = fixtures.filter((f) => f.status === 'cancelled').length
+	return cancelled / fixtures.length > 0.5 || cancelled > 5
+}
+
+/**
+ * Whole-round void for classic. Triggered when too many fixtures in a
+ * round get cancelled (see `classicVoidThresholdCrossed`).
+ *
+ * Behaviour:
+ *  1. round.voided_at = now; round.status = 'completed'.
+ *  2. Every pick on the round → result='void', reason='round-voided'.
+ *     This *retroactively voids* picks that already settled (win/loss
+ *     /draw) — the round outcome is now meaningless.
+ *  3. Players eliminated by this round are reinstated to 'alive'.
+ *  4. Team usage for round-voided picks is filtered out at validation
+ *     time (validate.ts reads `cancellationReason !== 'round-voided'`),
+ *     so the teams are effectively released.
+ *  5. Games currently sitting on this round get completion-checked +
+ *     advanced via the standard flow.
+ */
+async function voidWholeRound(roundId: string, result: SettleResult): Promise<void> {
+	const r = await db.query.round.findFirst({
+		where: eq(round.id, roundId),
+	})
+	if (!r) return
+	if (r.voidedAt != null) return // already voided
+
+	await db
+		.update(round)
+		.set({ voidedAt: new Date(), status: 'completed' })
+		.where(eq(round.id, roundId))
+
+	// Void every pick on the round. Includes settled rows — the round is
+	// being torn down.
+	const roundPicks = await db.query.pick.findMany({
+		where: eq(pick.roundId, roundId),
+	})
+	for (const p of roundPicks) {
+		await db
+			.update(pick)
+			.set({
+				result: 'void',
+				cancellationReason: 'round-voided',
+				goalsScored: 0,
+				lifeGained: 0,
+				lifeSpent: false,
+			})
+			.where(eq(pick.id, p.id))
+	}
+	result.picksVoided += roundPicks.length
+	result.roundsVoided.push(roundId)
+
+	// Reinstate players eliminated by this round. Players eliminated in
+	// earlier rounds stay eliminated — their rounds still happened.
+	await db
+		.update(gamePlayer)
+		.set({
+			status: 'alive',
+			eliminatedRoundId: null,
+			eliminatedReason: null,
+		})
+		.where(and(eq(gamePlayer.eliminatedRoundId, roundId), eq(gamePlayer.status, 'eliminated')))
 }
 
 /**

--- a/src/lib/live/types.ts
+++ b/src/lib/live/types.ts
@@ -8,6 +8,7 @@ export type PickResultState =
 	| 'hidden'
 	| 'restricted'
 	| 'pending'
+	| 'void'
 
 export interface LiveFixture {
 	id: string
@@ -45,6 +46,7 @@ export interface LivePick {
 		| 'settled-win'
 		| 'settled-loss'
 		| 'pending'
+		| 'void'
 		| null
 }
 

--- a/src/lib/schema/competition.ts
+++ b/src/lib/schema/competition.ts
@@ -32,6 +32,11 @@ export const fixtureStatusEnum = pgEnum('fixture_status', [
 	'live',
 	'finished',
 	'postponed',
+	// Fixture won't be played. settle.ts normalises adapter-reported
+	// 'postponed' to this when the matchday boundary is crossed (per the
+	// cancellation design — postponed PL fixtures move to other matchdays,
+	// the survivor game has to roll over).
+	'cancelled',
 ])
 
 // -- Tables --
@@ -56,6 +61,11 @@ export const round = pgTable('round', {
 	name: varchar('name', { length: 100 }),
 	status: roundStatusEnum('status').notNull().default('upcoming'),
 	deadline: timestamp('deadline'),
+	// Set when classic-mode round-void threshold (>50% or >5 absolute
+	// fixtures cancelled) fires. round.status still flips to 'completed'
+	// so game advancement runs; voided_at lets the UI render the
+	// prominent "round voided" treatment without inferring it.
+	voidedAt: timestamp('voided_at'),
 	createdAt: timestamp('created_at').defaultNow().notNull(),
 })
 

--- a/src/lib/schema/game.ts
+++ b/src/lib/schema/game.ts
@@ -28,6 +28,11 @@ export const pickResultEnum = pgEnum('pick_result', [
 	'loss',
 	'draw',
 	'saved_by_life',
+	// Fixture cancelled (or postponed → auto-cancel). Distinct from `pending`
+	// because the pick is settled-as-non-event. Queries that count "real"
+	// settled outcomes should exclude this. See
+	// docs/superpowers/specs/2026-05-12-fixture-cancellation-handling-design.md.
+	'void',
 ])
 
 // -- Tables --
@@ -102,6 +107,9 @@ export const pick = pgTable(
 		// life_spent when a save consumed a life).
 		lifeGained: integer('life_gained').notNull().default(0),
 		lifeSpent: boolean('life_spent').notNull().default(false),
+		// Free-text reason on void picks: 'postponed' | 'cancelled' | 'round-voided'.
+		// Null for any non-void pick. See cancellation design doc.
+		cancellationReason: text('cancellation_reason'),
 		autoSubmitted: boolean('auto_submitted').notNull().default(false),
 		isAuto: boolean('is_auto').notNull().default(false),
 		createdAt: timestamp('created_at').defaultNow().notNull(),


### PR DESCRIPTION
Implements the design captured at `docs/superpowers/specs/2026-05-12-fixture-cancellation-handling-design.md`.

## What's in the PR

### Schema (`drizzle/0005_add_cancellation_state.sql`)
- `pickResultEnum` gains `'void'`
- `fixtureStatusEnum` gains `'cancelled'`
- `round.voided_at` timestamp (set when classic threshold fires)
- `pick.cancellation_reason` text ('cancelled' | 'round-voided')

### Settlement (`src/lib/game/settle.ts`)
- `settleFixture` routes by fixture status. `postponed` normalises to `cancelled` at the boundary, then dispatches to `voidFixtureInternal`. Existing finished path unchanged.
- `voidFixtureInternal`: per-pick void (`pick.result='void'`, `cancellation_reason='cancelled'`) for every pending pick. Mode-specific cleanup: cup re-eval rerun; classic threshold check fires when needed.
- **Round-void threshold (classic):** >50% of fixtures cancelled OR >5 absolute. When crossed, `voidWholeRound` retroactively voids every pick on the round (including previously-settled wins/losses), reinstates players eliminated by this round, marks `round.voided_at`. Team usage for round-voided picks is filtered out at validation time → teams released.
- Round-completion check treats cancelled fixtures as terminal → they don't block advancement.

### Live projection
- `LivePick.projectedOutcome` gains `'void'`.
- Per-mode player projections skip voided picks (classic: doesn't count as elimination; turbo/cup: streak walks past).

### UI
- `GridCell` gains `'void'` variant — soft blue tile with VOID label, distinct from neutral `pending`. The one cell-state where we deliberately diverge from settled-style visuals because there's no settled equivalent.
- `GridRound` gains `voidedAt` — voided round columns get a prominent "VOIDED" header + tinted background.
- `VoidedPickBanner` — dismissible (localStorage-keyed) banner on game-detail page with mode-specific copy.

### Wire points
- `syncCompetition` + `poll-scores` both detect non-terminal → terminal transitions (finished OR cancelled) and call `settleFixture`.

### Docs
- Cancellation section appended to `docs/game-modes/{classic,turbo,cup}.md` cross-referencing the design doc.

## Smoke coverage (16 scenarios, all green against local Postgres)
- Classic single-fixture void: pick voided, player alive, round advances after remaining fixtures finish.
- Classic round-void threshold: 3/4 cancelled, all picks (including previously-settled loss) become `'void'`/'round-voided', eliminated player reinstated, round flagged voided, game advances.
- Turbo auto-skip: streak walks past voided rank.
- Cup auto-skip: re-eval ignores voided picks.
- Postponed → cancelled normalisation.
- Idempotent re-settle.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec biome check .` clean (3 pre-existing warnings unrelated)
- [x] `pnpm exec vitest run` — 409/409 unit pass
- [x] `just smoke` — 16/16 (10 lifecycle + 6 cancellation)
- [ ] Post-merge: confirm voided-pick banner renders for a real cancelled fixture
- [ ] Post-merge: simulate classic round-void by cancelling >50% of fixtures via admin or live-poll and verify player reinstatement

🤖 Generated with [Claude Code](https://claude.com/claude-code)