### PR TITLE
fix(game-detail): make WinnerBanner prop JSON-serializable across RSC boundary

### DIFF
--- a/scripts/seed-completed-turbo.ts
+++ b/scripts/seed-completed-turbo.ts
@@ -1,0 +1,135 @@
+/**
+ * One-off seed for manual verification of the post-completion turbo UX:
+ * creates a finished turbo game with two players, settles one fixture so the
+ * game auto-completes (winner determined), and prints the URL to open.
+ *
+ * Run with: pnpm tsx scripts/seed-completed-turbo.ts
+ */
+import { eq, sql } from 'drizzle-orm'
+import { auth } from '../src/lib/auth'
+import { db } from '../src/lib/db'
+import { generateInviteCode } from '../src/lib/game/invite-code'
+import { settleFixture } from '../src/lib/game/settle'
+import { user as userTable } from '../src/lib/schema/auth'
+import {
+	competition,
+	fixture as fixtureTable,
+	round as roundTable,
+	team as teamTable,
+} from '../src/lib/schema/competition'
+import { game, gamePlayer, pick } from '../src/lib/schema/game'
+
+async function ensureUser(email: string, name: string): Promise<string> {
+	const existing = await db.query.user.findFirst({ where: eq(userTable.email, email) })
+	if (existing) return existing.id
+	const res = await auth.api.signUpEmail({
+		body: { email, password: 'password123', name },
+	})
+	return res.user.id
+}
+
+async function main(): Promise<void> {
+	const winnerUserId = await ensureUser('seedwinner@example.com', 'Seed Winner')
+	const loserUserId = await ensureUser('seedloser@example.com', 'Seed Loser')
+
+	const [comp] = await db
+		.insert(competition)
+		.values({
+			name: 'Seed Turbo Comp',
+			type: 'league',
+			dataSource: 'fpl',
+			status: 'active',
+		})
+		.returning()
+
+	const [a] = await db
+		.insert(teamTable)
+		.values({ name: 'Seed Alpha', shortName: 'ALP', externalIds: {} })
+		.returning()
+	const [b] = await db
+		.insert(teamTable)
+		.values({ name: 'Seed Bravo', shortName: 'BRV', externalIds: {} })
+		.returning()
+
+	const [r1] = await db
+		.insert(roundTable)
+		.values({
+			competitionId: comp.id,
+			number: 1,
+			name: 'Round 1',
+			status: 'open',
+			deadline: new Date(Date.now() - 60_000),
+		})
+		.returning()
+
+	const [fx] = await db
+		.insert(fixtureTable)
+		.values({
+			roundId: r1.id,
+			homeTeamId: a.id,
+			awayTeamId: b.id,
+			kickoff: new Date(Date.now() - 3_600_000),
+			status: 'scheduled',
+		})
+		.returning()
+
+	const [g] = await db
+		.insert(game)
+		.values({
+			name: 'Seed Completed Turbo',
+			competitionId: comp.id,
+			gameMode: 'turbo',
+			currentRoundId: r1.id,
+			createdBy: winnerUserId,
+			inviteCode: generateInviteCode(),
+			status: 'active',
+			modeConfig: { numberOfPicks: 1 },
+		})
+		.returning()
+
+	const [gpWin] = await db
+		.insert(gamePlayer)
+		.values({ gameId: g.id, userId: winnerUserId, livesRemaining: 0 })
+		.returning()
+	const [gpLose] = await db
+		.insert(gamePlayer)
+		.values({ gameId: g.id, userId: loserUserId, livesRemaining: 0 })
+		.returning()
+
+	await db.insert(pick).values({
+		gameId: g.id,
+		gamePlayerId: gpWin.id,
+		roundId: r1.id,
+		teamId: a.id,
+		fixtureId: fx.id,
+		confidenceRank: 1,
+		predictedResult: 'home_win',
+	})
+	await db.insert(pick).values({
+		gameId: g.id,
+		gamePlayerId: gpLose.id,
+		roundId: r1.id,
+		teamId: b.id,
+		fixtureId: fx.id,
+		confidenceRank: 1,
+		predictedResult: 'away_win',
+	})
+
+	await db
+		.update(fixtureTable)
+		.set({ status: 'finished', homeScore: 2, awayScore: 0 })
+		.where(sql`${fixtureTable.id} = ${fx.id}`)
+	await settleFixture(fx.id)
+
+	const after = await db.query.game.findFirst({ where: eq(game.id, g.id) })
+	console.log(`\n  game id: ${g.id}`)
+	console.log(`  status:  ${after?.status}`)
+	console.log(`  open at: http://localhost:3000/game/${g.id}`)
+	console.log(`  login:   seedwinner@example.com / password123\n`)
+	process.exit(0)
+}
+
+main().catch((err) => {
+	console.error(err)
+	process.exit(1)
+})

