### PR TITLE
fix(game-detail): reveal picks at deadline, keep standings + winner banner post-completion

### DIFF
--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -20,7 +20,12 @@
 import { eq } from 'drizzle-orm'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 import { db } from '@/lib/db'
-import { getLivePayload } from '@/lib/game/detail-queries'
+import { getCupLadderData, getCupStandingsData } from '@/lib/game/cup-standings-queries'
+import {
+	getLivePayload,
+	getProgressGridData,
+	getTurboStandingsData,
+} from '@/lib/game/detail-queries'
 import { settleFixture } from '@/lib/game/settle'
 import { round as roundTable } from '@/lib/schema/competition'
 import { game, gamePlayer, pick } from '@/lib/schema/game'
@@ -527,5 +532,373 @@ describe('live projection', () => {
 		const payload = await getLivePayload(gameId, 'u')
 		const projected = payload?.players.find((p) => p.id === gp)?.projectedStreak
 		expect(projected).toBe(2)
+	})
+})
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Post-deadline + post-completion visibility                              */
+/*                                                                         */
+/* Regression coverage for: picks staying locked behind the lock icon      */
+/* AFTER the deadline (because the competition round's status flag only    */
+/* flips to 'completed' once every fixture has settled — sometimes 2+ days */
+/* later); and standings/ladder vanishing the moment a game completes      */
+/* (because applyAutoCompletion nulls out currentRoundId for every mode).  */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe('post-deadline + post-completion visibility', () => {
+	it("classic: progress grid reveals other players' picks once deadline passes", async () => {
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const a = await makeTeam({ name: 'A', shortName: 'A' })
+		const b = await makeTeam({ name: 'B', shortName: 'B' })
+		// Round is 'open' at the competition level (one fixture pending) but deadline has passed.
+		const r2 = await makeRound(compId, {
+			number: 2,
+			status: 'open',
+			deadline: new Date(Date.now() - 60_000),
+		})
+		await makeRound(compId, {
+			number: 3,
+			status: 'upcoming',
+			deadline: new Date(Date.now() + 86_400_000),
+		})
+		const fx = await makeFixture({ roundId: r2, homeTeamId: a, awayTeamId: b })
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r2,
+			modeConfig: { allowRebuys: false },
+		})
+		const gpMe = await makePlayer({ gameId, userId: 'u-me' })
+		const gpOther = await makePlayer({ gameId, userId: 'u-other' })
+		await makePick({ gameId, gamePlayerId: gpMe, roundId: r2, teamId: a, fixtureId: fx })
+		await makePick({ gameId, gamePlayerId: gpOther, roundId: r2, teamId: b, fixtureId: fx })
+		// NB: fixture is still pending; nothing has settled. This is exactly the
+		// post-deadline-but-pre-final-whistle window where the original bug bit.
+
+		const grid = await getProgressGridData(gameId, 'u-me')
+		const otherRow = grid?.players.find((p) => p.id === gpOther)
+		expect(otherRow?.cellsByRoundId[r2]?.result).not.toBe('locked')
+	})
+
+	it('turbo: standings keep showing the round + reveal picks once deadline passes', async () => {
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const teams: string[] = []
+		for (let i = 0; i < 4; i++) {
+			teams.push(await makeTeam({ name: `T${i}`, shortName: `T${i}` }))
+		}
+		const r1 = await makeRound(compId, {
+			number: 1,
+			status: 'open',
+			deadline: new Date(Date.now() - 60_000),
+		})
+		const fx1 = await makeFixture({ roundId: r1, homeTeamId: teams[0], awayTeamId: teams[1] })
+		const fx2 = await makeFixture({ roundId: r1, homeTeamId: teams[2], awayTeamId: teams[3] })
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'turbo',
+			currentRoundId: r1,
+			modeConfig: { numberOfPicks: 2 },
+		})
+		const gpMe = await makePlayer({ gameId, userId: 'u-me' })
+		const gpOther = await makePlayer({ gameId, userId: 'u-other' })
+		await makePick({
+			gameId,
+			gamePlayerId: gpMe,
+			roundId: r1,
+			teamId: teams[0],
+			fixtureId: fx1,
+			confidenceRank: 1,
+			predictedResult: 'home_win',
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpOther,
+			roundId: r1,
+			teamId: teams[2],
+			fixtureId: fx2,
+			confidenceRank: 1,
+			predictedResult: 'home_win',
+		})
+
+		const standings = await getTurboStandingsData(gameId, 'u-me')
+		expect(standings?.rounds.length).toBe(1)
+		const others = standings?.rounds[0].players.find((p) => p.id === gpOther)
+		expect(others?.picks.every((c) => c.result !== 'hidden')).toBe(true)
+	})
+
+	it('turbo: standings survive game completion (currentRoundId null)', async () => {
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const a = await makeTeam({ name: 'A', shortName: 'A' })
+		const b = await makeTeam({ name: 'B', shortName: 'B' })
+		const r1 = await makeRound(compId, { number: 1, status: 'open' })
+		const fx = await makeFixture({ roundId: r1, homeTeamId: a, awayTeamId: b })
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'turbo',
+			currentRoundId: r1,
+			modeConfig: { numberOfPicks: 1 },
+		})
+		const gp = await makePlayer({ gameId, userId: 'u' })
+		await makePick({
+			gameId,
+			gamePlayerId: gp,
+			roundId: r1,
+			teamId: a,
+			fixtureId: fx,
+			confidenceRank: 1,
+			predictedResult: 'home_win',
+		})
+
+		// Finish the single fixture — turbo auto-completes, currentRoundId is nulled.
+		await finishFixture(fx, 1, 0)
+		await settleFixture(fx)
+		const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+		expect(g?.status).toBe('completed')
+		expect(g?.currentRoundId).toBeNull()
+
+		// Standings query must still return the round/players/picks for the UI
+		// to render the post-game grid + winner banner.
+		const standings = await getTurboStandingsData(gameId, 'u')
+		expect(standings?.rounds.length).toBe(1)
+		expect(standings?.rounds[0].players[0].picks.length).toBe(1)
+		expect(standings?.rounds[0].status).toBe('completed')
+	})
+
+	it('cup: standings ladder survives game completion (falls back to last picked round)', async () => {
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		const a = await makeTeam({ name: 'A', shortName: 'A', fifaPot: 2 })
+		const b = await makeTeam({ name: 'B', shortName: 'B', fifaPot: 2 })
+		const r1 = await makeRound(compId, { number: 1, status: 'open' })
+		await makeRound(compId, {
+			number: 2,
+			status: 'upcoming',
+			deadline: new Date(Date.now() + 86_400_000),
+		})
+		const fx = await makeFixture({ roundId: r1, homeTeamId: a, awayTeamId: b })
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'cup',
+			currentRoundId: r1,
+			modeConfig: { numberOfPicks: 1, startingLives: 0 },
+		})
+		// 2 players — one wins on the only fixture, the other loses → alive=1 → auto-completion.
+		const gpWin = await makePlayer({ gameId, userId: 'u-win', livesRemaining: 0 })
+		const gpLose = await makePlayer({ gameId, userId: 'u-lose', livesRemaining: 0 })
+		await makePick({
+			gameId,
+			gamePlayerId: gpWin,
+			roundId: r1,
+			teamId: a,
+			fixtureId: fx,
+			confidenceRank: 1,
+			predictedResult: 'home_win',
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpLose,
+			roundId: r1,
+			teamId: b,
+			fixtureId: fx,
+			confidenceRank: 1,
+			predictedResult: 'away_win',
+		})
+
+		await finishFixture(fx, 1, 0)
+		await settleFixture(fx)
+		const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+		expect(g?.status).toBe('completed')
+		expect(g?.currentRoundId).toBeNull()
+
+		// Without the displayRound fallback, getCupStandingsData would return null
+		// here and the WC ladder would vanish the moment the trophy is decided.
+		const cup = await getCupStandingsData(gameId, 'u-win')
+		expect(cup).not.toBeNull()
+		expect(cup?.roundId).toBe(r1)
+		expect(cup?.roundStatus).toBe('completed')
+		expect(cup?.players.length).toBe(2)
+	})
+
+	it('cup: getCupLadderData (the function the page actually calls) survives game completion', async () => {
+		// Regression guard for the ladder-side fixturesRaw fallback added alongside
+		// the displayRound fix. If that path is broken, the cup page renders the
+		// banner + empty standings — same UX failure as the original bug.
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		const a = await makeTeam({ name: 'A', shortName: 'A', fifaPot: 2 })
+		const b = await makeTeam({ name: 'B', shortName: 'B', fifaPot: 2 })
+		const r1 = await makeRound(compId, { number: 1, status: 'open' })
+		await makeRound(compId, {
+			number: 2,
+			status: 'upcoming',
+			deadline: new Date(Date.now() + 86_400_000),
+		})
+		const fx = await makeFixture({ roundId: r1, homeTeamId: a, awayTeamId: b })
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'cup',
+			currentRoundId: r1,
+			modeConfig: { numberOfPicks: 1, startingLives: 0 },
+		})
+		const gpWin = await makePlayer({ gameId, userId: 'u-win', livesRemaining: 0 })
+		const gpLose = await makePlayer({ gameId, userId: 'u-lose', livesRemaining: 0 })
+		await makePick({
+			gameId,
+			gamePlayerId: gpWin,
+			roundId: r1,
+			teamId: a,
+			fixtureId: fx,
+			confidenceRank: 1,
+			predictedResult: 'home_win',
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpLose,
+			roundId: r1,
+			teamId: b,
+			fixtureId: fx,
+			confidenceRank: 1,
+			predictedResult: 'away_win',
+		})
+
+		await finishFixture(fx, 1, 0)
+		await settleFixture(fx)
+		const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+		expect(g?.status).toBe('completed')
+		expect(g?.currentRoundId).toBeNull()
+
+		const ladder = await getCupLadderData(gameId, 'u-win')
+		expect(ladder).not.toBeNull()
+		expect(ladder?.roundId).toBe(r1)
+		expect(ladder?.fixtures.length).toBe(1)
+		expect(ladder?.fixtures[0].id).toBe(fx)
+		expect(ladder?.players.length).toBe(2)
+	})
+
+	it('classic: progress grid hides other players picks BEFORE the deadline', async () => {
+		// Regression guard for the opposite of the deadline-reveal fix: when the
+		// deadline is still in the future, other players' picks must show as
+		// 'locked', not their team name.
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const a = await makeTeam({ name: 'A', shortName: 'A' })
+		const b = await makeTeam({ name: 'B', shortName: 'B' })
+		const r2 = await makeRound(compId, {
+			number: 2,
+			status: 'open',
+			deadline: new Date(Date.now() + 86_400_000),
+		})
+		await makeRound(compId, {
+			number: 3,
+			status: 'upcoming',
+			deadline: new Date(Date.now() + 172_800_000),
+		})
+		const fx = await makeFixture({ roundId: r2, homeTeamId: a, awayTeamId: b })
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r2,
+			modeConfig: { allowRebuys: false },
+		})
+		const gpMe = await makePlayer({ gameId, userId: 'u-me' })
+		const gpOther = await makePlayer({ gameId, userId: 'u-other' })
+		await makePick({ gameId, gamePlayerId: gpMe, roundId: r2, teamId: a, fixtureId: fx })
+		await makePick({ gameId, gamePlayerId: gpOther, roundId: r2, teamId: b, fixtureId: fx })
+
+		const grid = await getProgressGridData(gameId, 'u-me')
+		const myRow = grid?.players.find((p) => p.id === gpMe)
+		const otherRow = grid?.players.find((p) => p.id === gpOther)
+		// My own pick stays visible; the other player's pick is locked behind the icon.
+		expect(myRow?.cellsByRoundId[r2]?.result).not.toBe('locked')
+		expect(otherRow?.cellsByRoundId[r2]?.result).toBe('locked')
+	})
+
+	it('turbo: standings hide other players picks BEFORE the deadline', async () => {
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const teams: string[] = []
+		for (let i = 0; i < 4; i++) {
+			teams.push(await makeTeam({ name: `T${i}`, shortName: `T${i}` }))
+		}
+		const r1 = await makeRound(compId, {
+			number: 1,
+			status: 'open',
+			deadline: new Date(Date.now() + 86_400_000),
+		})
+		const fx1 = await makeFixture({ roundId: r1, homeTeamId: teams[0], awayTeamId: teams[1] })
+		const fx2 = await makeFixture({ roundId: r1, homeTeamId: teams[2], awayTeamId: teams[3] })
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'turbo',
+			currentRoundId: r1,
+			modeConfig: { numberOfPicks: 2 },
+		})
+		const gpMe = await makePlayer({ gameId, userId: 'u-me' })
+		const gpOther = await makePlayer({ gameId, userId: 'u-other' })
+		await makePick({
+			gameId,
+			gamePlayerId: gpMe,
+			roundId: r1,
+			teamId: teams[0],
+			fixtureId: fx1,
+			confidenceRank: 1,
+			predictedResult: 'home_win',
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpOther,
+			roundId: r1,
+			teamId: teams[2],
+			fixtureId: fx2,
+			confidenceRank: 1,
+			predictedResult: 'home_win',
+		})
+
+		const standings = await getTurboStandingsData(gameId, 'u-me')
+		const me = standings?.rounds[0].players.find((p) => p.id === gpMe)
+		const others = standings?.rounds[0].players.find((p) => p.id === gpOther)
+		// My picks remain visible (not hidden); other player's are hidden.
+		expect(me?.picks.every((c) => c.result !== 'hidden')).toBe(true)
+		expect(others?.picks.every((c) => c.result === 'hidden')).toBe(true)
+	})
+
+	it('cup: standings hide other players picks BEFORE the deadline', async () => {
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		const a = await makeTeam({ name: 'A', shortName: 'A', fifaPot: 2 })
+		const b = await makeTeam({ name: 'B', shortName: 'B', fifaPot: 2 })
+		const r1 = await makeRound(compId, {
+			number: 1,
+			status: 'open',
+			deadline: new Date(Date.now() + 86_400_000),
+		})
+		const fx = await makeFixture({ roundId: r1, homeTeamId: a, awayTeamId: b })
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'cup',
+			currentRoundId: r1,
+			modeConfig: { numberOfPicks: 1, startingLives: 3 },
+		})
+		const gpMe = await makePlayer({ gameId, userId: 'u-me', livesRemaining: 3 })
+		const gpOther = await makePlayer({ gameId, userId: 'u-other', livesRemaining: 3 })
+		await makePick({
+			gameId,
+			gamePlayerId: gpMe,
+			roundId: r1,
+			teamId: a,
+			fixtureId: fx,
+			confidenceRank: 1,
+			predictedResult: 'home_win',
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpOther,
+			roundId: r1,
+			teamId: b,
+			fixtureId: fx,
+			confidenceRank: 1,
+			predictedResult: 'away_win',
+		})
+
+		const cup = await getCupStandingsData(gameId, 'u-me')
+		const me = cup?.players.find((p) => p.id === gpMe)
+		const others = cup?.players.find((p) => p.id === gpOther)
+		expect(me?.picks.every((c) => c.result !== 'hidden')).toBe(true)
+		expect(others?.picks.every((c) => c.result === 'hidden')).toBe(true)
 	})
 })

