### PR TITLE
fix(adapter): send browser-like UA to FPL so Cloudflare lets us in

### DIFF
--- a/src/lib/data/fpl.test.ts
+++ b/src/lib/data/fpl.test.ts
@@ -79,4 +79,18 @@ describe('FplAdapter', () => {
 		expect(rounds[0].fixtures[0].status).toBe('finished')
 		expect(rounds[1].fixtures[0].status).toBe('scheduled')
 	})
+
+	it('sends a browser-like User-Agent so Cloudflare does not 403 the request', async () => {
+		// Default Node fetch UA gets 403/empty body on Cloudflare-fronted FPL from
+		// cloud-provider IPs (root cause of the 24-day daily-sync outage —
+		// 2026-04-28 → 2026-05-22). Lock the workaround in with a test.
+		await adapter.fetchTeams()
+		const fetchMock = vi.mocked(globalThis.fetch)
+		expect(fetchMock).toHaveBeenCalled()
+		const [, init] = fetchMock.mock.calls[0]
+		const headers = (init as RequestInit | undefined)?.headers as Record<string, string>
+		expect(headers).toBeDefined()
+		expect(headers['User-Agent']).toMatch(/Mozilla\/5\.0/)
+		expect(headers.Accept).toContain('application/json')
+	})
 })

--- a/src/lib/data/fpl.ts
+++ b/src/lib/data/fpl.ts
@@ -9,6 +9,19 @@ import type {
 
 const FPL_BASE = 'https://fantasy.premierleague.com/api'
 
+// FPL is fronted by Cloudflare, which 403s the default Node fetch UA from
+// cloud-provider egress IPs (observed via the cron_run audit trail on
+// 2026-05-22: 24 days of daily-sync silently failing with status=403,
+// body=""). A realistic browser UA + Accept headers gets us through —
+// every other FPL API client in the wild does the same. Not abusive: this
+// is one request per FPL endpoint per daily-sync run.
+const FPL_HEADERS: Record<string, string> = {
+	'User-Agent':
+		'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+	Accept: 'application/json, text/plain, */*',
+	'Accept-Language': 'en-GB,en;q=0.9',
+}
+
 interface FplBootstrap {
 	teams: Array<{ id: number; name: string; short_name: string; code: number }>
 	events: Array<{ id: number; name: string; deadline_time: string; finished: boolean }>
@@ -33,13 +46,17 @@ export class FplAdapter implements CompetitionAdapter {
 
 	private async getBootstrap(): Promise<FplBootstrap> {
 		if (this.bootstrapCache) return this.bootstrapCache
-		this.bootstrapCache = await fetchJson<FplBootstrap>(`${FPL_BASE}/bootstrap-static/`)
+		this.bootstrapCache = await fetchJson<FplBootstrap>(`${FPL_BASE}/bootstrap-static/`, {
+			headers: FPL_HEADERS,
+		})
 		return this.bootstrapCache
 	}
 
 	private async getFixtures(): Promise<FplFixture[]> {
 		if (this.fixturesCache) return this.fixturesCache
-		this.fixturesCache = await fetchJson<FplFixture[]>(`${FPL_BASE}/fixtures/`)
+		this.fixturesCache = await fetchJson<FplFixture[]>(`${FPL_BASE}/fixtures/`, {
+			headers: FPL_HEADERS,
+		})
 		return this.fixturesCache
 	}
 


### PR DESCRIPTION
## Root cause (confirmed via PR #50's audit trail)

`cron_run` row from the manual daily-sync trigger at 2026-05-22 14:26:59Z:

\`\`\`
route:       /api/cron/daily-sync
status:      failure
duration_ms: 124
error:       AdapterFetch https://fantasy.premierleague.com/api/bootstrap-static/ status=403 body=""
\`\`\`

FPL is fronted by Cloudflare. The default Node fetch UA (`User-Agent: node`) gets 403/empty-body from cloud-provider egress IPs — Cloudflare's bot heuristics reject anonymous-looking traffic from AWS/GCP/etc. Local curl from a residential IP gets 200, which is why this hid for 24 days while the cron silently 500'd every 04:00 UTC.

## The fix

Send a realistic Chrome User-Agent + `Accept`/`Accept-Language` headers on the two FPL endpoints (`bootstrap-static/`, `fixtures/`). Standard workaround for the FPL public API — every wild-side FPL client does this. One request per endpoint per daily-sync run, not abusive.

football-data adapter is unaffected (it already sends `X-Auth-Token` which Cloudflare uses as the auth signal).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test src/lib/data/fpl.test.ts` — new test asserts the UA + Accept header is actually sent
- [x] Full vitest suite green
- [ ] After merge + deploy + migration: re-trigger `/api/cron/daily-sync` manually. Expected: `HTTP 200` with comp summaries, and a new `cron_run` row with `status='success'`. GW37 fixture statuses then back-fill on first run.
- [ ] If still 403: Cloudflare has tightened beyond just UA — fall back to plan (3) from PR #50 (drop FPL for PL, use football-data only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)