### PR TITLE
fix(daily-sync): jq -c so the FPL payload fits Vercel's 4.5MB limit

### DIFF
--- a/.github/workflows/daily-sync.yml
+++ b/.github/workflows/daily-sync.yml
@@ -29,7 +29,10 @@ jobs:
           set -euo pipefail
           curl -sSf -o /tmp/bootstrap.json https://fantasy.premierleague.com/api/bootstrap-static/
           curl -sSf -o /tmp/fixtures.json https://fantasy.premierleague.com/api/fixtures/
-          jq -n \
+          # -c (compact output) keeps the payload near the FPL response sizes
+          # (~3MB combined) instead of jq's default pretty-print, which doubled
+          # the size to ~6MB and exceeded Vercel's 4.5MB function body limit.
+          jq -cn \
             --slurpfile b /tmp/bootstrap.json \
             --slurpfile f /tmp/fixtures.json \
             '{fpl: {bootstrap: $b[0], fixtures: $f[0]}}' \


### PR DESCRIPTION
First dispatch of the new workflow (run 26302164682) failed with HTTP 413 / `FUNCTION_PAYLOAD_TOO_LARGE`. jq's default output is pretty-printed:

\`\`\`
payload bytes: 6139841   ← jq default
\`\`\`

vs Vercel's 4.5MB function body limit. FPL's API returns already-minified JSON (bootstrap is 2MB, fixtures 1MB), so the extra ~3MB was pure indentation. Adding \`-c\` to jq restores compact output and the payload drops back to ~3MB.

## Test plan

- [ ] After merge: re-dispatch \`daily-sync.yml\`. Workflow log should show `payload bytes:` near 3MB, then `HTTP 200` from Vercel.
- [ ] `cron_run` row appears with `status='success'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)