### PR TITLE
feat(auth): password reset via Resend + Better Auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,10 @@ VERCEL_URL=http://localhost:3000
 # /api/auth/* endpoints. NEXT_PUBLIC_* vars are bundled into the client at
 # build time — changing this requires a redeploy.
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# ─── Resend (transactional email — password reset) ─────────────────────────
+# Provisioned via the Vercel Marketplace integration, NOT Doppler. The
+# Marketplace writes RESEND_API_KEY directly into Vercel prod + preview envs.
+# For local dev: `vercel env pull` populates this. If absent, email sending
+# is logged to stdout instead of dispatched (sandbox dev experience).
+RESEND_API_KEY=re_dev_placeholder

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ Variables:
 - `QSTASH_CURRENT_SIGNING_KEY` and `QSTASH_NEXT_SIGNING_KEY` — QStash webhook signature verification.
 - `VERCEL_URL` — deployment URL used as the QStash callback base. Populated automatically in Vercel builds; set manually in dev if you want to exercise QStash locally.
 - `NEXT_PUBLIC_APP_URL` — public origin of the deployed app. Used by the Better Auth client (`src/lib/auth-client.ts`) as its `baseURL`. **Must match the deployed URL exactly** so the browser can reach `/api/auth/*`. As a `NEXT_PUBLIC_*` var, it's bundled into the client at build time — changing it requires a redeploy.
+- `RESEND_API_KEY` — Resend API key for transactional email (password reset). **Exception to the Doppler-first rule:** provisioned via the Vercel Marketplace Resend integration, which writes directly into Vercel prod + preview envs. Don't add it to Doppler — the Marketplace key would get overwritten by the sync. For local dev, `vercel env pull` brings it in; if absent, `src/lib/email.ts` logs the email payload to stdout instead of sending.
 
 GitHub Actions secrets (repo-level):
 - `CRON_SECRET` — same value as Doppler `prd.CRON_SECRET`. Used by `live-scores.yml` for the every-minute poll.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"radix-ui": "^1.4.3",
 		"react": "19.2.4",
 		"react-dom": "19.2.4",
+		"resend": "^6.12.4",
 		"sonner": "^2.0.7",
 		"tailwind-merge": "^3.5.0",
 		"tw-animate-css": "^1.4.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      resend:
