### PR TITLE
fix(cup): anchor +N lives badge to the underdog team

### DIFF
--- a/src/components/picks/cup-pick.tsx
+++ b/src/components/picks/cup-pick.tsx
@@ -50,9 +50,19 @@ interface CupPickProps {
 	roundNumber?: number
 }
 
-function tierForDisplay(fixture: CupPickFixture): { value: number; plusN: number; heart: boolean } {
+function tierForDisplay(fixture: CupPickFixture): {
+	value: number
+	plusN: number
+	heart: boolean
+	underdogSide: 'home' | 'away' | null
+} {
 	const abs = Math.abs(fixture.tierDifference)
-	return { value: abs, plusN: abs, heart: abs >= 2 }
+	// tierDifference > 0 → home stronger → underdog is away.
+	// tierDifference < 0 → away stronger → underdog is home.
+	// tierDifference === 0 → no underdog (no bonus available).
+	const underdogSide: 'home' | 'away' | null =
+		fixture.tierDifference > 0 ? 'away' : fixture.tierDifference < 0 ? 'home' : null
+	return { value: abs, plusN: abs, heart: abs >= 2, underdogSide }
 }
 
 function sideRestricted(
@@ -236,6 +246,7 @@ export function CupPick({
 									tierMax={3}
 									plusN={tier.plusN}
 									showHeart={tier.heart}
+									underdogSide={tier.underdogSide}
 									homeState={homeState}
 									awayState={awayState}
 									onPickHome={() => handlePickTeam(f.id, 'home')}

--- a/src/components/picks/fixture-row.tsx
+++ b/src/components/picks/fixture-row.tsx
@@ -45,6 +45,14 @@ export interface FixtureRowProps {
 	tierMax?: 3 | 5
 	plusN?: number
 	showHeart?: boolean
+	/**
+	 * Which side is the underdog (lower tier) — used to anchor the +N
+	 * lives indicator to the team that earns the bonus. Without this,
+	 * the +N sits on the top strip and the viewer has to know which
+	 * pot each team is in to work it out. With it, the badge lives on
+	 * the underdog's pick button directly.
+	 */
+	underdogSide?: 'home' | 'away' | null
 	homeState?: SideState
 	awayState?: SideState
 	// Required for the form-detail sheet. Optional only for old callsites that
@@ -74,6 +82,7 @@ export function FixtureRow({
 	tierMax,
 	plusN,
 	showHeart,
+	underdogSide,
 	homeState,
 	awayState,
 	competitionId,
@@ -81,7 +90,13 @@ export function FixtureRow({
 	children,
 }: FixtureRowProps) {
 	const isFullyUsed = usedSide === 'both'
-	const showTierStrip = tierValue != null || plusN != null || showHeart
+	// The +N badge moves onto the underdog team's button when we know
+	// which side it is. The top strip keeps heart + pips as the generic
+	// "this fixture has a tier gap" indicator; the actionable bonus
+	// indicator goes where the click happens.
+	const bonusLivesOnButton = underdogSide && plusN ? plusN : 0
+	const showTopPlusN = !underdogSide && plusN != null && plusN > 0
+	const showTierStrip = tierValue != null || showTopPlusN || showHeart
 	const [sheetTeam, setSheetTeam] = useState<'home' | 'away' | null>(null)
 	const sheetEnabled = !!competitionId
 
@@ -93,7 +108,7 @@ export function FixtureRow({
 					{tierValue != null && (
 						<TierPips value={tierValue as 0 | 1 | 2 | 3 | 4 | 5} max={tierMax} />
 					)}
-					{plusN != null && <PlusNBadge value={plusN} />}
+					{showTopPlusN && plusN != null && <PlusNBadge value={plusN} />}
 					{kickoff && (
 						<span className="ml-auto">
 							<LocalDateTime date={kickoff} />
@@ -112,6 +127,7 @@ export function FixtureRow({
 						disabledReason={disabledReason}
 						state={homeState}
 						onClick={onPickHome}
+						bonusLives={underdogSide === 'home' ? bonusLivesOnButton : 0}
 					/>
 					<div className="flex flex-col items-center justify-center px-3 shrink-0 min-w-[56px] bg-muted/30 border-l border-r border-border">
 						<span className="text-xs text-muted-foreground font-semibold uppercase tracking-wide">
@@ -133,6 +149,7 @@ export function FixtureRow({
 						disabledReason={disabledReason}
 						state={awayState}
 						onClick={onPickAway}
+						bonusLives={underdogSide === 'away' ? bonusLivesOnButton : 0}
 					/>
 					{usedLabel && (
 						<span className="text-[0.7rem] text-muted-foreground px-2 self-center shrink-0">
@@ -263,6 +280,13 @@ interface TeamPickButtonProps {
 	disabledReason?: string
 	state?: SideState
 	onClick?: () => void
+	/**
+	 * Lives gained if this team's pick wins (cup mode, when this side is
+	 * the underdog). Rendered as a chip on the button so the bonus is
+	 * attributed unambiguously to the team that earns it. 0 / undefined
+	 * hides the chip.
+	 */
+	bonusLives?: number
 }
 
 function TeamPickButton({
@@ -273,6 +297,7 @@ function TeamPickButton({
 	disabled,
 	state,
 	onClick,
+	bonusLives,
 }: TeamPickButtonProps) {
 	const stateBlocksClick =
 		state?.kind === 'restricted' || state?.kind === 'used' || state?.kind === 'planned-elsewhere'
@@ -280,6 +305,7 @@ function TeamPickButton({
 	const isHome = side === 'home'
 	const stateCls = sideClass(state)
 	const chip = sideChip(state)
+	const showBonus = !!bonusLives && bonusLives > 0
 
 	return (
 		<button
@@ -304,7 +330,27 @@ function TeamPickButton({
 					<span className="sm:hidden">{team.shortName}</span>
 					<span className="hidden sm:inline">{team.name}</span>
 				</span>
-				{chip && <div className={cn('flex', isHome ? 'justify-end' : 'justify-start')}>{chip}</div>}
+				{(showBonus || chip) && (
+					<div
+						className={cn(
+							'flex items-center gap-1.5 flex-wrap',
+							isHome ? 'justify-end' : 'justify-start',
+						)}
+					>
+						{showBonus && (
+							<span
+								className={cn(
+									'inline-flex items-center gap-0.5 rounded px-1.5 py-[1px] text-[10px] font-bold leading-none',
+									bonusLives >= 2 ? 'bg-amber-100 text-amber-900' : 'bg-muted text-foreground/80',
+								)}
+								title={`Pick ${team.name} — win earns +${bonusLives} ${bonusLives === 1 ? 'life' : 'lives'}`}
+							>
+								+{bonusLives} {bonusLives === 1 ? 'life' : 'lives'}
+							</span>
+						)}
+						{chip}
+					</div>
+				)}
 			</div>
 		</button>
 	)

--- a/src/components/standings/cup-ladder.tsx
+++ b/src/components/standings/cup-ladder.tsx
@@ -4,7 +4,6 @@ import { AlertTriangle, CheckCircle2, Flame, Target, Zap } from 'lucide-react'
 import { useLiveGame } from '@/components/live/use-live-game'
 import { LocalDateTime } from '@/components/local-datetime'
 import { HeartIcon } from '@/components/picks/heart-icon'
-import { PlusNBadge } from '@/components/picks/plus-n-badge'
 import { TeamBadge } from '@/components/picks/team-badge'
 import { TierPips } from '@/components/picks/tier-pips'
 import type {
@@ -164,6 +163,13 @@ function CupFixtureCard({
 	const displayAway = liveFixture?.awayScore != null ? liveFixture.awayScore : fixture.awayScore
 	const score = displayHome != null && displayAway != null ? `${displayHome}–${displayAway}` : null
 
+	// Which side is the underdog? Anchors the +N lives indicator to the
+	// team that earns the bonus (rather than the centred vs-box, where
+	// it isn't obvious which team the badge applies to). Matches the
+	// pick-interface treatment in FixtureRow.
+	const underdogSide: 'home' | 'away' | null =
+		fixture.tierDifference > 0 ? 'away' : fixture.tierDifference < 0 ? 'home' : null
+
 	return (
 		<div
 			className={cn(
@@ -192,7 +198,12 @@ function CupFixtureCard({
 						<span className="font-semibold text-base truncate w-full text-right">
 							{fixture.homeTeam.name}
 						</span>
-						<span className="text-xs text-muted-foreground">Home</span>
+						<div className="flex items-center gap-1.5 justify-end">
+							<span className="text-xs text-muted-foreground">Home</span>
+							{underdogSide === 'home' && fixture.plusN > 0 && (
+								<UnderdogBonusChip value={fixture.plusN} />
+							)}
+						</div>
 					</div>
 				</div>
 				<div className="flex flex-col items-center justify-center px-3 shrink-0 min-w-[96px] bg-muted/30 border-l border-r border-border">
@@ -234,11 +245,14 @@ function CupFixtureCard({
 							)}
 						</>
 					)}
-					<div className="mt-1.5 flex items-center gap-1">
-						<TierPips value={Math.min(fixture.plusN, 3) as 0 | 1 | 2 | 3} max={3} />
-						{fixture.plusN >= 1 && <PlusNBadge value={fixture.plusN} />}
-						{fixture.heart && <HeartIcon size={12} />}
-					</div>
+					{/* Generic tier-gap indicator (heart + pips). The actionable
+					    +N badge has moved next to the underdog team's name. */}
+					{(fixture.heart || fixture.plusN > 0) && (
+						<div className="mt-1.5 flex items-center gap-1">
+							<TierPips value={Math.min(fixture.plusN, 3) as 0 | 1 | 2 | 3} max={3} />
+							{fixture.heart && <HeartIcon size={12} />}
+						</div>
+					)}
 				</div>
 				<div className="flex items-center gap-3 px-4 py-3 flex-1 min-w-0">
 					<TeamBadge
@@ -248,7 +262,12 @@ function CupFixtureCard({
 					/>
 					<div className="flex flex-col items-start min-w-0">
 						<span className="font-semibold text-base truncate w-full">{fixture.awayTeam.name}</span>
-						<span className="text-xs text-muted-foreground">Away</span>
+						<div className="flex items-center gap-1.5">
+							<span className="text-xs text-muted-foreground">Away</span>
+							{underdogSide === 'away' && fixture.plusN > 0 && (
+								<UnderdogBonusChip value={fixture.plusN} />
+							)}
+						</div>
 					</div>
 				</div>
 			</div>
@@ -358,4 +377,23 @@ function BackerChip({ backer }: { backer: CupLadderBacker }) {
 
 function outcomeLabel(o: 'home_win' | 'draw' | 'away_win'): string {
 	return o === 'home_win' ? 'HOME' : o === 'away_win' ? 'AWAY' : 'DRAW'
+}
+
+/**
+ * Lives-gain indicator sitting next to the underdog team's name. Matches
+ * the pick-interface chip styling so the bonus is attributed to the
+ * actual team that earns it, not the centred vs-box.
+ */
+function UnderdogBonusChip({ value }: { value: number }) {
+	const strong = value >= 2
+	return (
+		<span
+			className={cn(
+				'inline-flex items-center rounded px-1.5 py-[1px] text-[10px] font-bold leading-none',
+				strong ? 'bg-amber-100 text-amber-900' : 'bg-muted text-foreground/80',
+			)}
+		>
+			+{value} {value === 1 ? 'life' : 'lives'}
+		</span>
+	)
 }


### PR DESCRIPTION
## Summary

In cup mode the lives-gain indicator was placed where it gave no information about which team earns it — top-left of each fixture row on the pick interface, and the centre vs-box on the standings ladder. Particularly between pots 3 and 4, the viewer has no way to know which TLA is which without leaving the screen.

This PR moves the +N badge directly onto the underdog team in both views.

## Changes

### Pick interface (`FixtureRow` + `TeamPickButton`)
- New \`underdogSide\` prop on FixtureRow, derived in cup-pick.tsx from the signed \`fixture.tierDifference\`.
- TeamPickButton accepts \`bonusLives\` and renders a "+N life(s)" chip alongside the existing state chips (CURRENT, TENTATIVE, etc).
- Tooltip names the team explicitly.
- Top strip keeps heart + pips as the "this fixture has a tier gap" cue but no longer shows the +N — the actionable indicator now lives on the team you'd actually click.

### Standings ladder (\`CupFixtureCard\`)
- Underdog side derived from the same signed tierDifference.
- New \`UnderdogBonusChip\` next to the underdog team's name.
- Centre vs-box still shows heart + pips for the generic gap cue.

## Test plan
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`pnpm exec vitest run\` — 409/409
- [x] \`pnpm exec biome check\` clean
- [ ] Post-merge: open a WC cup pick — verify the +N chip is on the team button, not the top strip
- [ ] Post-merge: open the cup ladder — verify the +N appears next to the underdog team's name

🤖 Generated with [Claude Code](https://claude.com/claude-code)