### PR TITLE
fix(share): drop invite blurb from image share, use per-variant caption

### DIFF
--- a/src/components/game/share-dialog.tsx
+++ b/src/components/game/share-dialog.tsx
@@ -40,6 +40,22 @@ const VARIANT_LABEL: Record<Variant, string> = {
 	winner: 'Winner',
 }
 
+// Captions for native share sheets when sending the image to existing
+// players. NOT the same as the invite blurb — when you share a standings
+// screenshot to your group chat, you don't want "Join me in <game>" tacked
+// onto it. The invite blurb stays on the dedicated WhatsApp invite button
+// up top.
+function captionFor(variant: Variant, gameName: string): string {
+	switch (variant) {
+		case 'standings':
+			return `${gameName} — standings`
+		case 'live':
+			return `${gameName} — live update`
+		case 'winner':
+			return `${gameName} — winner 🏆`
+	}
+}
+
 export function ShareDialog({
 	open,
 	onOpenChange,
@@ -103,7 +119,7 @@ export function ShareDialog({
 			await navigator.share({
 				files: [file],
 				title: `${gameName} — ${VARIANT_LABEL[variant]}`,
-				text: inviteMessage,
+				text: captionFor(variant, gameName),
 			})
 		} catch (err) {
 			// AbortError fires when the user dismisses the native sheet — treat


### PR DESCRIPTION
## Summary

Follow-up to PR #58. The native Share button was sending the *invite* blurb (\"Join me in <game> on Last Person Standing — £X pot. <inviteUrl>\") alongside every shared image. Wrong context — when someone screenshots standings to send to the group chat of existing players, those people are already in the game; they don't need the invite link or the join CTA.

Replaced with a short variant-specific caption:

| Variant   | Caption                       |
| --------- | ----------------------------- |
| standings | \`<gameName> — standings\`         |
| live      | \`<gameName> — live update\`       |
| winner    | \`<gameName> — winner 🏆\`         |

The dedicated **Share invite to WhatsApp** button at the top of the dialog still uses the invite blurb — that's the correct surface for it.

## Verification

- [x] \`pnpm typecheck\` clean
- [ ] On-device check post-merge: open share sheet on phone, confirm the WhatsApp draft caption now reads \"<game name> — standings\" instead of the invite blurb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)