+        specifier: ^6.12.4
+        version: 6.12.4
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1881,6 +1884,9 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -2405,6 +2411,9 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -2654,6 +2663,9 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2737,6 +2749,15 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resend@6.12.4:
+    resolution: {integrity: sha512-lRpJ2Hxd+ht+JPDm97juRcUp9HOMuZyxaRFRFmc9Tx8iNWiei94Dx9v6SWufgKk2667C/uCeKKspMotOHSpCSg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -2808,6 +2829,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
@@ -4479,6 +4503,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
@@ -4923,6 +4949,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0:
     optional: true
 
+  fast-sha256@1.3.0: {}
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -5140,6 +5168,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  postal-mime@2.7.4: {}
+
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.11
@@ -5267,6 +5297,11 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  resend@6.12.4:
+    dependencies:
+      postal-mime: 2.7.4
+      standardwebhooks: 1.0.0
+
   resolve-pkg-maps@1.0.0: {}
 
   restore-cursor@5.1.0:
@@ -5371,6 +5406,11 @@ snapshots:
   source-map@0.6.1: {}
 
   stackback@0.0.2: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   std-env@4.0.0: {}
 

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,5 @@
+import { ForgotPasswordForm } from '@/components/auth/forgot-password-form'
+
+export default function ForgotPasswordPage() {
+	return <ForgotPasswordForm />
+}

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from 'react'
+import { ResetPasswordForm } from '@/components/auth/reset-password-form'
+
+export default function ResetPasswordPage() {
+	return (
+		<Suspense>
+			<ResetPasswordForm />
+		</Suspense>
+	)
+}

--- a/src/components/auth/auth-form.tsx
+++ b/src/components/auth/auth-form.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
@@ -13,6 +14,7 @@ export function AuthForm() {
 	const router = useRouter()
 	const searchParams = useSearchParams()
 	const callbackUrl = searchParams.get('callbackUrl') || '/'
+	const resetSuccess = searchParams.get('reset') === 'success'
 
 	const [error, setError] = useState<string | null>(null)
 	const [loading, setLoading] = useState(false)
@@ -66,13 +68,26 @@ export function AuthForm() {
 				</TabsList>
 
 				<TabsContent value="signin">
+					{resetSuccess && (
+						<div className="mb-3 rounded-md border border-emerald-300 bg-emerald-50 p-3 text-sm text-emerald-900">
+							Password updated. Sign in with your new password.
+						</div>
+					)}
 					<form onSubmit={handleSignIn} className="space-y-3">
 						<div>
 							<Label htmlFor="email-signin">Email</Label>
 							<Input id="email-signin" name="email" type="email" required autoComplete="email" />
 						</div>
 						<div>
-							<Label htmlFor="password-signin">Password</Label>
+							<div className="flex items-baseline justify-between">
+								<Label htmlFor="password-signin">Password</Label>
+								<Link
+									href="/forgot-password"
+									className="text-xs text-muted-foreground hover:text-foreground underline"
+								>
+									Forgot?
+								</Link>
+							</div>
 							<Input
 								id="password-signin"
 								name="password"

--- a/src/components/auth/forgot-password-form.tsx
+++ b/src/components/auth/forgot-password-form.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { requestPasswordReset } from '@/lib/auth-client'
+
+export function ForgotPasswordForm() {
+	const [submitted, setSubmitted] = useState(false)
+	const [loading, setLoading] = useState(false)
+	const [error, setError] = useState<string | null>(null)
+
+	async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+		e.preventDefault()
+		setError(null)
+		setLoading(true)
+		const formData = new FormData(e.currentTarget)
+		const email = formData.get('email') as string
+
+		const origin = window.location.origin
+		const result = await requestPasswordReset({
+			email,
+			redirectTo: `${origin}/reset-password`,
+		})
+		setLoading(false)
+		// Always show the success state, even on error. The whole point of
+		// password reset UX is not to leak whether an email is in our system —
+		// the API silently no-ops for unknown emails; we mirror that here.
+		if (result.error) {
+			console.warn('requestPasswordReset error', result.error)
+		}
+		setSubmitted(true)
+	}
+
+	if (submitted) {
+		return (
+			<Card className="p-8 w-full max-w-md">
+				<div className="text-center mb-4">
+					<h1 className="font-display font-bold text-2xl">Check your inbox</h1>
+				</div>
+				<p className="text-sm text-muted-foreground text-center">
+					If an account exists for that email, we've sent a link to reset your password. The link
+					expires in 1 hour.
+				</p>
+				<div className="mt-6 text-center">
+					<Link href="/auth" className="text-sm font-semibold underline">
+						Back to sign in
+					</Link>
+				</div>
+			</Card>
+		)
+	}
+
+	return (
+		<Card className="p-8 w-full max-w-md">
+			<div className="text-center mb-6">
+				<h1 className="font-display font-bold text-2xl">Forgot password?</h1>
+				<p className="text-sm text-muted-foreground mt-1">
+					Enter the email you signed up with and we'll send you a reset link.
+				</p>
+			</div>
+			<form onSubmit={handleSubmit} className="space-y-3">
+				<div>
+					<Label htmlFor="email-forgot">Email</Label>
+					<Input
+						id="email-forgot"
+						name="email"
+						type="email"
+						required
+						autoComplete="email"
+						autoFocus
+					/>
+				</div>
+				{error && <p className="text-sm text-[var(--eliminated)]">{error}</p>}
+				<Button type="submit" className="w-full" disabled={loading}>
+					{loading ? 'Sending...' : 'Send reset link'}
+				</Button>
+			</form>
+			<div className="mt-6 text-center">
+				<Link
+					href="/auth"
+					className="text-sm text-muted-foreground hover:text-foreground underline"
+				>
+					Back to sign in
+				</Link>
+			</div>
+		</Card>
+	)
+}

--- a/src/components/auth/reset-password-form.tsx
+++ b/src/components/auth/reset-password-form.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { resetPassword } from '@/lib/auth-client'
+
+export function ResetPasswordForm() {
+	const router = useRouter()
+	const searchParams = useSearchParams()
+	const token = searchParams.get('token')
+	const errorParam = searchParams.get('error')
+
+	const [loading, setLoading] = useState(false)
+	const [error, setError] = useState<string | null>(
+		errorParam === 'invalid_token' || errorParam === 'INVALID_TOKEN'
+			? 'This reset link has expired or already been used. Request a new one below.'
+			: null,
+	)
+
+	if (!token) {
+		return (
+			<Card className="p-8 w-full max-w-md">
+				<div className="text-center mb-4">
+					<h1 className="font-display font-bold text-2xl">Reset link missing</h1>
+				</div>
+				<p className="text-sm text-muted-foreground text-center">
+					This page needs a reset token. Request a fresh link below.
+				</p>
+				<div className="mt-6 text-center">
+					<Link href="/forgot-password" className="text-sm font-semibold underline">
+						Request a new link
+					</Link>
+				</div>
+			</Card>
+		)
+	}
+
+	async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+		e.preventDefault()
+		setError(null)
+		const formData = new FormData(e.currentTarget)
+		const newPassword = formData.get('password') as string
+		const confirm = formData.get('confirm') as string
+		if (newPassword !== confirm) {
+			setError("Passwords don't match.")
+			return
+		}
+		if (!token) return
+		setLoading(true)
+		const result = await resetPassword({ newPassword, token })
+		setLoading(false)
+		if (result.error) {
+			setError(result.error.message ?? 'Could not reset password. Try requesting a new link.')
+			return
+		}
+		router.push('/auth?reset=success')
+	}
+
+	return (
+		<Card className="p-8 w-full max-w-md">
+			<div className="text-center mb-6">
+				<h1 className="font-display font-bold text-2xl">Choose a new password</h1>
+				<p className="text-sm text-muted-foreground mt-1">At least 8 characters.</p>
+			</div>
+			<form onSubmit={handleSubmit} className="space-y-3">
+				<div>
+					<Label htmlFor="password-reset">New password</Label>
+					<Input
+						id="password-reset"
+						name="password"
+						type="password"
+						required
+						minLength={8}
+						autoComplete="new-password"
+						autoFocus
+					/>
+				</div>
+				<div>
+					<Label htmlFor="confirm-reset">Confirm password</Label>
+					<Input
+						id="confirm-reset"
+						name="confirm"
+						type="password"
+						required
+						minLength={8}
+						autoComplete="new-password"
+					/>
+				</div>
+				{error && <p className="text-sm text-[var(--eliminated)]">{error}</p>}
+				<Button type="submit" className="w-full" disabled={loading}>
+					{loading ? 'Updating...' : 'Update password'}
+				</Button>
+			</form>
+			<div className="mt-6 text-center">
+				<Link
+					href="/auth"
+					className="text-sm text-muted-foreground hover:text-foreground underline"
+				>
+					Back to sign in
+				</Link>
+			</div>
+		</Card>
+	)
+}

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -4,4 +4,5 @@ export const authClient = createAuthClient({
 	baseURL: process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000',
 })
 
-export const { signIn, signUp, signOut, useSession } = authClient
+export const { signIn, signUp, signOut, useSession, requestPasswordReset, resetPassword } =
+	authClient

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import { betterAuth } from 'better-auth'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { db } from './db'
+import { sendPasswordResetEmail } from './email'
 
 export const auth = betterAuth({
 	database: drizzleAdapter(db, {
@@ -8,6 +9,18 @@ export const auth = betterAuth({
 	}),
 	emailAndPassword: {
 		enabled: true,
+		// `url` already contains the token + redirectTo the client passed in.
+		// Fire-and-forget per Better Auth guidance: awaiting would let attackers
+		// learn whether an email exists by comparing response times. The function
+		// signature requires Promise<void>, so we return immediately while the
+		// email send runs in the background.
+		sendResetPassword: async ({ user, url }) => {
+			void sendPasswordResetEmail({
+				to: user.email,
+				resetUrl: url,
+				displayName: user.name,
+			})
+		},
 	},
 	session: {
 		expiresIn: 60 * 60 * 24 * 7, // 7 days

--- a/src/lib/email.test.ts
+++ b/src/lib/email.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { sendMock } = vi.hoisted(() => ({ sendMock: vi.fn() }))
+
+vi.mock('resend', () => {
+	class ResendMock {
+		emails = { send: sendMock }
+	}
+	return { Resend: ResendMock }
+})
+
+describe('sendPasswordResetEmail', () => {
+	const originalKey = process.env.RESEND_API_KEY
+
+	beforeEach(() => {
+		sendMock.mockReset()
+		sendMock.mockResolvedValue({ data: { id: 'msg_123' }, error: null })
+		vi.resetModules()
+	})
+
+	afterEach(() => {
+		if (originalKey === undefined) delete process.env.RESEND_API_KEY
+		else process.env.RESEND_API_KEY = originalKey
+	})
+
+	it('sends an email with the reset URL when RESEND_API_KEY is set', async () => {
+		process.env.RESEND_API_KEY = 're_test_key'
+		const { sendPasswordResetEmail } = await import('./email')
+
+		await sendPasswordResetEmail({
+			to: 'user@example.com',
+			resetUrl: 'https://lps.example/reset?token=abc',
+			displayName: 'Alice',
+		})
+
+		expect(sendMock).toHaveBeenCalledTimes(1)
+		const call = sendMock.mock.calls[0][0]
+		expect(call.to).toBe('user@example.com')
+		expect(call.subject).toMatch(/reset/i)
+		expect(call.text).toContain('https://lps.example/reset?token=abc')
+		expect(call.text).toContain('Alice')
+		expect(call.from).toContain('onboarding@resend.dev')
+	})
+
+	it('uses a generic greeting when no displayName is supplied', async () => {
+		process.env.RESEND_API_KEY = 're_test_key'
+		const { sendPasswordResetEmail } = await import('./email')
+
+		await sendPasswordResetEmail({
+			to: 'user@example.com',
+			resetUrl: 'https://lps.example/reset?token=abc',
+		})
+
+		const call = sendMock.mock.calls[0][0]
+		expect(call.text).toMatch(/^Hi,/)
+	})
+
+	it('throws when Resend returns an error so callers can log it', async () => {
+		process.env.RESEND_API_KEY = 're_test_key'
+		sendMock.mockResolvedValue({ data: null, error: { message: 'rate limited' } })
+		const { sendPasswordResetEmail } = await import('./email')
+
+		await expect(
+			sendPasswordResetEmail({
+				to: 'user@example.com',
+				resetUrl: 'https://lps.example/reset?token=abc',
+			}),
+		).rejects.toThrow(/rate limited/)
+	})
+
+	it('falls back to logging when RESEND_API_KEY is missing (local dev sandbox)', async () => {
+		delete process.env.RESEND_API_KEY
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+		const { sendPasswordResetEmail } = await import('./email')
+
+		await sendPasswordResetEmail({
+			to: 'user@example.com',
+			resetUrl: 'https://lps.example/reset?token=abc',
+		})
+
+		expect(sendMock).not.toHaveBeenCalled()
+		expect(warnSpy).toHaveBeenCalled()
+		const messages = warnSpy.mock.calls.map((c) => c.join(' '))
+		expect(messages.some((m) => m.includes('https://lps.example/reset?token=abc'))).toBe(true)
+		warnSpy.mockRestore()
+	})
+})

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,63 @@
+import { Resend } from 'resend'
+
+// Resend is provisioned via the Vercel Marketplace integration, which writes
+// RESEND_API_KEY directly into Vercel envs (prod + preview). This bypasses
+// the project's usual Doppler→Vercel sync — see AGENTS.md.
+//
+// For local dev: `vercel env pull` populates .env.local with the same key.
+// If RESEND_API_KEY is missing, the wrapper logs the email instead of sending
+// so flows still work without a key.
+
+const FROM_ADDRESS = 'Last Person Standing <onboarding@resend.dev>'
+// onboarding@resend.dev is Resend's shared sandbox sender. Works without DNS
+// verification but only delivers to the workspace owner's email address. When
+// a custom domain is verified, swap this for noreply@<domain>.
+
+let resendClient: Resend | null = null
+function getResend(): Resend | null {
+	const key = process.env.RESEND_API_KEY
+	if (!key) return null
+	if (!resendClient) resendClient = new Resend(key)
+	return resendClient
+}
+
+export interface PasswordResetEmailArgs {
+	to: string
+	resetUrl: string
+	displayName?: string
+}
+
+export async function sendPasswordResetEmail(args: PasswordResetEmailArgs): Promise<void> {
+	const { to, resetUrl, displayName } = args
+	const greeting = displayName ? `Hi ${displayName},` : 'Hi,'
+	const text = [
+		greeting,
+		'',
+		'You asked to reset your password for Last Person Standing.',
+		'',
+		`Open this link to set a new one (expires in 1 hour):`,
+		resetUrl,
+		'',
+		"If you didn't ask for this, ignore this email — your password stays the same.",
+		'',
+		'— Last Person Standing',
+	].join('\n')
+
+	const resend = getResend()
+	if (!resend) {
+		console.warn('[email] RESEND_API_KEY not set — logging instead of sending')
+		console.warn(`[email] to=${to} resetUrl=${resetUrl}`)
+		return
+	}
+
+	const { error } = await resend.emails.send({
+		from: FROM_ADDRESS,
+		to,
+		subject: 'Reset your Last Person Standing password',
+		text,
+	})
+	if (error) {
+		console.error('[email] resend.emails.send failed', { to, error })
+		throw new Error(`Failed to send password reset email: ${error.message ?? 'unknown error'}`)
+	}
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,12 +4,14 @@ import { auth } from '@/lib/auth'
 
 // Paths that bypass the Better Auth session check in this proxy.
 // /auth — login page renders for unauthenticated users.
+// /forgot-password, /reset-password — password reset flow needs to be reachable
+//   without a session (the whole point — user has forgotten how to sign in).
 // /api/auth — Better Auth's own request handler.
 // /api/cron — every route under this checks CRON_SECRET (or QStash signature
 //   for qstash-handler) at the route level. The proxy must let them through
 //   so route-level auth can run; otherwise GitHub Actions and QStash callbacks
 //   get redirected to /auth.
-const publicPaths = ['/auth', '/api/auth', '/api/cron']
+const publicPaths = ['/auth', '/forgot-password', '/reset-password', '/api/auth', '/api/cron']
 
 export const config = {
 	matcher: ['/((?!_next/static|_next/image|favicon.ico|public).*)'],


### PR DESCRIPTION
## Summary

Adds the password-reset flow that's been on the deferred list since Phase 4.5. Users who forget their password hit "Forgot?" on the sign-in page, receive a reset link by email, choose a new password, and sign back in.

- **Email transport**: Resend, via the Vercel Marketplace integration (auto-provisions `RESEND_API_KEY` into prod + preview Vercel envs — bypasses Doppler intentionally, documented in AGENTS.md).
- **Sender**: `onboarding@resend.dev` as a starting sandbox sender — works without DNS verification but only delivers to the Resend workspace owner's email. Swap for a custom-domain sender once a domain is verified.
- **Routing**: dedicated `/forgot-password` + `/reset-password` routes, added to the proxy public-paths list.
- **Dev experience**: if `RESEND_API_KEY` is absent (local without `vercel env pull`), the wrapper logs the reset URL to stdout instead of dispatching. The whole flow still works locally without an internet round-trip.

## Anti-enumeration posture

- Server-side `sendResetPassword` is fire-and-forget (Better Auth guidance — awaiting leaks "email exists" via timing).
- Client always shows the same "check your inbox" screen, whether the email is known or not (mirrors Better Auth's silent no-op on unknown emails).
- Reset tokens are short-lived (Better Auth default: 1 hour).

## Verification

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 430/430 (4 new tests in `src/lib/email.test.ts` cover happy path, generic greeting, Resend-error path, missing-key fallback)
- [x] `just smoke` — 24/24
- [x] `pnpm build` — succeeds
- [x] **Manual end-to-end in dev** (the step I skipped on PR #55; *not* skipping again):
  1. `POST /api/auth/request-password-reset` → `200`, reset URL logged
  2. `GET` the logged link → `302` redirect to `/reset-password?token=…` with the validated token
  3. `POST /api/auth/reset-password` with new password → `200`
  4. Sign in with **old** password → `401 INVALID_EMAIL_OR_PASSWORD`
  5. Sign in with **new** password → `200` + session cookie

  Steps 4 + 5 are the proof the password actually changed.

## After merge — user actions needed

1. Install the **Resend** integration via the Vercel Marketplace. That auto-provisions `RESEND_API_KEY` into prod + preview Vercel envs.
2. Until a custom domain is verified in Resend, password-reset emails only reach the Resend workspace owner's address. Verify yourself first, then optionally verify a real sender domain to widen delivery.

## Out of scope (deliberately)

- Email verification on signup, magic-link sign-in, social providers — separate features.
- Switching `onboarding@resend.dev` → `noreply@<custom-domain>` — flip the constant in `src/lib/email.ts` once a domain is verified in Resend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)