### PR TITLE
feat(cron): make daily-sync diagnosable + persistent run audit

### DIFF
--- a/drizzle/0006_add_cron_run.sql
+++ b/drizzle/0006_add_cron_run.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "cron_run" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"route" varchar(100) NOT NULL,
+	"started_at" timestamp NOT NULL,
+	"duration_ms" integer NOT NULL,
+	"status" varchar(20) NOT NULL,
+	"error" text,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,1672 @@
+{
+  "id": "e5cf3bd1-ea9a-40b2-9c29-174ece5c6a9a",
+  "prevId": "bccac251-1114-479a-8fef-037f5d50be2d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition": {
+      "name": "competition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "competition_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_source": {
+          "name": "data_source",
+          "type": "competition_data_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "season": {
+          "name": "season",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fixture": {
+      "name": "fixture",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_team_id": {
+          "name": "home_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "away_team_id": {
+          "name": "away_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kickoff": {
+          "name": "kickoff",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_score": {
+          "name": "home_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "away_score": {
+          "name": "away_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "fixture_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ids": {
+          "name": "external_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fixture_round_id_round_id_fk": {
+          "name": "fixture_round_id_round_id_fk",
+          "tableFrom": "fixture",
+          "tableTo": "round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fixture_home_team_id_team_id_fk": {
+          "name": "fixture_home_team_id_team_id_fk",
+          "tableFrom": "fixture",
+          "tableTo": "team",
+          "columnsFrom": [
+            "home_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fixture_away_team_id_team_id_fk": {
+          "name": "fixture_away_team_id_team_id_fk",
+          "tableFrom": "fixture",
+          "tableTo": "team",
+          "columnsFrom": [
+            "away_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.round": {
+      "name": "round",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "round_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upcoming'"
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "round_competition_id_competition_id_fk": {
+          "name": "round_competition_id_competition_id_fk",
+          "tableFrom": "round",
+          "tableTo": "competition",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team": {
+      "name": "team",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_url": {
+          "name": "badge_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_color": {
+          "name": "primary_color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ids": {
+          "name": "external_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "league_position": {
+          "name": "league_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_form": {
+      "name": "team_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recent_results": {
+          "name": "recent_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "home_form": {
+          "name": "home_form",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "away_form": {
+          "name": "away_form",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "league_position": {
+          "name": "league_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_form_team_comp_idx": {
+          "name": "team_form_team_comp_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_form_team_id_team_id_fk": {
+          "name": "team_form_team_id_team_id_fk",
+          "tableFrom": "team_form",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_form_competition_id_competition_id_fk": {
+          "name": "team_form_competition_id_competition_id_fk",
+          "tableFrom": "team_form",
+          "tableTo": "competition",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game": {
+      "name": "game",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "game_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'setup'"
+        },
+        "game_mode": {
+          "name": "game_mode",
+          "type": "game_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode_config": {
+          "name": "mode_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_players": {
+          "name": "max_players",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_round_id": {
+          "name": "current_round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_competition_id_competition_id_fk": {
+          "name": "game_competition_id_competition_id_fk",
+          "tableFrom": "game",
+          "tableTo": "competition",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_current_round_id_round_id_fk": {
+          "name": "game_current_round_id_round_id_fk",
+          "tableFrom": "game",
+          "tableTo": "round",
+          "columnsFrom": [
+            "current_round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "game_invite_code_unique": {
+          "name": "game_invite_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_player": {
+      "name": "game_player",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "player_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'alive'"
+        },
+        "eliminated_round_id": {
+          "name": "eliminated_round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eliminated_reason": {
+          "name": "eliminated_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lives_remaining": {
+          "name": "lives_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_player_unique_idx": {
+          "name": "game_player_unique_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_player_game_id_game_id_fk": {
+          "name": "game_player_game_id_game_id_fk",
+          "tableFrom": "game_player",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_player_eliminated_round_id_round_id_fk": {
+          "name": "game_player_eliminated_round_id_round_id_fk",
+          "tableFrom": "game_player",
+          "tableTo": "round",
+          "columnsFrom": [
+            "eliminated_round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pick": {
+      "name": "pick",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_player_id": {
+          "name": "game_player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fixture_id": {
+          "name": "fixture_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_rank": {
+          "name": "confidence_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "predicted_result": {
+          "name": "predicted_result",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "pick_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "goals_scored": {
+          "name": "goals_scored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "life_gained": {
+          "name": "life_gained",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "life_spent": {
+          "name": "life_spent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_submitted": {
+          "name": "auto_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_auto": {
+          "name": "is_auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pick_player_round_idx": {
+          "name": "pick_player_round_idx",
+          "columns": [
+            {
+              "expression": "game_player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "round_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "confidence_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pick_game_id_game_id_fk": {
+          "name": "pick_game_id_game_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_game_player_id_game_player_id_fk": {
+          "name": "pick_game_player_id_game_player_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "game_player",
+          "columnsFrom": [
+            "game_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_round_id_round_id_fk": {
+          "name": "pick_round_id_round_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_team_id_team_id_fk": {
+          "name": "pick_team_id_team_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_fixture_id_fixture_id_fk": {
+          "name": "pick_fixture_id_fixture_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "fixture",
+          "columnsFrom": [
+            "fixture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planned_pick": {
+      "name": "planned_pick",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_player_id": {
+          "name": "game_player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_submit": {
+          "name": "auto_submit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "planned_pick_unique_idx": {
+          "name": "planned_pick_unique_idx",
+          "columns": [
+            {
+              "expression": "game_player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "round_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "planned_pick_game_player_id_game_player_id_fk": {
+          "name": "planned_pick_game_player_id_game_player_id_fk",
+          "tableFrom": "planned_pick",
+          "tableTo": "game_player",
+          "columnsFrom": [
+            "game_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "planned_pick_round_id_round_id_fk": {
+          "name": "planned_pick_round_id_round_id_fk",
+          "tableFrom": "planned_pick",
+          "tableTo": "round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "planned_pick_team_id_team_id_fk": {
+          "name": "planned_pick_team_id_team_id_fk",
+          "tableFrom": "planned_pick",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_run": {
+      "name": "cron_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "route": {
+          "name": "route",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment": {
+      "name": "payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payment_game_id_game_id_fk": {
+          "name": "payment_game_id_game_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payout": {
+      "name": "payout",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_split": {
+          "name": "is_split",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "payout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payout_game_id_game_id_fk": {
+          "name": "payout_game_id_game_id_fk",
+          "tableFrom": "payout",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.competition_data_source": {
+      "name": "competition_data_source",
+      "schema": "public",
+      "values": [
+        "fpl",
+        "football_data",
+        "manual"
+      ]
+    },
+    "public.competition_type": {
+      "name": "competition_type",
+      "schema": "public",
+      "values": [
+        "league",
+        "knockout",
+        "group_knockout"
+      ]
+    },
+    "public.fixture_status": {
+      "name": "fixture_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "live",
+        "finished",
+        "postponed",
+        "cancelled"
+      ]
+    },
+    "public.round_status": {
+      "name": "round_status",
+      "schema": "public",
+      "values": [
+        "upcoming",
+        "open",
+        "active",
+        "completed"
+      ]
+    },
+    "public.game_mode": {
+      "name": "game_mode",
+      "schema": "public",
+      "values": [
+        "classic",
+        "turbo",
+        "cup"
+      ]
+    },
+    "public.game_status": {
+      "name": "game_status",
+      "schema": "public",
+      "values": [
+        "setup",
+        "open",
+        "active",
+        "completed"
+      ]
+    },
+    "public.pick_result": {
+      "name": "pick_result",
+      "schema": "public",
+      "values": [
+        "pending",
+        "win",
+        "loss",
+        "draw",
+        "saved_by_life",
+        "void"
+      ]
+    },
+    "public.player_status": {
+      "name": "player_status",
+      "schema": "public",
+      "values": [
+        "alive",
+        "eliminated",
+        "winner"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "manual",
+        "mangopay"
+      ]
+    },
+    "public.payment_status": {
+      "name": "payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "claimed",
+        "paid",
+        "refunded"
+      ]
+    },
+    "public.payout_status": {
+      "name": "payout_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1778598565917,
       "tag": "0005_add_cancellation_state",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1779462870708,
+      "tag": "0006_add_cron_run",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/cron/daily-sync/route.test.ts
+++ b/src/app/api/cron/daily-sync/route.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const cronRunInsertValues = vi.fn().mockResolvedValue(undefined)
+
 vi.mock('@/lib/db', () => ({
 	db: {
 		query: {
 			competition: { findMany: vi.fn() },
 			game: { findMany: vi.fn().mockResolvedValue([]) },
 		},
+		insert: vi.fn(() => ({ values: cronRunInsertValues })),
 	},
 }))
 
@@ -42,7 +45,52 @@ import { POST } from './route'
 describe('daily-sync route', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
+		cronRunInsertValues.mockClear()
+		cronRunInsertValues.mockResolvedValue(undefined)
 		process.env.CRON_SECRET = 'test-secret'
+	})
+
+	it('records a success cron_run when the body completes', async () => {
+		vi.mocked(db.query.competition.findMany).mockResolvedValue([{ id: 'c1' }] as never)
+		vi.mocked(syncCompetition).mockResolvedValue({
+			rounds: 0,
+			fixtures: 0,
+			deadlinePassedRoundIds: [],
+			settledFixtureIds: [],
+		})
+		const res = await POST(
+			new Request('http://x', {
+				method: 'POST',
+				headers: { authorization: 'Bearer test-secret' },
+			}),
+		)
+		expect(res.status).toBe(200)
+		expect(cronRunInsertValues).toHaveBeenCalledTimes(1)
+		expect(cronRunInsertValues.mock.calls[0][0]).toMatchObject({
+			route: '/api/cron/daily-sync',
+			status: 'success',
+			error: null,
+		})
+	})
+
+	it('returns 500 with a serialized error and records a failure cron_run when an adapter throws', async () => {
+		vi.mocked(db.query.competition.findMany).mockResolvedValue([{ id: 'c1' }] as never)
+		vi.mocked(syncCompetition).mockRejectedValue(new Error('upstream blew up'))
+		const res = await POST(
+			new Request('http://x', {
+				method: 'POST',
+				headers: { authorization: 'Bearer test-secret' },
+			}),
+		)
+		expect(res.status).toBe(500)
+		const body = (await res.json()) as { error: { message: string } }
+		expect(body.error.message).toBe('upstream blew up')
+		expect(cronRunInsertValues).toHaveBeenCalledTimes(1)
+		expect(cronRunInsertValues.mock.calls[0][0]).toMatchObject({
+			route: '/api/cron/daily-sync',
+			status: 'failure',
+			error: 'upstream blew up',
+		})
 	})
 
 	it('returns 401 without auth', async () => {

--- a/src/app/api/cron/daily-sync/route.ts
+++ b/src/app/api/cron/daily-sync/route.ts
@@ -1,5 +1,6 @@
 import { eq } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
+import { serializeError } from '@/lib/cron/serialize-error'
 import { db } from '@/lib/db'
 import {
 	applyPotAssignments,
@@ -12,6 +13,9 @@ import { reconcileAllActiveGames } from '@/lib/game/reconcile'
 import { openRoundForGame } from '@/lib/game/round-lifecycle'
 import { competition } from '@/lib/schema/competition'
 import { game } from '@/lib/schema/game'
+import { cronRun } from '@/lib/schema/ops'
+
+const ROUTE = '/api/cron/daily-sync'
 
 export async function POST(request: Request) {
 	const secret = process.env.CRON_SECRET
@@ -21,83 +25,114 @@ export async function POST(request: Request) {
 	if (request.headers.get('authorization') !== `Bearer ${secret}`) {
 		return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 	}
-	const apiKey = process.env.FOOTBALL_DATA_API_KEY
-	const comps = await db.query.competition.findMany({
-		where: eq(competition.status, 'active'),
-	})
-	const results = []
-	const deadlineLockedRoundIds: string[] = []
-	for (const c of comps) {
-		const summary = await syncCompetition(c, { footballDataApiKey: apiKey })
-		const entry: {
-			competitionId: string
-			rounds: number
-			fixtures: number
-			pots?: { matched: number; unmatched: string[] }
-		} = {
-			competitionId: c.id,
-			rounds: summary.rounds,
-			fixtures: summary.fixtures,
+
+	const startedAt = new Date()
+	const startTs = Date.now()
+	try {
+		const apiKey = process.env.FOOTBALL_DATA_API_KEY
+		const comps = await db.query.competition.findMany({
+			where: eq(competition.status, 'active'),
+		})
+		const results = []
+		const deadlineLockedRoundIds: string[] = []
+		for (const c of comps) {
+			const summary = await syncCompetition(c, { footballDataApiKey: apiKey })
+			const entry: {
+				competitionId: string
+				rounds: number
+				fixtures: number
+				pots?: { matched: number; unmatched: string[] }
+			} = {
+				competitionId: c.id,
+				rounds: summary.rounds,
+				fixtures: summary.fixtures,
+			}
+			if (summary.deadlinePassedRoundIds?.length) {
+				deadlineLockedRoundIds.push(...summary.deadlinePassedRoundIds)
+			}
+			// For FPL-bootstrapped competitions, merge football-data IDs onto fresh
+			// fixtures + teams so the live-score poll can match by external_ids.football_data.
+			if (c.dataSource === 'fpl' && apiKey) {
+				await mergeFootballDataIds(c, apiKey)
+			}
+			// Group-knockout competitions (e.g. World Cup) need FIFA pot assignments
+			// on every team for cup-mode tier-difference maths. Run on every sync so
+			// late-arriving teams (playoff winners) get tagged without a redeploy.
+			if (c.type === 'group_knockout') {
+				entry.pots = await applyPotAssignments(c.id)
+			}
+			results.push(entry)
 		}
-		if (summary.deadlinePassedRoundIds?.length) {
-			deadlineLockedRoundIds.push(...summary.deadlinePassedRoundIds)
+
+		// Reconciliation: any active game whose currentRoundId still points at an
+		// 'upcoming' round means the open transition didn't fire (e.g. a game
+		// created before the round-lifecycle fix shipped, or a future-round
+		// advance whose new round was upcoming when the game advanced into it).
+		// Heal here so the progress grid filter and processDeadlineLock both see
+		// the round as open.
+		const activeGames = await db.query.game.findMany({
+			where: eq(game.status, 'active'),
+			with: { currentRound: true },
+		})
+		const reconciledRoundIds: string[] = []
+		for (const g of activeGames) {
+			if (g.currentRound && g.currentRound.status === 'upcoming') {
+				await openRoundForGame(g.currentRound.id)
+				reconciledRoundIds.push(g.currentRound.id)
+			}
 		}
-		// For FPL-bootstrapped competitions, merge football-data IDs onto fresh
-		// fixtures + teams so the live-score poll can match by external_ids.football_data.
-		if (c.dataSource === 'fpl' && apiKey) {
-			await mergeFootballDataIds(c, apiKey)
+
+		// 24h safety-net: sweep all active games through reconcile. Per-fixture
+		// settlement (called inline above from syncCompetition) handles the
+		// happy path; this catches anything missed (network failure on the
+		// inline settle, an in-flight migration, future bugs). settleFixture is
+		// idempotent so this is a no-op for healthy games.
+		const reconcileSummary = await reconcileAllActiveGames()
+
+		// Pre-schedule a poll-scores trigger for every upcoming fixture across all
+		// competitions. Each fixture gets its own QStash trigger 10 min before
+		// kickoff, which starts the self-perpetuating chain reliably.
+		await scheduleUpcomingFixturePolls()
+		let deadlineLock: {
+			autoPicksInserted: number
+			playersEliminated: number
+			paymentsRefunded: number
+		} | null = null
+		if (deadlineLockedRoundIds.length > 0) {
+			deadlineLock = await processDeadlineLock(deadlineLockedRoundIds)
 		}
-		// Group-knockout competitions (e.g. World Cup) need FIFA pot assignments
-		// on every team for cup-mode tier-difference maths. Run on every sync so
-		// late-arriving teams (playoff winners) get tagged without a redeploy.
-		if (c.type === 'group_knockout') {
-			entry.pots = await applyPotAssignments(c.id)
-		}
-		results.push(entry)
+
+		await recordRun(startedAt, startTs, 'success', null)
+		return NextResponse.json({
+			competitions: results,
+			deadlineLock,
+			reconciledRoundIds,
+			reconcile: reconcileSummary,
+		})
+	} catch (err) {
+		const serialized = serializeError(err)
+		console.error('[cron/daily-sync] failed', serialized)
+		await recordRun(startedAt, startTs, 'failure', serialized.message)
+		return NextResponse.json({ error: serialized }, { status: 500 })
 	}
+}
 
-	// Reconciliation: any active game whose currentRoundId still points at an
-	// 'upcoming' round means the open transition didn't fire (e.g. a game
-	// created before the round-lifecycle fix shipped, or a future-round
-	// advance whose new round was upcoming when the game advanced into it).
-	// Heal here so the progress grid filter and processDeadlineLock both see
-	// the round as open.
-	const activeGames = await db.query.game.findMany({
-		where: eq(game.status, 'active'),
-		with: { currentRound: true },
-	})
-	const reconciledRoundIds: string[] = []
-	for (const g of activeGames) {
-		if (g.currentRound && g.currentRound.status === 'upcoming') {
-			await openRoundForGame(g.currentRound.id)
-			reconciledRoundIds.push(g.currentRound.id)
-		}
+async function recordRun(
+	startedAt: Date,
+	startTs: number,
+	status: 'success' | 'failure',
+	error: string | null,
+): Promise<void> {
+	try {
+		await db.insert(cronRun).values({
+			route: ROUTE,
+			startedAt,
+			durationMs: Date.now() - startTs,
+			status,
+			error,
+		})
+	} catch (logErr) {
+		// Don't let the audit-trail insert mask the real outcome.
+		console.error('[cron/daily-sync] failed to record cron_run', logErr)
 	}
-
-	// 24h safety-net: sweep all active games through reconcile. Per-fixture
-	// settlement (called inline above from syncCompetition) handles the
-	// happy path; this catches anything missed (network failure on the
-	// inline settle, an in-flight migration, future bugs). settleFixture is
-	// idempotent so this is a no-op for healthy games.
-	const reconcileSummary = await reconcileAllActiveGames()
-
-	// Pre-schedule a poll-scores trigger for every upcoming fixture across all
-	// competitions. Each fixture gets its own QStash trigger 10 min before
-	// kickoff, which starts the self-perpetuating chain reliably.
-	await scheduleUpcomingFixturePolls()
-	let deadlineLock: {
-		autoPicksInserted: number
-		playersEliminated: number
-		paymentsRefunded: number
-	} | null = null
-	if (deadlineLockedRoundIds.length > 0) {
-		deadlineLock = await processDeadlineLock(deadlineLockedRoundIds)
-	}
-
-	return NextResponse.json({
-		competitions: results,
-		deadlineLock,
-		reconciledRoundIds,
-		reconcile: reconcileSummary,
-	})
 }

--- a/src/app/api/cron/poll-scores/route.ts
+++ b/src/app/api/cron/poll-scores/route.ts
@@ -1,5 +1,6 @@
 import { eq, inArray, sql } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
+import { serializeError } from '@/lib/cron/serialize-error'
 import { FootballDataAdapter, resolveFootballDataCode } from '@/lib/data/football-data'
 import { hasActiveFixture } from '@/lib/data/match-window'
 import { enqueuePollScores } from '@/lib/data/qstash'
@@ -22,6 +23,16 @@ export async function POST(request: Request) {
 		return NextResponse.json({ error: 'FOOTBALL_DATA_API_KEY not configured' }, { status: 500 })
 	}
 
+	try {
+		return await pollScores(apiKey)
+	} catch (err) {
+		const serialized = serializeError(err)
+		console.error('[cron/poll-scores] failed', serialized)
+		return NextResponse.json({ error: serialized }, { status: 500 })
+	}
+}
+
+async function pollScores(apiKey: string): Promise<NextResponse> {
 	const activeGames = await db.query.game.findMany({
 		where: eq(game.status, 'active'),
 		with: { currentRound: true, competition: true },

--- a/src/lib/cron/serialize-error.ts
+++ b/src/lib/cron/serialize-error.ts
@@ -1,0 +1,54 @@
+import { AdapterFetchError } from '@/lib/data/fetch-json'
+
+export interface SerializedError {
+	message: string
+	name: string
+	stack?: string
+	adapter?: {
+		url: string
+		httpStatus: number | null
+		contentType: string | null
+		bodyPreview: string | null
+	}
+	cause?: { name: string; message: string }
+}
+
+/**
+ * Flatten an unknown thrown value into a structured shape that survives
+ * `console.error` (Vercel's JSON log renderer) and HTTP response
+ * serialisation. AdapterFetchError gets first-class treatment so adapter
+ * failures land in logs with the request URL, status, content-type and
+ * body preview — the breadcrumb that was previously absent.
+ */
+export function serializeError(err: unknown): SerializedError {
+	if (err instanceof AdapterFetchError) {
+		return {
+			message: err.message,
+			name: err.name,
+			stack: err.stack,
+			adapter: {
+				url: err.url,
+				httpStatus: err.httpStatus,
+				contentType: err.contentType,
+				bodyPreview: err.bodyPreview,
+			},
+			...causeFrom(err.cause),
+		}
+	}
+	if (err instanceof Error) {
+		return {
+			message: err.message,
+			name: err.name,
+			stack: err.stack,
+			...causeFrom(err.cause),
+		}
+	}
+	return { message: String(err), name: 'NonError' }
+}
+
+function causeFrom(cause: unknown): { cause?: { name: string; message: string } } {
+	if (cause instanceof Error) {
+		return { cause: { name: cause.name, message: cause.message } }
+	}
+	return {}
+}

--- a/src/lib/data/fetch-json.test.ts
+++ b/src/lib/data/fetch-json.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AdapterFetchError, fetchJson } from './fetch-json'
+
+describe('fetchJson', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks()
+	})
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('parses a successful JSON response', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(
+				async () =>
+					new Response(JSON.stringify({ ok: true, n: 7 }), {
+						status: 200,
+						headers: { 'content-type': 'application/json' },
+					}),
+			),
+		)
+		const data = await fetchJson<{ ok: boolean; n: number }>('https://example.test/x')
+		expect(data).toEqual({ ok: true, n: 7 })
+	})
+
+	it('throws AdapterFetchError with status + body preview when the response is not 2xx', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(
+				async () =>
+					new Response('rate limit exceeded', {
+						status: 429,
+						headers: { 'content-type': 'text/plain' },
+					}),
+			),
+		)
+		await expect(fetchJson('https://example.test/x')).rejects.toMatchObject({
+			name: 'AdapterFetchError',
+			url: 'https://example.test/x',
+			httpStatus: 429,
+			contentType: 'text/plain',
+			bodyPreview: 'rate limit exceeded',
+		})
+	})
+
+	it('throws AdapterFetchError on empty body / unparseable JSON (the silent-500 case)', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(
+				async () =>
+					new Response('', {
+						status: 200,
+						headers: { 'content-type': 'application/json' },
+					}),
+			),
+		)
+		const err = (await fetchJson('https://example.test/empty').catch(
+			(e: unknown) => e,
+		)) as AdapterFetchError
+		expect(err).toBeInstanceOf(AdapterFetchError)
+		expect(err.httpStatus).toBe(200)
+		expect(err.bodyPreview).toBe('')
+	})
+
+	it('throws AdapterFetchError when fetch itself rejects (network failure)', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => {
+				throw new TypeError('fetch failed')
+			}),
+		)
+		const err = (await fetchJson('https://example.test/down').catch(
+			(e: unknown) => e,
+		)) as AdapterFetchError
+		expect(err).toBeInstanceOf(AdapterFetchError)
+		expect(err.httpStatus).toBeNull()
+		expect(err.url).toBe('https://example.test/down')
+	})
+})

--- a/src/lib/data/fetch-json.ts
+++ b/src/lib/data/fetch-json.ts
@@ -1,0 +1,46 @@
+/**
+ * Structured error thrown by `fetchJson` when an outbound HTTP/JSON call
+ * doesn't return parseable JSON. Captures the URL, response status, content
+ * type, and a body preview so the caller can log what actually came back —
+ * the missing breadcrumb behind the silent `SyntaxError: Unexpected end of
+ * JSON input` that previously surfaced from bare `res.json()` calls.
+ */
+export class AdapterFetchError extends Error {
+	constructor(
+		public readonly url: string,
+		public readonly httpStatus: number | null,
+		public readonly contentType: string | null,
+		public readonly bodyPreview: string | null,
+		options?: { cause?: unknown },
+	) {
+		const parts = [`AdapterFetch ${url}`]
+		if (httpStatus != null) parts.push(`status=${httpStatus}`)
+		if (contentType) parts.push(`content-type=${contentType}`)
+		if (bodyPreview != null) parts.push(`body="${bodyPreview.slice(0, 200).replace(/\s+/g, ' ')}"`)
+		super(parts.join(' '), options)
+		this.name = 'AdapterFetchError'
+	}
+}
+
+const BODY_PREVIEW_CHARS = 500
+
+export async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+	let res: Response
+	try {
+		res = await fetch(url, init)
+	} catch (cause) {
+		throw new AdapterFetchError(url, null, null, null, { cause })
+	}
+	const contentType = res.headers.get('content-type')
+	const text = await res.text()
+	if (!res.ok) {
+		throw new AdapterFetchError(url, res.status, contentType, text.slice(0, BODY_PREVIEW_CHARS))
+	}
+	try {
+		return JSON.parse(text) as T
+	} catch (cause) {
+		throw new AdapterFetchError(url, res.status, contentType, text.slice(0, BODY_PREVIEW_CHARS), {
+			cause,
+		})
+	}
+}

--- a/src/lib/data/football-data.ts
+++ b/src/lib/data/football-data.ts
@@ -1,4 +1,5 @@
 import type { competition } from '@/lib/schema/competition'
+import { fetchJson } from './fetch-json'
 import type {
 	AdapterFixture,
 	AdapterFixtureScore,
@@ -69,10 +70,9 @@ export class FootballDataAdapter implements CompetitionAdapter {
 	) {}
 
 	private async request<T>(path: string): Promise<T> {
-		const res = await fetch(`${BASE_URL}${path}`, {
+		return fetchJson<T>(`${BASE_URL}${path}`, {
 			headers: { 'X-Auth-Token': this.apiKey },
 		})
-		return res.json() as Promise<T>
 	}
 
 	async fetchTeams(): Promise<AdapterTeam[]> {

--- a/src/lib/data/fpl.ts
+++ b/src/lib/data/fpl.ts
@@ -1,3 +1,4 @@
+import { fetchJson } from './fetch-json'
 import type {
 	AdapterFixture,
 	AdapterFixtureScore,
@@ -32,15 +33,13 @@ export class FplAdapter implements CompetitionAdapter {
 
 	private async getBootstrap(): Promise<FplBootstrap> {
 		if (this.bootstrapCache) return this.bootstrapCache
-		const res = await fetch(`${FPL_BASE}/bootstrap-static/`)
-		this.bootstrapCache = (await res.json()) as FplBootstrap
+		this.bootstrapCache = await fetchJson<FplBootstrap>(`${FPL_BASE}/bootstrap-static/`)
 		return this.bootstrapCache
 	}
 
 	private async getFixtures(): Promise<FplFixture[]> {
 		if (this.fixturesCache) return this.fixturesCache
-		const res = await fetch(`${FPL_BASE}/fixtures/`)
-		this.fixturesCache = (await res.json()) as FplFixture[]
+		this.fixturesCache = await fetchJson<FplFixture[]>(`${FPL_BASE}/fixtures/`)
 		return this.fixturesCache
 	}
 

--- a/src/lib/schema/index.ts
+++ b/src/lib/schema/index.ts
@@ -1,4 +1,5 @@
 export * from './auth'
 export * from './competition'
 export * from './game'
+export * from './ops'
 export * from './payment'

--- a/src/lib/schema/ops.ts
+++ b/src/lib/schema/ops.ts
@@ -1,0 +1,20 @@
+import { integer, pgTable, text, timestamp, uuid, varchar } from 'drizzle-orm/pg-core'
+
+// Operational tables — internal observability, not part of any game model.
+//
+// `cron_run` is appended-to by every scheduled route (daily-sync today;
+// poll-scores etc. can opt in later). One row per invocation captures the
+// outcome so we can answer "did the cron actually run?" without trawling
+// Vercel's transient runtime logs. Status is recorded after the handler
+// body finishes (success or failure path), so a catastrophic crash that
+// kills the function before the insert WILL leave no row — that's the
+// signal that something killed the runtime, not the handler logic.
+export const cronRun = pgTable('cron_run', {
+	id: uuid('id').primaryKey().defaultRandom(),
+	route: varchar('route', { length: 100 }).notNull(),
+	startedAt: timestamp('started_at').notNull(),
+	durationMs: integer('duration_ms').notNull(),
+	status: varchar('status', { length: 20 }).notNull(), // 'success' | 'failure'
+	error: text('error'),
+	createdAt: timestamp('created_at').defaultNow().notNull(),
+})


### PR DESCRIPTION
## Why

The daily-sync cron has been deployed since 2026-04-28 (24 days) but has never produced visible side-effects. Manual trigger today returned `HTTP 500` with an empty body and a runtime log of `SyntaxError: Unexpected end of JSON input at JSON.parse (<anonymous>)`. There's no breadcrumb to which adapter call returned the empty body, no record that the cron ever fired, and Vercel's runtime logs reset on every redeploy so "did it ever work?" can't be answered.

This PR doesn't try to fix the root cause yet — it makes the next failure self-describing and queryable, so the fix in the follow-up PR is informed by actual evidence rather than guessing.

## What

- **`fetchJson` helper + `AdapterFetchError`** (`src/lib/data/fetch-json.ts`) — every outbound adapter call goes through this. On failure the error carries `url`, `httpStatus`, `contentType`, and a 500-char `bodyPreview`. So when an upstream returns an empty body, the next 500 log will say exactly which URL and what came back, not just `JSON.parse (<anonymous>)`.
- **Adapters wired through the helper** — `FplAdapter.getBootstrap`, `FplAdapter.getFixtures`, and `FootballDataAdapter.request`. Happy path unchanged.
- **`/api/cron/daily-sync` wrapped in try/catch** — `console.error`s a structured payload (via the new `serializeError`), returns the same payload as a non-empty 500 response body, and inserts a row into the new `cron_run` table for every invocation.
- **`cron_run` table** (`src/lib/schema/ops.ts` + migration 0006) — `{route, started_at, duration_ms, status, error}`. Survives redeploys, so "did daily-sync run today?" is a one-row `SELECT`. This is the durable signal that's been missing.
- **`/api/cron/poll-scores` gets the same try/catch + serialized-500** — no `cron_run` insert there (runs every 60s during live windows, would flood the table).

## Test plan

- [x] `pnpm typecheck`
- [x] Full vitest suite — 415 passing
- [x] New `fetchJson` tests cover: parseable JSON, non-2xx, empty body, network rejection
- [x] New daily-sync tests cover: success path writes `status:'success'` to `cron_run`; failure path returns 500 with serialized error AND writes `status:'failure'` to `cron_run`
- [ ] After merge: `curl -X POST -H "Authorization: Bearer $CRON_SECRET" https://last-person-standing-theta.vercel.app/api/cron/daily-sync` — expect either a 200 with comp summaries (root cause was transient, daily-sync now works) or a 500 with a body like `{"error":{"name":"AdapterFetchError","message":"...","adapter":{"url":"...","httpStatus":...,"contentType":"...","bodyPreview":"..."}}}` (root cause is captured, next PR fixes it)
- [ ] `SELECT route, status, started_at, duration_ms, error FROM cron_run ORDER BY started_at DESC LIMIT 10;` should show the manual trigger row

## Follow-ups (not in this PR)

- Whatever the next failure log reveals — actual root cause of the JSON parse error.
- `refreshPastRounds(competitionId, fromRound, toRound)` helper so missed past-round data can be back-filled on demand, not just by waiting for daily-sync to succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)