### PR TITLE
fix(cup): mobile order + collapsible sections + pre-deadline picks view + ladder layout

### DIFF
--- a/src/components/picks/cup-pick.tsx
+++ b/src/components/picks/cup-pick.tsx
@@ -3,6 +3,7 @@
 import { ChevronDown, ChevronUp, X } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { LocalDateTime } from '@/components/local-datetime'
+import { Disclosure } from '@/components/ui/disclosure'
 import { cn } from '@/lib/utils'
 import { FixtureRow, type SideState } from './fixture-row'
 import { HeartIcon } from './heart-icon'
@@ -211,11 +212,13 @@ export function CupPick({
 				· rank {numberOfPicks} picks
 			</div>
 			<div className="grid gap-3 md:grid-cols-[1fr_320px]">
-				<div>
-					<div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
-						Available fixtures
-					</div>
-					<div className="space-y-3">
+				<Disclosure
+					className="order-2 md:order-1"
+					title="Available fixtures"
+					subtitle={`${fixtures.length} fixture${fixtures.length === 1 ? '' : 's'} this round`}
+					defaultOpen
+				>
+					<div className="space-y-3 p-3">
 						{fixtures.map((f) => {
 							const tier = tierForDisplay(f)
 							const slot = slots.find((s) => s.fixtureId === f.id)
@@ -257,49 +260,53 @@ export function CupPick({
 							)
 						})}
 					</div>
-				</div>
-				<div>
-					<div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
-						Your picks, ranked
-					</div>
-					<div className="space-y-1.5">
-						{Array.from({ length: numberOfPicks }, (_, i) => i + 1).map((rank) => {
-							const slot = slots.find((s) => s.confidenceRank === rank)
-							if (!slot) return <EmptySlot key={rank} rank={rank} />
-							return (
-								<CupRankedRow
-									key={rank}
-									slot={slot}
-									fixtures={fixtures}
-									isFirst={rank === 1}
-									isLast={rank === slots.length}
-									onMoveUp={() => handleReorder(rank, rank - 1)}
-									onMoveDown={() => handleReorder(rank, rank + 1)}
-									onRemove={() => handleRemoveSlot(rank)}
-								/>
-							)
-						})}
-					</div>
-					<button
-						type="button"
-						className={cn(
-							'mt-3 w-full rounded bg-foreground text-background py-3 font-semibold',
-							'disabled:opacity-50 disabled:cursor-not-allowed',
-							'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+				</Disclosure>
+				<Disclosure
+					className="order-1 md:order-2"
+					title="Your picks, ranked"
+					subtitle={`${slots.length} of ${numberOfPicks} selected${slots.length < minPicks ? ` — need ${minPicks}` : ''}`}
+					defaultOpen
+				>
+					<div className="p-3">
+						<div className="space-y-1.5">
+							{Array.from({ length: numberOfPicks }, (_, i) => i + 1).map((rank) => {
+								const slot = slots.find((s) => s.confidenceRank === rank)
+								if (!slot) return <EmptySlot key={rank} rank={rank} />
+								return (
+									<CupRankedRow
+										key={rank}
+										slot={slot}
+										fixtures={fixtures}
+										isFirst={rank === 1}
+										isLast={rank === slots.length}
+										onMoveUp={() => handleReorder(rank, rank - 1)}
+										onMoveDown={() => handleReorder(rank, rank + 1)}
+										onRemove={() => handleRemoveSlot(rank)}
+									/>
+								)
+							})}
+						</div>
+						<button
+							type="button"
+							className={cn(
+								'mt-3 w-full rounded bg-foreground text-background py-3 font-semibold',
+								'disabled:opacity-50 disabled:cursor-not-allowed',
+								'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+							)}
+							disabled={readonly || slots.length < minPicks || loading}
+							onClick={handleSubmit}
+						>
+							{loading
+								? 'Submitting...'
+								: (submitLabelOverride ?? `Submit ${slots.length} of ${numberOfPicks} picks`)}
+						</button>
+						{error && (
+							<p className="mt-2 text-xs text-[var(--eliminated)]" role="alert">
+								{error}
+							</p>
 						)}
-						disabled={readonly || slots.length < minPicks || loading}
-						onClick={handleSubmit}
-					>
-						{loading
-							? 'Submitting...'
-							: (submitLabelOverride ?? `Submit ${slots.length} of ${numberOfPicks} picks`)}
-					</button>
-					{error && (
-						<p className="mt-2 text-xs text-[var(--eliminated)]" role="alert">
-							{error}
-						</p>
-					)}
-				</div>
+					</div>
+				</Disclosure>
 			</div>
 		</div>
 	)

--- a/src/components/standings/cup-ladder.tsx
+++ b/src/components/standings/cup-ladder.tsx
@@ -188,25 +188,22 @@ function CupFixtureCard({
 
 			{/* Fixture header */}
 			<div className="flex items-stretch">
-				<div className="flex items-center gap-3 px-4 py-3 flex-1 min-w-0 flex-row-reverse">
+				<div className="flex items-center gap-3 px-3 py-3 flex-1 min-w-0 flex-row-reverse">
 					<TeamBadge
 						shortName={fixture.homeTeam.shortName}
 						badgeUrl={fixture.homeTeam.badgeUrl}
 						size="lg"
 					/>
 					<div className="flex flex-col items-end min-w-0">
-						<span className="font-semibold text-base truncate w-full text-right">
+						<span className="font-semibold text-sm sm:text-base truncate w-full text-right">
 							{fixture.homeTeam.name}
 						</span>
-						<div className="flex items-center gap-1.5 justify-end">
-							<span className="text-xs text-muted-foreground">Home</span>
-							{underdogSide === 'home' && fixture.plusN > 0 && (
-								<UnderdogBonusChip value={fixture.plusN} />
-							)}
-						</div>
+						{underdogSide === 'home' && fixture.plusN > 0 && (
+							<UnderdogBonusChip value={fixture.plusN} />
+						)}
 					</div>
 				</div>
-				<div className="flex flex-col items-center justify-center px-3 shrink-0 min-w-[96px] bg-muted/30 border-l border-r border-border">
+				<div className="flex flex-col items-center justify-center px-2 shrink-0 min-w-[72px] sm:min-w-[88px] bg-muted/30 border-l border-r border-border">
 					{score ? (
 						<>
 							<span className="font-display font-bold text-lg leading-none">{score}</span>
@@ -254,20 +251,19 @@ function CupFixtureCard({
 						</div>
 					)}
 				</div>
-				<div className="flex items-center gap-3 px-4 py-3 flex-1 min-w-0">
+				<div className="flex items-center gap-3 px-3 py-3 flex-1 min-w-0">
 					<TeamBadge
 						shortName={fixture.awayTeam.shortName}
 						badgeUrl={fixture.awayTeam.badgeUrl}
 						size="lg"
 					/>
 					<div className="flex flex-col items-start min-w-0">
-						<span className="font-semibold text-base truncate w-full">{fixture.awayTeam.name}</span>
-						<div className="flex items-center gap-1.5">
-							<span className="text-xs text-muted-foreground">Away</span>
-							{underdogSide === 'away' && fixture.plusN > 0 && (
-								<UnderdogBonusChip value={fixture.plusN} />
-							)}
-						</div>
+						<span className="font-semibold text-sm sm:text-base truncate w-full">
+							{fixture.awayTeam.name}
+						</span>
+						{underdogSide === 'away' && fixture.plusN > 0 && (
+							<UnderdogBonusChip value={fixture.plusN} />
+						)}
 					</div>
 				</div>
 			</div>

--- a/src/components/standings/cup-standings.tsx
+++ b/src/components/standings/cup-standings.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { Clock, LayoutGrid, ListTree } from 'lucide-react'
+import { Clock, LayoutGrid, ListTree, Lock, UserCircle2 } from 'lucide-react'
 import { useState } from 'react'
+import { Disclosure } from '@/components/ui/disclosure'
 import type { CupLadderData } from '@/lib/game/cup-standings-queries'
 import { cn } from '@/lib/utils'
 import { CupGrid } from './cup-grid'
@@ -19,63 +20,123 @@ interface CupStandingsProps {
 
 export function CupStandings({ data, onShare, showAdminActions, gameId }: CupStandingsProps) {
 	const [view, setView] = useState<ViewMode>('ladder')
+	const isPreDeadline = data.roundStatus === 'open'
+	const submittedCount = data.players.filter((p) => p.hasSubmitted).length
+	const totalCount = data.players.length
+
 	return (
-		<div className="rounded-xl border border-border bg-card overflow-hidden">
-			<div className="p-4 md:p-5 flex flex-wrap items-start justify-between gap-3 border-b border-border">
-				<div>
-					<h2 className="font-display text-2xl font-semibold">Standings</h2>
-					<p className="text-sm text-muted-foreground mt-1">
-						{data.roundStatus === 'completed'
-							? 'Round complete.'
-							: data.roundStatus === 'open'
-								? 'Round open — picks hidden until the deadline passes.'
-								: 'Round in play.'}
-					</p>
-				</div>
-				<div className="flex items-center gap-2">
-					<div className="flex gap-1 border border-border rounded-md p-0.5">
-						{(['ladder', 'timeline', 'grid'] as const).map((m) => (
-							<button
-								key={m}
-								type="button"
-								onClick={() => setView(m)}
-								className={cn(
-									'text-xs font-semibold px-2.5 py-1 rounded flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
-									view === m
-										? 'bg-foreground text-background'
-										: 'text-muted-foreground hover:text-foreground',
-								)}
-							>
-								{m === 'ladder' && <ListTree className="h-3 w-3" />}
-								{m === 'timeline' && <Clock className="h-3 w-3" />}
-								{m === 'grid' && <LayoutGrid className="h-3 w-3" />}
-								{m[0].toUpperCase() + m.slice(1)}
-							</button>
-						))}
+		<Disclosure
+			bordered
+			defaultOpen
+			title="Standings"
+			subtitle={
+				data.roundStatus === 'completed'
+					? 'Round complete'
+					: isPreDeadline
+						? `${submittedCount} of ${totalCount} ${submittedCount === 1 ? 'player has' : 'players have'} picked`
+						: 'Round in play'
+			}
+			rightSlot={
+				onShare ? (
+					<button
+						type="button"
+						onClick={onShare}
+						className="text-xs font-semibold px-3 py-1 rounded border border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+					>
+						Share
+					</button>
+				) : undefined
+			}
+		>
+			{isPreDeadline ? (
+				<PreDeadlinePicksStatus data={data} />
+			) : (
+				<>
+					<div className="px-4 md:px-5 pt-3 flex flex-wrap items-center gap-2">
+						<div className="flex gap-1 border border-border rounded-md p-0.5">
+							{(['ladder', 'timeline', 'grid'] as const).map((m) => (
+								<button
+									key={m}
+									type="button"
+									onClick={() => setView(m)}
+									className={cn(
+										'text-xs font-semibold px-2.5 py-1 rounded flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+										view === m
+											? 'bg-foreground text-background'
+											: 'text-muted-foreground hover:text-foreground',
+									)}
+								>
+									{m === 'ladder' && <ListTree className="h-3 w-3" />}
+									{m === 'timeline' && <Clock className="h-3 w-3" />}
+									{m === 'grid' && <LayoutGrid className="h-3 w-3" />}
+									{m[0].toUpperCase() + m.slice(1)}
+								</button>
+							))}
+						</div>
 					</div>
-					{onShare && (
-						<button
-							type="button"
-							onClick={onShare}
-							className="text-xs font-semibold px-3 py-1 rounded border border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-						>
-							Share
-						</button>
-					)}
-				</div>
-			</div>
-			<div className="p-4 md:p-5">
-				{view === 'ladder' && (
-					<CupLadder data={data} showAdminActions={showAdminActions} gameId={gameId} />
-				)}
-				{view === 'grid' && (
-					<CupGrid data={data} showAdminActions={showAdminActions} gameId={gameId} />
-				)}
-				{view === 'timeline' && (
-					<div className="overflow-x-auto">
-						<CupTimeline data={data} />
+					<div className="p-4 md:p-5">
+						{view === 'ladder' && (
+							<CupLadder data={data} showAdminActions={showAdminActions} gameId={gameId} />
+						)}
+						{view === 'grid' && (
+							<CupGrid data={data} showAdminActions={showAdminActions} gameId={gameId} />
+						)}
+						{view === 'timeline' && (
+							<div className="overflow-x-auto">
+								<CupTimeline data={data} />
+							</div>
+						)}
 					</div>
-				)}
+				</>
+			)}
+		</Disclosure>
+	)
+}
+
+/**
+ * Pre-deadline view: a compact "who's picked" status with a padlock per
+ * player who's submitted. Mirrors the classic-mode pre-deadline grid —
+ * the full ladder is irrelevant before the deadline because everyone's
+ * picks are hidden anyway. Viewer can peek at the full ladder via the
+ * inner "Show full standings" disclosure.
+ */
+function PreDeadlinePicksStatus({ data }: { data: CupLadderData }) {
+	const submitted = data.players.filter((p) => p.hasSubmitted)
+	const pending = data.players.filter((p) => !p.hasSubmitted)
+	const ordered = [...submitted, ...pending]
+
+	return (
+		<div className="p-4 md:p-5 space-y-3">
+			<div className="grid gap-2 sm:grid-cols-2">
+				{ordered.map((p) => (
+					<div
+						key={p.id}
+						className={cn(
+							'flex items-center gap-2 rounded-md border px-3 py-2',
+							p.hasSubmitted
+								? 'border-[var(--alive-bg)] bg-[var(--alive-bg)]/40'
+								: 'border-dashed border-border bg-muted/20',
+						)}
+					>
+						<UserCircle2
+							className={cn(
+								'h-5 w-5 shrink-0',
+								p.hasSubmitted ? 'text-[var(--alive)]' : 'text-muted-foreground',
+							)}
+							aria-hidden
+						/>
+						<span className="text-sm font-medium truncate flex-1">{p.name}</span>
+						{p.hasSubmitted ? (
+							<span className="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide text-[var(--alive)]">
+								<Lock className="h-3 w-3" aria-hidden /> Locked
+							</span>
+						) : (
+							<span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+								No picks
+							</span>
+						)}
+					</div>
+				))}
 			</div>
 		</div>
 	)

--- a/src/components/ui/disclosure.tsx
+++ b/src/components/ui/disclosure.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { ChevronDown } from 'lucide-react'
+import { useState } from 'react'
+import { cn } from '@/lib/utils'
+
+interface DisclosureProps {
+	title: React.ReactNode
+	subtitle?: React.ReactNode
+	rightSlot?: React.ReactNode
+	defaultOpen?: boolean
+	children: React.ReactNode
+	className?: string
+	/**
+	 * Style the disclosure as a section card with border + rounded
+	 * corners. Default true; pass false when the parent already
+	 * provides chrome.
+	 */
+	bordered?: boolean
+}
+
+/**
+ * Lightweight client-side collapsible. Keyboard-accessible (the toggle
+ * is a real button), uses an animated chevron, retains state across
+ * renders without a router round-trip. Sections in the cup pick
+ * interface + standings panels wrap with this so a long page can be
+ * folded down to what the viewer wants to see.
+ */
+export function Disclosure({
+	title,
+	subtitle,
+	rightSlot,
+	defaultOpen = true,
+	children,
+	className,
+	bordered = true,
+}: DisclosureProps) {
+	const [open, setOpen] = useState(defaultOpen)
+	return (
+		<div
+			className={cn(
+				bordered && 'rounded-lg border border-border bg-card overflow-hidden',
+				className,
+			)}
+		>
+			<button
+				type="button"
+				onClick={() => setOpen((v) => !v)}
+				aria-expanded={open}
+				className={cn(
+					'flex w-full items-center justify-between gap-3 text-left',
+					bordered ? 'px-4 py-3' : 'py-2',
+					'hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+				)}
+			>
+				<div className="min-w-0 flex-1">
+					<div className="text-sm font-semibold leading-tight">{title}</div>
+					{subtitle && (
+						<div className="text-xs text-muted-foreground mt-0.5 leading-tight">{subtitle}</div>
+					)}
+				</div>
+				<div className="flex items-center gap-2 shrink-0">
+					{rightSlot}
+					<ChevronDown
+						className={cn('h-4 w-4 transition-transform', open && 'rotate-180')}
+						aria-hidden
+					/>
+				</div>
+			</button>
+			{open && <div className={cn(bordered && 'border-t border-border')}>{children}</div>}
+		</div>
+	)
+}


### PR DESCRIPTION
Four UX fixes for cup mode based on real use.

## 1. Mobile: ranking above selection

On the cup pick interface, long fixture lists pushed the rank-your-picks UI off-screen on mobile, so players started picking without realising they had to rank. The grid now stacks ranking first on mobile (\`order-1\` / \`md:order-2\`); desktop layout unchanged.

## 2. Collapsible sections

New \`Disclosure\` UI primitive (\`src/components/ui/disclosure.tsx\`) wraps:
- Available Fixtures (cup pick)
- Your Picks Ranked (cup pick)
- Standings panel

Default-open; clickable header collapses with an animated chevron.

## 3. Cup ladder layout cleanup

- Dropped "Home" / "Away" sublabels. Left/right placement implies it, and WC venues are neutral anyway.
- The +N lives chip now sits cleanly below each team name instead of being crowded by the label — fixes the "falling off the right edge" issue.
- Centre vs-box shrunk (\`min-w-[72px]\` mobile / \`min-w-[88px]\` sm+) so team-name columns have room on narrow viewports.

## 4. Pre-deadline picks-status view

When the round is still open (\`roundStatus === 'open'\`), the Standings panel shows a compact "who's picked" grid instead of the full ladder — same intent as classic mode's pre-deadline grid. Each player row: name + padlock icon if hasSubmitted, "No picks" otherwise. Ladder / timeline / grid tabs reappear post-deadline.

## Test plan
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`pnpm exec vitest run\` — 409/409
- [x] \`pnpm exec biome check\` clean (3 pre-existing warnings)
- [ ] Post-merge: open a WC cup game on mobile — verify ranking appears above selection
- [ ] Post-merge: verify Standings panel shows the picks-status grid before the round deadline; toggle to ladder/grid/timeline after the deadline
- [ ] Post-merge: verify the +N lives chip on the ladder doesn't overflow on a narrow viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)