--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -1,10 +1,8 @@
 import { and, eq } from 'drizzle-orm'
-import { Flame, Heart, ListChecks, Target } from 'lucide-react'
 import { notFound, redirect } from 'next/navigation'
 import { ActingAsBanner } from '@/components/game/acting-as-banner'
 import { GameDetailView } from '@/components/game/game-detail-view'
 import { RebuyBanner } from '@/components/game/rebuy-banner'
-import type { WinnerBannerEntry } from '@/components/game/winner-banner'
 import { ClassicPick } from '@/components/picks/classic-pick'
 import type { CupPickFixture, CupPickSlot } from '@/components/picks/cup-pick'
 import { CupPickForm } from '@/components/picks/cup-pick-form'
@@ -22,8 +20,8 @@ import {
 } from '@/lib/game/detail-queries'
 import { reconcileGameState } from '@/lib/game/reconcile'
 import { roundLabel, roundLabelLong } from '@/lib/game/round-label'
+import { buildWinnerBanner } from '@/lib/game/winner-banner-builder'
 import { computeTierDifference } from '@/lib/game-logic/cup-tier'
-import { calculatePayouts } from '@/lib/game-logic/prizes'
 import { user } from '@/lib/schema/auth'
 import { gamePlayer } from '@/lib/schema/game'
 