--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -1,8 +1,10 @@
 import { and, eq } from 'drizzle-orm'
+import { Flame, Heart, ListChecks, Target } from 'lucide-react'
 import { notFound, redirect } from 'next/navigation'
 import { ActingAsBanner } from '@/components/game/acting-as-banner'
 import { GameDetailView } from '@/components/game/game-detail-view'
 import { RebuyBanner } from '@/components/game/rebuy-banner'
+import type { WinnerBannerEntry } from '@/components/game/winner-banner'
 import { ClassicPick } from '@/components/picks/classic-pick'
 import type { CupPickFixture, CupPickSlot } from '@/components/picks/cup-pick'
 import { CupPickForm } from '@/components/picks/cup-pick-form'
@@ -21,6 +23,7 @@ import {
 import { reconcileGameState } from '@/lib/game/reconcile'
 import { roundLabel, roundLabelLong } from '@/lib/game/round-label'
 import { computeTierDifference } from '@/lib/game-logic/cup-tier'
+import { calculatePayouts } from '@/lib/game-logic/prizes'
 import { user } from '@/lib/schema/auth'
 import { gamePlayer } from '@/lib/schema/game'
 
@@ -131,6 +134,81 @@ export default async function GameDetailPage({
 		game.gameMode === 'turbo' ? await getTurboStandingsData(game.id, session.user.id) : null
 	const cupStandingsData =
 		game.gameMode === 'cup' ? await getCupLadderData(game.id, session.user.id) : null
+
+	// Winner banner: rendered above standings on completed games. Splits + tied
+	// finishes (multiple players with status='winner') get a "split pot" header
+	// and the per-winner pot share comes from calculatePayouts so the maths
+	// matches the share card. Per-mode stats are filled in below.
+	const winnerBanner: { winners: WinnerBannerEntry[]; runnerUpName?: string } | null = (() => {
+		if (game.status !== 'completed') return null
+		const winnerPlayers = game.players.filter((p) => p.status === 'winner')
+		if (winnerPlayers.length === 0) return null
+		const payouts = calculatePayouts(
+			game.pot.total,
+			winnerPlayers.map((p) => p.userId),
+		)
+		const potShareFor = (userId: string) =>
+			payouts.find((po) => po.userId === userId)?.amount ?? '0.00'
+
+		if (game.gameMode === 'turbo' && turboStandingsData && turboStandingsData.rounds.length > 0) {
+			const lastRound = turboStandingsData.rounds[turboStandingsData.rounds.length - 1]
+			const winners: WinnerBannerEntry[] = winnerPlayers.map((p) => {
+				const tp = lastRound.players.find((x) => x.id === p.id)
+				return {
+					userId: p.userId,
+					name: tp?.name ?? 'Player',
+					potShare: potShareFor(p.userId),
+					stats: [
+						{ icon: Flame, value: tp?.streak ?? 0, label: 'streak' },
+						{ icon: Target, value: tp?.goals ?? 0, label: 'goals' },
+					],
+				}
+			})
+			const winnerIds = new Set(winnerPlayers.map((p) => p.id))
+			const runnerUp = [...lastRound.players]
+				.filter((tp) => !winnerIds.has(tp.id))
+				.sort((a, b) => b.streak - a.streak || b.goals - a.goals)[0]
+			return { winners, runnerUpName: runnerUp?.name }
+		}
+
+		if (game.gameMode === 'cup' && cupStandingsData) {
+			const winners: WinnerBannerEntry[] = winnerPlayers.map((p) => {
+				const cp = cupStandingsData.players.find((x) => x.id === p.id)
+				return {
+					userId: p.userId,
+					name: cp?.name ?? 'Player',
+					potShare: potShareFor(p.userId),
+					stats: [
+						{ icon: Heart, value: cp?.livesRemaining ?? 0, label: 'lives' },
+						{ icon: Flame, value: cp?.streak ?? 0, label: 'streak' },
+						{ icon: Target, value: cp?.goals ?? 0, label: 'goals' },
+					],
+				}
+			})
+			const winnerIds = new Set(winnerPlayers.map((p) => p.id))
+			const others = [...cupStandingsData.players]
+				.filter((cp) => !winnerIds.has(cp.id))
+				.sort(
+					(a, b) => b.livesRemaining - a.livesRemaining || b.streak - a.streak || b.goals - a.goals,
+				)
+			return { winners, runnerUpName: others[0]?.name }
+		}
+
+		if (game.gameMode === 'classic') {
+			// Classic doesn't carry per-player streak/goals; surface rounds-survived
+			// (the highest round number in the grid) so the banner has a stat.
+			const roundsPlayed = classicGrid?.rounds.length ?? 0
+			const winners: WinnerBannerEntry[] = winnerPlayers.map((p) => ({
+				userId: p.userId,
+				name: classicGrid?.players.find((x) => x.id === p.id)?.name ?? 'Player',
+				potShare: potShareFor(p.userId),
+				stats: [{ icon: ListChecks, value: roundsPlayed || '—', label: 'rounds' }],
+			}))
+			return { winners }
+		}
+
+		return null
+	})()
 
 	// Alive check is on the TARGET player (acting-as) or the viewer's own membership.
 	const targetPlayerStatus = actingAsTarget
@@ -322,6 +400,7 @@ export default async function GameDetailPage({
 			turboStandings={
 				turboStandingsData ? { rounds: turboStandingsData.rounds, numberOfPicks } : null
 			}
+			winnerBanner={winnerBanner}
 			cupStandings={cupStandingsData}
 		/>
 	)

--- a/src/components/game/game-detail-view.tsx
+++ b/src/components/game/game-detail-view.tsx
@@ -11,6 +11,7 @@ import type { PaymentStatus } from '@/components/game/payment-status-chip'
 import { type AdminPayment, PaymentsPanel } from '@/components/game/payments-panel'
 import { ShareDialog } from '@/components/game/share-dialog'
 import { VoidedPickBanner } from '@/components/game/voided-pick-banner'
+import { WinnerBanner, type WinnerBannerEntry } from '@/components/game/winner-banner'
 import { LiveProvider } from '@/components/live/live-provider'
 import { LiveScoreTicker } from '@/components/live/live-score-ticker'
 import { CupStandings } from '@/components/standings/cup-standings'
@@ -61,6 +62,10 @@ interface GameDetailViewProps {
 		rounds: TurboRoundSummary[]
 		numberOfPicks: number
 	} | null
+	winnerBanner?: {
+		winners: WinnerBannerEntry[]
+		runnerUpName?: string
+	} | null
 	cupStandings?: CupLadderData | null
 }
 
@@ -69,6 +74,7 @@ export function GameDetailView({
 	pickSection,
 	classicGrid,
 	turboStandings,
+	winnerBanner,
 	cupStandings,
 }: GameDetailViewProps) {
 	const [shareOpen, setShareOpen] = useState(false)
@@ -131,6 +137,10 @@ export function GameDetailView({
 				)}
 
 				<div className="mb-6">{pickSection}</div>
+
+				{winnerBanner && winnerBanner.winners.length > 0 && (
+					<WinnerBanner winners={winnerBanner.winners} runnerUpName={winnerBanner.runnerUpName} />
+				)}
 
 				{classicGrid && (
 					<ProgressGrid

--- a/src/components/game/winner-banner.tsx
+++ b/src/components/game/winner-banner.tsx
@@ -1,0 +1,79 @@
+import type { LucideIcon } from 'lucide-react'
+
+export interface WinnerStat {
+	icon: LucideIcon
+	value: number | string
+	label: string
+}
+
+export interface WinnerBannerEntry {
+	userId: string
+	name: string
+	potShare: string
+	stats: WinnerStat[]
+}
+
+interface WinnerBannerProps {
+	winners: WinnerBannerEntry[]
+	runnerUpName?: string
+}
+
+export function WinnerBanner({ winners, runnerUpName }: WinnerBannerProps) {
+	if (winners.length === 0) return null
+	const isSplit = winners.length > 1
+
+	return (
+		<div className="mb-6 overflow-hidden rounded-xl border border-amber-300 bg-gradient-to-br from-amber-50 via-amber-50 to-yellow-100 shadow-sm">
+			<div className="flex items-center gap-2 border-b border-amber-200 bg-amber-100/60 px-5 py-3">
+				<span className="text-xl" aria-hidden>
+					🏆
+				</span>
+				<span className="font-display text-xs font-bold uppercase tracking-wider text-amber-900">
+					{isSplit ? `Split pot · ${winners.length} way` : 'Winner'}
+				</span>
+				<span className="ml-auto text-[10px] font-semibold uppercase tracking-wider text-amber-700">
+					Game complete
+				</span>
+			</div>
+			<ul className="divide-y divide-amber-200/70">
+				{winners.map((w, idx) => (
+					<li key={w.userId} className="flex items-center gap-4 px-5 py-4">
+						<span className="text-2xl shrink-0" aria-hidden>
+							🥇
+						</span>
+						<div className="min-w-0 flex-1">
+							<div className="font-display text-xl font-bold text-amber-950 truncate">{w.name}</div>
+							{w.stats.length > 0 && (
+								<div className="mt-0.5 flex items-center gap-3 text-xs text-amber-800">
+									{w.stats.map((s) => {
+										const Icon = s.icon
+										return (
+											<span key={s.label} className="inline-flex items-center gap-1">
+												<Icon className="h-3 w-3" />
+												<span className="font-semibold">{s.value}</span>
+												<span className="text-amber-700/80">{s.label}</span>
+											</span>
+										)
+									})}
+								</div>
+							)}
+						</div>
+						<div className="text-right shrink-0">
+							<div className="font-display text-2xl font-bold leading-none text-amber-900">
+								£{w.potShare}
+							</div>
+							<div className="mt-1 text-[10px] font-semibold uppercase tracking-wider text-amber-700">
+								{isSplit ? 'share' : idx === 0 ? 'won' : ''}
+							</div>
+						</div>
+					</li>
+				))}
+			</ul>
+			{runnerUpName && (
+				<div className="border-t border-amber-200 bg-amber-50/80 px-5 py-2 text-[11px] text-amber-800">
+					Runner-up: <span className="font-semibold text-amber-900">{runnerUpName}</span>
+				</div>
+			)}
+		</div>
+	)
+}

--- a/src/lib/game/cup-standings-queries.test.ts
+++ b/src/lib/game/cup-standings-queries.test.ts
@@ -16,7 +16,7 @@ vi.mock('@/lib/db', () => ({
 	},
 }))
 
-const { findFirstMock } = mocks
+const { findFirstMock, findManyMock, selectMock } = mocks
 
 import {
 	type CupLadderBacker,
@@ -36,15 +36,54 @@ describe('getCupStandingsData', () => {
 		expect(await getCupStandingsData('g1', 'u1')).toBeNull()
 	})
 
-	it('returns null when there is no current round', async () => {
+	it('returns null when there is no current round AND no picks (game has no past rounds to fall back to)', async () => {
 		findFirstMock.mockResolvedValue({
 			id: 'g',
+			currentRoundId: null,
 			currentRound: null,
 			players: [],
-			competition: { type: 'group_knockout' },
+			competition: { type: 'group_knockout', rounds: [] },
 			modeConfig: {},
 		})
+		findManyMock.mockResolvedValue([])
 		expect(await getCupStandingsData('g1', 'u1')).toBeNull()
+	})
+
+	it('falls back to the latest round with picks when game has completed (currentRound is null)', async () => {
+		// Game completed: applyAutoCompletion has set currentRoundId=null. The ladder
+		// should still render, showing the round where the trophy was decided.
+		const r1 = {
+			id: 'r1',
+			number: 1,
+			status: 'completed' as const,
+			deadline: new Date('2026-05-01T12:00:00Z'),
+			fixtures: [],
+		}
+		const r2 = {
+			id: 'r2',
+			number: 2,
+			status: 'completed' as const,
+			deadline: new Date('2026-05-08T12:00:00Z'),
+			fixtures: [],
+		}
+		findFirstMock.mockResolvedValue({
+			id: 'g',
+			currentRoundId: null,
+			currentRound: null,
+			players: [],
+			competition: { type: 'group_knockout', rounds: [r1, r2] },
+			modeConfig: {},
+		})
+		// First findMany call: picks-by-game (round resolution). Second: picks-for-display-round.
+		findManyMock.mockResolvedValueOnce([{ roundId: 'r2' }]).mockResolvedValueOnce([])
+		// Mock the user-name lookup (db.select(...).from(...).where(...))
+		selectMock.mockReturnValue({
+			from: () => ({ where: () => Promise.resolve([]) }),
+		})
+		const result = await getCupStandingsData('g1', 'u1')
+		expect(result).not.toBeNull()
+		expect(result?.roundId).toBe('r2')
+		expect(result?.roundStatus).toBe('completed')
 	})
 })
 

--- a/src/lib/game/cup-standings-queries.ts
+++ b/src/lib/game/cup-standings-queries.ts
@@ -82,7 +82,18 @@ export async function getCupStandingsData(
 	const g = await db.query.game.findFirst({
 		where: (t, { eq: eqOp }) => eqOp(t.id, gameId),
 		with: {
-			competition: true,
+			competition: {
+				with: {
+					rounds: {
+						with: {
+							fixtures: {
+								with: { homeTeam: true, awayTeam: true },
+								orderBy: (fx, { asc }) => asc(fx.kickoff),
+							},
+						},
+					},
+				},
+			},
 			currentRound: {
 				with: {
 					fixtures: {
@@ -94,10 +105,27 @@ export async function getCupStandingsData(
 			players: true,
 		},
 	})
-	if (!g?.currentRound) return null
+	if (!g) return null
+
+	// Game-completed safety net: `applyAutoCompletion` nulls out currentRoundId
+	// when a cup game finishes, so without a fallback the ladder vanishes the
+	// moment the trophy is decided. Fall back to the latest round with picks
+	// (the round where the championship was won).
+	let displayRound = g.currentRound
+	if (!displayRound) {
+		const picksByRound = await db.query.pick.findMany({
+			where: eq(pick.gameId, gameId),
+		})
+		const pickRoundIds = new Set(picksByRound.map((p) => p.roundId))
+		const candidateRounds = g.competition.rounds
+			.filter((r) => pickRoundIds.has(r.id))
+			.sort((a, b) => b.number - a.number)
+		displayRound = candidateRounds[0] ?? null
+	}
+	if (!displayRound) return null
 
 	const allPicks = await db.query.pick.findMany({
-		where: and(eq(pick.gameId, gameId), eq(pick.roundId, g.currentRound.id)),
+		where: and(eq(pick.gameId, gameId), eq(pick.roundId, displayRound.id)),
 	})
 
 	// User-name lookup — mirror the pattern in getTurboStandingsData.
@@ -121,14 +149,13 @@ export async function getCupStandingsData(
 	// still be in 'active' state until processGameRound completes.
 	const now = new Date()
 	const hideOpenPicks =
-		g.currentRound.status !== 'completed' &&
-		(!g.currentRound.deadline || now < g.currentRound.deadline)
+		displayRound.status !== 'completed' && (!displayRound.deadline || now < displayRound.deadline)
 
 	const players: CupStandingsPlayer[] = g.players.map((p) => {
 		const isViewer = p.userId === viewerUserId
 		const myPicks = allPicks.filter((pk) => pk.gamePlayerId === p.id)
 		const picks: CupStandingsPick[] = myPicks.map((pk) => {
-			const fx = g.currentRound?.fixtures.find((f) => f.id === pk.fixtureId)
+			const fx = displayRound.fixtures.find((f) => f.id === pk.fixtureId)
 			if (!fx) {
 				// Shouldn't happen — pick referencing a fixture not in the round — but
 				// be defensive rather than throwing at the query layer.
@@ -194,18 +221,24 @@ export async function getCupStandingsData(
 
 	return {
 		gameId: g.id,
-		roundId: g.currentRound.id,
-		roundNumber: g.currentRound.number,
-		roundLabel: roundLabel(competitionType, g.currentRound.number),
+		roundId: displayRound.id,
+		roundNumber: displayRound.number,
+		roundLabel: roundLabel(competitionType, displayRound.number),
 		// Per-game derived round status — see src/lib/game/round-status.ts.
+		// Passes the game's currentRoundId / number so derivation returns
+		// 'completed' for a finished game even when displayRound is a past round.
 		roundStatus: deriveGameRoundStatus({
 			round: {
-				id: g.currentRound.id,
-				number: g.currentRound.number,
-				status: g.currentRound.status,
-				deadline: g.currentRound.deadline,
+				id: displayRound.id,
+				number: displayRound.number,
+				status: displayRound.status,
+				deadline: displayRound.deadline,
 			},
-			game: { currentRoundId: g.currentRound.id, currentRoundNumber: g.currentRound.number },
+			game: {
+				currentRoundId: g.currentRoundId,
+				currentRoundNumber:
+					g.competition.rounds.find((r) => r.id === g.currentRoundId)?.number ?? null,
+			},
 			now,
 		}) as 'open' | 'active' | 'completed',
 		maxLives: (g.modeConfig as { startingLives?: number } | null)?.startingLives ?? 3,
@@ -305,7 +338,8 @@ export async function getCupLadderData(
 	const base = await getCupStandingsData(gameId, viewerUserId)
 	if (!base) return null
 
-	// Re-fetch the round fixtures so we have team details + scores.
+	// Re-fetch fixtures for the round we're displaying (which may be a past
+	// round on a completed game — see displayRound logic in getCupStandingsData).
 	const g = await db.query.game.findFirst({
 		where: (t, { eq: eqOp }) => eqOp(t.id, gameId),
 		with: {
@@ -320,9 +354,25 @@ export async function getCupLadderData(
 			},
 		},
 	})
-	if (!g?.currentRound) return null
+	if (!g) return null
 
-	const fixturesRaw = g.currentRound.fixtures
+	const fixturesRaw = await (async () => {
+		if (g.currentRound && g.currentRound.id === base.roundId) {
+			return g.currentRound.fixtures
+		}
+		// Completed-game path: getCupStandingsData picked a past round; refetch its fixtures.
+		const roundFixtures = await db.query.round.findFirst({
+			where: (t, { eq: eqOp }) => eqOp(t.id, base.roundId),
+			with: {
+				fixtures: {
+					with: { homeTeam: true, awayTeam: true },
+					orderBy: (fx, { asc }) => asc(fx.kickoff),
+				},
+			},
+		})
+		return roundFixtures?.fixtures ?? null
+	})()
+	if (!fixturesRaw) return null
 
 	const fixtures: CupLadderFixture[] = fixturesRaw.map((fx) => {
 		const tierFromHome = computeTierDifference(fx.homeTeam, fx.awayTeam, g.competition.type)

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -539,15 +539,24 @@ export async function getTurboStandingsData(
 			: []
 	const userNames = new Map(userRows.map((u) => [u.id, u.name]))
 
-	// Turbo is a single-gameweek game — only surface the round this game is tied to.
-	const visibleRounds = gameData.currentRound ? [gameData.currentRound] : []
+	// Turbo is a single-gameweek game — surface the one round this game is tied to.
+	// `currentRound` is nulled out when the game completes (see settle.ts), so on
+	// completed games we recover the round from picks instead. Without this, the
+	// standings grid disappears the moment a turbo game finishes.
+	const pickRoundIds = new Set(
+		gameData.picks.map((pk) => pk.roundId).filter((id): id is string => id != null),
+	)
+	const visibleRounds = gameData.currentRound
+		? [gameData.currentRound]
+		: gameData.competition.rounds.filter((r) => pickRoundIds.has(r.id))
+	const primaryRoundId = visibleRounds[0]?.id ?? gameData.currentRoundId
 
 	// Precompute each player's streak progression so we can mark streak-breaker cells
 	// at the fixture level in the ladder view.
 	const playerStreakBreakRank = new Map<string, number | null>() // playerId -> rank where streak broke, or null
 	for (const p of gameData.players) {
 		const picks = gameData.picks
-			.filter((pk) => pk.gamePlayerId === p.id && pk.roundId === gameData.currentRoundId)
+			.filter((pk) => pk.gamePlayerId === p.id && pk.roundId === primaryRoundId)
 			.sort((a, b) => (a.confidenceRank ?? 99) - (b.confidenceRank ?? 99))
 		let broken: number | null = null
 		for (const pk of picks) {
@@ -564,7 +573,20 @@ export async function getTurboStandingsData(
 
 	return {
 		rounds: visibleRounds.map((r) => {
-			const isRoundOpen = r.status !== 'completed'
+			// Per-game round status — see src/lib/game/round-status.ts. `r.status`
+			// alone isn't enough: the competition-level round flips to 'completed'
+			// only after every fixture has settled, which can be 2+ days after the
+			// pick deadline. We need the deadline-aware derived status so picks
+			// reveal the moment the deadline passes, not when the last whistle blows.
+			const derivedStatus = deriveGameRoundStatus({
+				round: { id: r.id, number: r.number, status: r.status, deadline: r.deadline },
+				game: {
+					currentRoundId: gameData.currentRoundId,
+					currentRoundNumber: gameData.currentRound?.number ?? null,
+				},
+				now,
+			})
+			const isRoundOpen = derivedStatus === 'open'
 
 			const players = gameData.players.map((p) => {
 				const playerPicks = gameData.picks
@@ -758,15 +780,7 @@ export async function getTurboStandingsData(
 				number: r.number,
 				name: r.name ?? roundLabelLong(turboCompetitionType, r.number),
 				label: roundLabel(turboCompetitionType, r.number),
-				// Per-game round status — see src/lib/game/round-status.ts.
-				status: deriveGameRoundStatus({
-					round: { id: r.id, number: r.number, status: r.status, deadline: r.deadline },
-					game: {
-						currentRoundId: gameData.currentRoundId,
-						currentRoundNumber: gameData.currentRound?.number ?? null,
-					},
-					now,
-				}) as 'open' | 'active' | 'completed',
+				status: derivedStatus as 'open' | 'active' | 'completed',
 				players,
 				fixtures,
 			}
@@ -830,6 +844,25 @@ export async function getProgressGridData(
 		voidedAt: r.voidedAt ?? null,
 	}))
 
+	// Pre-compute per-game derived status for each round. Using `r.status` alone
+	// keeps picks locked even after the deadline (round.status flips to
+	// 'completed' only when every fixture has settled). The derived status
+	// returns 'open' only while deadline > now.
+	const now = new Date()
+	const currentRoundNumber =
+		gameData.competition.rounds.find((r) => r.id === gameData.currentRoundId)?.number ?? null
+	const derivedRoundStatus = new Map<string, 'upcoming' | 'open' | 'active' | 'completed'>()
+	for (const r of gameData.competition.rounds) {
+		derivedRoundStatus.set(
+			r.id,
+			deriveGameRoundStatus({
+				round: { id: r.id, number: r.number, status: r.status, deadline: r.deadline },
+				game: { currentRoundId: gameData.currentRoundId, currentRoundNumber },
+				now,
+			}),
+		)
+	}
+
 	// Get user names for players
 	const { user } = await import('@/lib/schema/auth')
 	const userRows =
@@ -862,11 +895,11 @@ export async function getProgressGridData(
 					continue
 				}
 			}
-			const round = gameData.competition.rounds.find((cr) => cr.id === r.id)
-			const isRoundOpen = round?.status !== 'completed'
+			const isRoundOpen = derivedRoundStatus.get(r.id) === 'open'
 			const isOwnPick = viewerGamePlayerId && thePick?.gamePlayerId === viewerGamePlayerId
-			// If the round is open and either the viewer isn't the picker or the caller
-			// has requested a shared-view (hide everything current) — hide the team info.
+			// If the round is open (deadline hasn't passed yet) and either the viewer
+			// isn't the picker or the caller has requested a shared-view (hide
+			// everything current) — hide the team info.
 			const hideTeam = isRoundOpen && (options?.hideAllCurrentPicks || !isOwnPick)
 
 			if (!thePick) {


### PR DESCRIPTION
## Summary

- **Lock bug (turbo + classic)**: `isRoundOpen` was sourced from `round.status !== 'completed'`, which only flips when every fixture has settled — often 2+ days past the deadline. Picks stayed hidden behind the lock icon the whole time. Now derived from `deriveGameRoundStatus()`, so the reveal happens at the deadline.
- **Vanishing grid/ladder post-completion**: `applyAutoCompletion` nulls `currentRoundId`. Turbo's `visibleRounds` and cup's whole query returned empty, so the page rendered blank after a game finished. Fallback added so the relevant round is recovered from picks.
- **Winner banner**: new shared `WinnerBanner` rendered above standings on completed games, with per-mode stats (turbo: streak/goals · cup: lives/streak/goals · classic: rounds played).

Discovered after a real PL turbo weekend where the lock didn't lift and the page went blank once the game ended. Also de-risks the WC launch — cup's vanishing-ladder bug would have hit at the moment the trophy was decided.

## Test plan

Smoke coverage filled the gap the original tests had (engine correctness was asserted, read-side UI queries weren't):

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 420/420 unit tests pass
- [x] `just smoke` — 24/24 smoke tests pass, including 8 new ones:
  - classic / turbo: picks reveal once deadline passes
  - classic / turbo / cup: picks are hidden BEFORE the deadline (regression guard against an inverted-condition fix)
  - turbo: standings survive game completion (currentRoundId null)
  - cup: `getCupStandingsData` + `getCupLadderData` both survive game completion
- [ ] Manual: smoke a real completed turbo game in dev to eyeball the banner styling

## What's deliberately not in this PR

- Password reset — design (Resend) chosen; implementation deferred to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)