### PR TITLE
chore: production URL is now https://last-person-standing.app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Football survivor picks game — private games where friends pick teams each rou
 - **Auth:** Better Auth (email + password, database-backed sessions)
 - **UI:** shadcn/ui + Tailwind CSS
 - **Testing:** Vitest
-- **Deployment:** Vercel (lhr1 region) — production: <https://last-person-standing-theta.vercel.app> (live since Phase 4.5, 2026-04-28)
+- **Deployment:** Vercel (lhr1 region) — production: <https://last-person-standing.app> (custom domain since 2026-06-04; `last-person-standing-theta.vercel.app` 308-redirects to it for backwards compatibility)
 
 ## Commands
 


### PR DESCRIPTION
Doc-only update reflecting today's domain migration. The actual functional change is the env vars in Doppler prd:
- \`NEXT_PUBLIC_APP_URL\` → \`https://last-person-standing.app\`
- \`BETTER_AUTH_URL\` → \`https://last-person-standing.app\`

This PR exists to **trigger a production redeploy** so the new \`NEXT_PUBLIC_APP_URL\` gets baked into the client JS bundle. Without a redeploy the build would still ship the old value.

theta.vercel.app stays alive as a 308 redirect (configured separately in the Vercel UI after this deploy lands and the new domain is verified working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)