@@ -135,80 +133,19 @@ export default async function GameDetailPage({
 	const cupStandingsData =
 		game.gameMode === 'cup' ? await getCupLadderData(game.id, session.user.id) : null
 
-	// Winner banner: rendered above standings on completed games. Splits + tied
-	// finishes (multiple players with status='winner') get a "split pot" header
-	// and the per-winner pot share comes from calculatePayouts so the maths
-	// matches the share card. Per-mode stats are filled in below.
-	const winnerBanner: { winners: WinnerBannerEntry[]; runnerUpName?: string } | null = (() => {
-		if (game.status !== 'completed') return null
-		const winnerPlayers = game.players.filter((p) => p.status === 'winner')
-		if (winnerPlayers.length === 0) return null
-		const payouts = calculatePayouts(
-			game.pot.total,
-			winnerPlayers.map((p) => p.userId),
-		)
-		const potShareFor = (userId: string) =>
-			payouts.find((po) => po.userId === userId)?.amount ?? '0.00'
-
-		if (game.gameMode === 'turbo' && turboStandingsData && turboStandingsData.rounds.length > 0) {
-			const lastRound = turboStandingsData.rounds[turboStandingsData.rounds.length - 1]
-			const winners: WinnerBannerEntry[] = winnerPlayers.map((p) => {
-				const tp = lastRound.players.find((x) => x.id === p.id)
-				return {
-					userId: p.userId,
-					name: tp?.name ?? 'Player',
-					potShare: potShareFor(p.userId),
-					stats: [
-						{ icon: Flame, value: tp?.streak ?? 0, label: 'streak' },
-						{ icon: Target, value: tp?.goals ?? 0, label: 'goals' },
-					],
-				}
-			})
-			const winnerIds = new Set(winnerPlayers.map((p) => p.id))
-			const runnerUp = [...lastRound.players]
-				.filter((tp) => !winnerIds.has(tp.id))
-				.sort((a, b) => b.streak - a.streak || b.goals - a.goals)[0]
-			return { winners, runnerUpName: runnerUp?.name }
-		}
-
-		if (game.gameMode === 'cup' && cupStandingsData) {
-			const winners: WinnerBannerEntry[] = winnerPlayers.map((p) => {
-				const cp = cupStandingsData.players.find((x) => x.id === p.id)
-				return {
-					userId: p.userId,
-					name: cp?.name ?? 'Player',
-					potShare: potShareFor(p.userId),
-					stats: [
-						{ icon: Heart, value: cp?.livesRemaining ?? 0, label: 'lives' },
-						{ icon: Flame, value: cp?.streak ?? 0, label: 'streak' },
-						{ icon: Target, value: cp?.goals ?? 0, label: 'goals' },
-					],
-				}
-			})
-			const winnerIds = new Set(winnerPlayers.map((p) => p.id))
-			const others = [...cupStandingsData.players]
-				.filter((cp) => !winnerIds.has(cp.id))
-				.sort(
-					(a, b) => b.livesRemaining - a.livesRemaining || b.streak - a.streak || b.goals - a.goals,
-				)
-			return { winners, runnerUpName: others[0]?.name }
-		}
-
-		if (game.gameMode === 'classic') {
-			// Classic doesn't carry per-player streak/goals; surface rounds-survived
-			// (the highest round number in the grid) so the banner has a stat.
-			const roundsPlayed = classicGrid?.rounds.length ?? 0
-			const winners: WinnerBannerEntry[] = winnerPlayers.map((p) => ({
-				userId: p.userId,
-				name: classicGrid?.players.find((x) => x.id === p.id)?.name ?? 'Player',
-				potShare: potShareFor(p.userId),
-				stats: [{ icon: ListChecks, value: roundsPlayed || '—', label: 'rounds' }],
-			}))
-			return { winners }
-		}
-
-		return null
-	})()
+	// Winner banner: rendered above standings on completed games. Built by a pure
+	// function so its output can be unit-tested for JSON-serializability — the
+	// prop crosses the Server → Client Component boundary, and a function ref
+	// here crashes the whole page render (PR #55 → #57 incident).
+	const winnerBanner = buildWinnerBanner({
+		gameMode: game.gameMode as 'classic' | 'turbo' | 'cup',
+		gameStatus: game.status,
+		potTotal: game.pot.total,
+		players: game.players,
+		turboStandings: turboStandingsData,
+		cupStandings: cupStandingsData,
+		classicGrid,
+	})
 
 	// Alive check is on the TARGET player (acting-as) or the viewer's own membership.
 	const targetPlayerStatus = actingAsTarget

--- a/src/components/game/winner-banner.tsx
+++ b/src/components/game/winner-banner.tsx
@@ -1,7 +1,21 @@
-import type { LucideIcon } from 'lucide-react'
+import { Flame, Heart, ListChecks, type LucideIcon, Target } from 'lucide-react'
+
+// String keys, not function refs — the page that builds this prop runs as a
+// Server Component, so values that cross the GameDetailView boundary must be
+// JSON-serializable. Passing a lucide-react component directly (`icon: Flame`)
+// throws "An error occurred in the Server Components render." at runtime on
+// any completed game.
+export type WinnerStatIcon = 'flame' | 'target' | 'heart' | 'list-checks'
+
+const ICONS: Record<WinnerStatIcon, LucideIcon> = {
+	flame: Flame,
+	target: Target,
+	heart: Heart,
+	'list-checks': ListChecks,
+}
 
 export interface WinnerStat {
-	icon: LucideIcon
+	iconKey: WinnerStatIcon
 	value: number | string
 	label: string
 }
@@ -46,7 +60,7 @@ export function WinnerBanner({ winners, runnerUpName }: WinnerBannerProps) {
 							{w.stats.length > 0 && (
 								<div className="mt-0.5 flex items-center gap-3 text-xs text-amber-800">
 									{w.stats.map((s) => {
-										const Icon = s.icon
+										const Icon = ICONS[s.iconKey]
 										return (
 											<span key={s.label} className="inline-flex items-center gap-1">
 												<Icon className="h-3 w-3" />

--- a/src/lib/game/winner-banner-builder.test.ts
+++ b/src/lib/game/winner-banner-builder.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest'
+import { buildWinnerBanner } from './winner-banner-builder'
+
+// The prop returned by buildWinnerBanner is passed from a Server Component
+// (game/[id]/page.tsx) to a Client Component (GameDetailView). Next.js
+// requires all values crossing that boundary to be JSON-serializable.
+// `structuredClone` throws on function refs / class instances — a faithful
+// proxy for the runtime serialization Next.js performs (whereas
+// `JSON.stringify` silently drops functions, hiding the bug).
+//
+// History: PR #55 shipped a version of this function that passed lucide-react
+// component refs (`icon: Flame`) as part of the prop. Production rendered a
+// blank page on every completed game with "An error occurred in the Server
+// Components render." This test exists so that class of bug fails here, not
+// in prod.
+
+function assertSerializable(value: unknown): void {
+	// Throws DataCloneError on functions / class instances / Maps with non-
+	// serializable values / etc. Throwing here means the prop would crash
+	// the RSC boundary at runtime.
+	structuredClone(value)
+}
+
+describe('buildWinnerBanner', () => {
+	it('returns null when the game is not completed', () => {
+		expect(
+			buildWinnerBanner({
+				gameMode: 'turbo',
+				gameStatus: 'active',
+				potTotal: '100.00',
+				players: [],
+				turboStandings: null,
+				cupStandings: null,
+				classicGrid: null,
+			}),
+		).toBeNull()
+	})
+
+	it('returns null when no players have status=winner', () => {
+		expect(
+			buildWinnerBanner({
+				gameMode: 'turbo',
+				gameStatus: 'completed',
+				potTotal: '100.00',
+				players: [{ id: 'gp1', userId: 'u1', status: 'eliminated' }],
+				turboStandings: null,
+				cupStandings: null,
+				classicGrid: null,
+			}),
+		).toBeNull()
+	})
+
+	it('turbo: builds a JSON-serializable payload with streak + goals stats', () => {
+		const banner = buildWinnerBanner({
+			gameMode: 'turbo',
+			gameStatus: 'completed',
+			potTotal: '100.00',
+			players: [{ id: 'gp1', userId: 'u1', status: 'winner' }],
+			turboStandings: {
+				rounds: [
+					{
+						id: 'r1',
+						number: 1,
+						name: 'GW1',
+						label: 'GW1',
+						status: 'completed',
+						players: [
+							{
+								id: 'gp1',
+								name: 'Alice',
+								picks: [],
+								streak: 6,
+								goals: 4,
+								hasSubmitted: true,
+							},
+						],
+						fixtures: [],
+					},
+				],
+				// biome-ignore lint/suspicious/noExplicitAny: shape-only fixture for the builder
+			} as any,
+			cupStandings: null,
+			classicGrid: null,
+		})
+		expect(banner).not.toBeNull()
+		expect(banner?.winners).toHaveLength(1)
+		expect(banner?.winners[0]).toMatchObject({
+			userId: 'u1',
+			name: 'Alice',
+			potShare: '100.00',
+		})
+		// String keys, not function refs — the whole point of this fix.
+		expect(banner?.winners[0].stats[0].iconKey).toBe('flame')
+		expect(banner?.winners[0].stats[1].iconKey).toBe('target')
+		// Must survive the RSC boundary.
+		assertSerializable(banner)
+	})
+
+	it('cup: builds a JSON-serializable payload with lives + streak + goals stats', () => {
+		const banner = buildWinnerBanner({
+			gameMode: 'cup',
+			gameStatus: 'completed',
+			potTotal: '480.00',
+			players: [{ id: 'gp1', userId: 'u1', status: 'winner' }],
+			turboStandings: null,
+			cupStandings: {
+				gameId: 'g1',
+				roundId: 'r1',
+				roundNumber: 1,
+				roundLabel: 'R1',
+				roundStatus: 'completed',
+				maxLives: 3,
+				numberOfPicks: 6,
+				players: [
+					{
+						id: 'gp1',
+						userId: 'u1',
+						name: 'Bob',
+						status: 'winner',
+						livesRemaining: 2,
+						streak: 5,
+						goals: 7,
+						hasSubmitted: true,
+						eliminatedRoundNumber: null,
+						eliminatedRoundLabel: null,
+						picks: [],
+					},
+				],
+				fixtures: [],
+			},
+			classicGrid: null,
+		})
+		expect(banner?.winners[0].stats.map((s) => s.iconKey)).toEqual(['heart', 'flame', 'target'])
+		assertSerializable(banner)
+	})
+
+	it('classic: builds a JSON-serializable payload with rounds-played stat', () => {
+		const banner = buildWinnerBanner({
+			gameMode: 'classic',
+			gameStatus: 'completed',
+			potTotal: '50.00',
+			players: [{ id: 'gp1', userId: 'u1', status: 'winner' }],
+			turboStandings: null,
+			cupStandings: null,
+			classicGrid: {
+				rounds: [
+					{ id: 'r1', number: 1, name: 'GW1', label: 'GW1', isStartingRound: true, voidedAt: null },
+					{
+						id: 'r2',
+						number: 2,
+						name: 'GW2',
+						label: 'GW2',
+						isStartingRound: false,
+						voidedAt: null,
+					},
+				],
+				players: [{ id: 'gp1', name: 'Cara', status: 'winner', cellsByRoundId: {} }],
+				aliveCount: 1,
+				eliminatedCount: 0,
+				pot: '50.00',
+				// biome-ignore lint/suspicious/noExplicitAny: shape-only fixture for the builder
+			} as any,
+		})
+		expect(banner?.winners[0].stats[0]).toMatchObject({ iconKey: 'list-checks', label: 'rounds' })
+		expect(banner?.winners[0].stats[0].value).toBe(2)
+		assertSerializable(banner)
+	})
+
+	it('split-pot: divides the pot across multiple winners', () => {
+		const banner = buildWinnerBanner({
+			gameMode: 'turbo',
+			gameStatus: 'completed',
+			potTotal: '100.00',
+			players: [
+				{ id: 'gp1', userId: 'u1', status: 'winner' },
+				{ id: 'gp2', userId: 'u2', status: 'winner' },
+			],
+			turboStandings: {
+				rounds: [
+					{
+						id: 'r1',
+						number: 1,
+						name: 'GW1',
+						label: 'GW1',
+						status: 'completed',
+						players: [
+							{ id: 'gp1', name: 'A', picks: [], streak: 4, goals: 3, hasSubmitted: true },
+							{ id: 'gp2', name: 'B', picks: [], streak: 4, goals: 3, hasSubmitted: true },
+						],
+						fixtures: [],
+					},
+				],
+				// biome-ignore lint/suspicious/noExplicitAny: shape-only fixture for the builder
+			} as any,
+			cupStandings: null,
+			classicGrid: null,
+		})
+		expect(banner?.winners).toHaveLength(2)
+		expect(banner?.winners[0].potShare).toBe('50.00')
+		expect(banner?.winners[1].potShare).toBe('50.00')
+		assertSerializable(banner)
+	})
+})

--- a/src/lib/game/winner-banner-builder.ts
+++ b/src/lib/game/winner-banner-builder.ts
@@ -1,0 +1,106 @@
+import type { WinnerBannerEntry } from '@/components/game/winner-banner'
+import type { CupLadderData } from '@/lib/game/cup-standings-queries'
+import type { getProgressGridData, getTurboStandingsData } from '@/lib/game/detail-queries'
+import { calculatePayouts } from '@/lib/game-logic/prizes'
+
+// The prop crosses the Server → Client Component boundary (page.tsx → GameDetailView).
+// Everything in here must be JSON-serializable. There is a unit test
+// (`winner-banner-builder.test.ts`) that round-trips the result via
+// `structuredClone` to enforce this — `structuredClone` throws on function
+// refs, where `JSON.stringify` silently drops them. Don't add Date / Map /
+// component refs / class instances here without updating that test.
+
+type WinnerPlayerInput = {
+	id: string
+	userId: string
+	status: 'alive' | 'eliminated' | 'winner'
+}
+
+interface BuildWinnerBannerInput {
+	gameMode: 'classic' | 'turbo' | 'cup'
+	gameStatus: string
+	potTotal: string
+	players: WinnerPlayerInput[]
+	turboStandings: Awaited<ReturnType<typeof getTurboStandingsData>> | null
+	cupStandings: CupLadderData | null
+	classicGrid: Awaited<ReturnType<typeof getProgressGridData>> | null
+}
+
+export interface WinnerBannerPayload {
+	winners: WinnerBannerEntry[]
+	runnerUpName?: string
+}
+
+export function buildWinnerBanner(input: BuildWinnerBannerInput): WinnerBannerPayload | null {
+	if (input.gameStatus !== 'completed') return null
+	const winnerPlayers = input.players.filter((p) => p.status === 'winner')
+	if (winnerPlayers.length === 0) return null
+
+	const payouts = calculatePayouts(
+		input.potTotal,
+		winnerPlayers.map((p) => p.userId),
+	)
+	const potShareFor = (userId: string) =>
+		payouts.find((po) => po.userId === userId)?.amount ?? '0.00'
+
+	if (
+		input.gameMode === 'turbo' &&
+		input.turboStandings &&
+		input.turboStandings.rounds.length > 0
+	) {
+		const lastRound = input.turboStandings.rounds[input.turboStandings.rounds.length - 1]
+		const winners: WinnerBannerEntry[] = winnerPlayers.map((p) => {
+			const tp = lastRound.players.find((x) => x.id === p.id)
+			return {
+				userId: p.userId,
+				name: tp?.name ?? 'Player',
+				potShare: potShareFor(p.userId),
+				stats: [
+					{ iconKey: 'flame', value: tp?.streak ?? 0, label: 'streak' },
+					{ iconKey: 'target', value: tp?.goals ?? 0, label: 'goals' },
+				],
+			}
+		})
+		const winnerIds = new Set(winnerPlayers.map((p) => p.id))
+		const runnerUp = [...lastRound.players]
+			.filter((tp) => !winnerIds.has(tp.id))
+			.sort((a, b) => b.streak - a.streak || b.goals - a.goals)[0]
+		return { winners, runnerUpName: runnerUp?.name }
+	}
+
+	if (input.gameMode === 'cup' && input.cupStandings) {
+		const winners: WinnerBannerEntry[] = winnerPlayers.map((p) => {
+			const cp = input.cupStandings?.players.find((x) => x.id === p.id)
+			return {
+				userId: p.userId,
+				name: cp?.name ?? 'Player',
+				potShare: potShareFor(p.userId),
+				stats: [
+					{ iconKey: 'heart', value: cp?.livesRemaining ?? 0, label: 'lives' },
+					{ iconKey: 'flame', value: cp?.streak ?? 0, label: 'streak' },
+					{ iconKey: 'target', value: cp?.goals ?? 0, label: 'goals' },
+				],
+			}
+		})
+		const winnerIds = new Set(winnerPlayers.map((p) => p.id))
+		const others = [...input.cupStandings.players]
+			.filter((cp) => !winnerIds.has(cp.id))
+			.sort(
+				(a, b) => b.livesRemaining - a.livesRemaining || b.streak - a.streak || b.goals - a.goals,
+			)
+		return { winners, runnerUpName: others[0]?.name }
+	}
+
+	if (input.gameMode === 'classic') {
+		const roundsPlayed = input.classicGrid?.rounds.length ?? 0
+		const winners: WinnerBannerEntry[] = winnerPlayers.map((p) => ({
+			userId: p.userId,
+			name: input.classicGrid?.players.find((x) => x.id === p.id)?.name ?? 'Player',
+			potShare: potShareFor(p.userId),
+			stats: [{ iconKey: 'list-checks', value: roundsPlayed || '—', label: 'rounds' }],
+		}))
+		return { winners }
+	}
+
+	return null
+}


### PR DESCRIPTION
## Summary

PR #55 shipped a regression: the `winnerBanner` prop built in `page.tsx` (Server Component) and passed to `GameDetailView` (Client Component) contained `lucide-react` component refs — `{ icon: Flame, ... }`. Next.js requires Server→Client props to be JSON-serializable; function refs aren't. Every completed game rendered a blank page with *"An error occurred in the Server Components render."*

Three changes:

1. **Structural fix**: `WinnerStat.icon: LucideIcon` → `iconKey: 'flame' | 'target' | 'heart' | 'list-checks'`. The banner maps the key to an icon internally. The type now forbids passing a function ref.
2. **Extract + unit test the prop builder**: pulled the inline IIFE in `page.tsx` into `buildWinnerBanner(...)`, a pure function exercised by `winner-banner-builder.test.ts`. Each test calls `structuredClone(banner)` on the output — `structuredClone` throws on functions / class instances, where `JSON.stringify` silently drops them. This is the regression guard PR #55 should have had.
3. **Seed helper** (`scripts/seed-completed-turbo.ts`): one-shot DB seed creating a finished turbo game so the post-completion UX can be loaded manually in dev. Used to verify this fix end-to-end.

## Why the original tests missed this

| Layer | Caught? | Why not |
| --- | --- | --- |
| Unit tests | ❌ | Pure-function tests; never crossed an RSC boundary |
| Smoke tests | ❌ | Data-layer queries against a real DB; never rendered React |
| `tsc --noEmit` | ❌ | `icon: LucideIcon` is type-valid; TS has no concept of Next.js serialization rules |
| `pnpm build` | ❌ | RSC serialization is a runtime check; the build succeeded |
| Manual dev-server | ⛔ | Skipped — left explicitly unchecked in #55's PR description |

The new `structuredClone` test is the closest cheap proxy for the runtime check that actually catches this bug class.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 426/426 (incl. 6 new `buildWinnerBanner` tests)
- [x] `just smoke` — 24/24
- [x] `pnpm build` — succeeds
- [x] Manual: seed a completed turbo game, authed `curl /game/[id]` → HTTP 200, response body contains the winner banner ("🏆", "Winner", winner name, "£100.00 won") and standings panel. No RSC error in the rendered HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)