### PR TITLE
fix(auth): password reset email never reached Resend on Vercel (next/server after)

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import { betterAuth } from 'better-auth'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
+import { after } from 'next/server'
 import { db } from './db'
 import { sendPasswordResetEmail } from './email'
 
@@ -9,17 +10,21 @@ export const auth = betterAuth({
 	}),
 	emailAndPassword: {
 		enabled: true,
-		// `url` already contains the token + redirectTo the client passed in.
-		// Fire-and-forget per Better Auth guidance: awaiting would let attackers
-		// learn whether an email exists by comparing response times. The function
-		// signature requires Promise<void>, so we return immediately while the
-		// email send runs in the background.
+		// Anti-enumeration via timing attacks: never await the email send, or
+		// attackers can compare response times for known vs unknown emails.
+		// next/server's `after()` schedules the work to run AFTER the response
+		// has been flushed — but keeps the serverless function alive until it
+		// settles. A bare `void` looked equivalent but Vercel can tear the
+		// function down the instant the response goes out, killing the in-
+		// flight fetch to Resend before it lands (PR #61 → #62 incident).
 		sendResetPassword: async ({ user, url }) => {
-			void sendPasswordResetEmail({
-				to: user.email,
-				resetUrl: url,
-				displayName: user.name,
-			})
+			after(
+				sendPasswordResetEmail({
+					to: user.email,
+					resetUrl: url,
+					displayName: user.name,
+				}),
+			)
 		},
 	},
 	session: {


### PR DESCRIPTION
## Bug

Smoke test against prod after PR #61:
- Hit /forgot-password with an existing account email
- Server returned 200
- No email arrived; Resend dashboard showed zero invocations

## Root cause

In \`src/lib/auth.ts\` the \`sendResetPassword\` handler fires-and-forgets with a bare \`void\`:

\`\`\`ts
sendResetPassword: async ({ user, url }) => {
  void sendPasswordResetEmail({ ... })
}
\`\`\`

On a long-lived server this works fine. **On Vercel serverless, the function instance can be torn down the instant the 200 response flushes** — killing the in-flight \`fetch\` to Resend before it lands.

Better Auth's docs explicitly call this out:
> Avoid awaiting the email sending to prevent timing attacks. Consider using \`waitUntil\` on serverless platforms.

I skipped the "consider using waitUntil" half in PR #57.

## Fix

Use Next.js's \`after()\` (stable since 15, exported from \`next/server\`):

\`\`\`ts
sendResetPassword: async ({ user, url }) => {
  after(sendPasswordResetEmail({ ... }))
}
\`\`\`

This schedules the email send to run **after** the response is flushed (preserving the anti-timing-attack guarantee) but **keeps the function alive until the work settles**. No new dependency.

## Why tests missed this (again)

The 4 \`src/lib/email.test.ts\` cases mock Resend synchronously — the bug only manifests under real serverless runtime conditions where the function lifecycle vs network round-trip races.

Caught by the manual post-deploy smoke (which we did this time, per the discipline established by PR #56's \`feedback_verify_ui_before_pr\`). Would be a runtime-only end-to-end test to guard structurally — heavy for a single code path, not worth it yet. Manual smoke remains the safety net.

## Post-merge

Same test as before: hit /forgot-password with your account email, watch for the email + the Resend dashboard event. If it lands, we're done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)