### PR TITLE
fix(game-header): keep title + pot side-by-side on mobile

### DIFF
--- a/src/components/game/game-header.tsx
+++ b/src/components/game/game-header.tsx
@@ -49,7 +49,7 @@ export function GameHeader({
 
 	return (
 		<div className="mb-6 bg-card border border-border rounded-xl overflow-hidden">
-			<div className="p-5 flex flex-wrap items-start justify-between gap-4">
+			<div className="p-5 flex items-start justify-between gap-3 md:gap-4">
 				<div className="min-w-0">
 					<h1 className="font-display text-2xl md:text-3xl font-semibold leading-tight">{name}</h1>
 					<p className="text-sm text-muted-foreground mt-1">
@@ -68,10 +68,10 @@ export function GameHeader({
 						<div className="text-[0.65rem] uppercase tracking-wider text-muted-foreground font-semibold">
 							Pot (confirmed)
 						</div>
-						<div className="font-display text-3xl md:text-4xl font-bold leading-none">
+						<div className="font-display text-2xl md:text-4xl font-bold leading-none">
 							£{potBreakdown.confirmed}
 						</div>
-						<div className="text-[0.7rem] text-muted-foreground mt-1 max-w-[200px] leading-relaxed">
+						<div className="text-[0.7rem] text-muted-foreground mt-1 max-w-[150px] md:max-w-[200px] leading-relaxed">
 							{hasPending && <span>£{potBreakdown.pending} pending · </span>}
 							{hasUnpaid && <span>£{unpaid} unpaid · </span>}
 							<span>£{target} target</span>


### PR DESCRIPTION
## What

On mobile the game header's title and pot took up too much vertical space because the pot block wrapped onto its own line, stacked below the title.

## Change

`src/components/game/game-header.tsx` — top row only:
- Removed `flex-wrap` so the title and pot stay on a single row. The title column already has `min-w-0`, so a long name wraps/shrinks within its own column instead of forcing the pot underneath.
- Pot figure is `text-2xl` on mobile (`md:text-4xl` unchanged) so it fits beside the title in the narrower space.
- Pot detail line caps at `max-w-[150px]` on mobile (`md:max-w-[200px]` unchanged).

Desktop layout is unaffected (the row was already side-by-side there via `justify-between`).

## Verification

- `tsc --noEmit` — passes
- `biome check` — clean

CSS-only change within an existing client component. Worth an eyeball on a narrow viewport with a long game name + large pot before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)