### PR TITLE
chore: temporary proof workflow for GH→FPL access

### DIFF
--- a/.github/workflows/fpl-proof.yml
+++ b/.github/workflows/fpl-proof.yml
@@ -1,0 +1,29 @@
+name: FPL access proof (temporary)
+
+# One-shot proof that GitHub Actions runners can reach FPL's API where
+# Vercel egress IPs cannot. Delete the workflow once we've seen the result.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - name: GET bootstrap-static (no UA tweak)
+        run: |
+          curl -sS -o /tmp/bootstrap.json \
+            -w "HTTP %{http_code} bytes %{size_download} time %{time_total}s\n" \
+            "https://fantasy.premierleague.com/api/bootstrap-static/"
+          echo "--- first 300 chars of body ---"
+          head -c 300 /tmp/bootstrap.json
+          echo
+          echo "--- jq sanity check ---"
+          jq '.events | length' /tmp/bootstrap.json
+      - name: GET fixtures (no UA tweak)
+        run: |
+          curl -sS -o /tmp/fixtures.json \
+            -w "HTTP %{http_code} bytes %{size_download} time %{time_total}s\n" \
+            "https://fantasy.premierleague.com/api/fixtures/"
+          echo "--- count ---"
+          jq 'length' /tmp/fixtures.json


### PR DESCRIPTION
One-shot workflow_dispatch that curls FPL's bootstrap-static + fixtures from a GH Actions runner. Validates the assumption that GH egress IPs aren't blocked by FPL's Cloudflare rules (Vercel egress IPs are — see PR #50 cron_run audit log).

Will be removed in the follow-up PR that wires the real GH-Actions-driven daily sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)