### PR TITLE
fix(wc): alias WC pot names to football-data + fail loud on untagged team

### DIFF
--- a/src/lib/data/wc-pots.test.ts
+++ b/src/lib/data/wc-pots.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getPotFor, potForTeamName, WC_2026_POTS } from './wc-pots'
+import { FD_NAME_TO_WC_POT_NAME, getPotFor, potForTeamName, WC_2026_POTS } from './wc-pots'
 
 describe('WC 2026 pot data', () => {
 	it('has exactly 48 teams', () => {
@@ -39,5 +39,43 @@ describe('WC 2026 pot data', () => {
 	it('potForTeamName is case insensitive', () => {
 		const first = WC_2026_POTS[0]
 		expect(potForTeamName(first.name.toUpperCase())).toBe(first.pot)
+	})
+
+	it('potForTeamName returns null for an unknown name', () => {
+		expect(potForTeamName('Italy')).toBeNull()
+	})
+
+	describe('FD_NAME_TO_WC_POT_NAME alias map', () => {
+		it('every alias target is a real WC_2026_POTS name', () => {
+			// A typo in a value would make the alias resolve to nothing — guard it.
+			const potNames = new Set(WC_2026_POTS.map((t) => t.name.toLowerCase()))
+			for (const [alias, target] of Object.entries(FD_NAME_TO_WC_POT_NAME)) {
+				expect(potNames.has(target.toLowerCase()), `alias "${alias}" → "${target}"`).toBe(true)
+			}
+		})
+
+		it('every alias resolves to a pot via potForTeamName', () => {
+			for (const alias of Object.keys(FD_NAME_TO_WC_POT_NAME)) {
+				expect(potForTeamName(alias), `alias "${alias}"`).not.toBeNull()
+			}
+		})
+
+		it('keys are stored lower-cased so case-insensitive lookup hits them', () => {
+			for (const key of Object.keys(FD_NAME_TO_WC_POT_NAME)) {
+				expect(key).toBe(key.toLowerCase())
+			}
+		})
+
+		it('resolves the known assumed mismatches to the right pot', () => {
+			// Spot-check the headline cases from issue #67. These spellings are
+			// ASSUMPTIONS pending the #65 spike (see TODO in wc-pots.ts).
+			expect(potForTeamName('Korea Republic')).toBe(potForTeamName('South Korea'))
+			expect(potForTeamName('Czech Republic')).toBe(potForTeamName('Czechia'))
+			expect(potForTeamName('Türkiye')).toBe(potForTeamName('Turkey'))
+			expect(potForTeamName('Cape Verde')).toBe(potForTeamName('Cape Verde Islands'))
+			expect(potForTeamName('DR Congo')).toBe(potForTeamName('Congo DR'))
+			expect(potForTeamName('Bosnia and Herzegovina')).toBe(potForTeamName('Bosnia-Herzegovina'))
+			expect(potForTeamName('Curacao')).toBe(potForTeamName('Curaçao'))
+		})
 	})
 })

--- a/src/lib/data/wc-pots.ts
+++ b/src/lib/data/wc-pots.ts
@@ -84,11 +84,78 @@ export const WC_2026_POTS: WcTeamPot[] = [
 	{ footballDataId: '', name: 'Iraq', pot: 4 },
 ]
 
+/**
+ * Maps a football-data.org canonical team name → the `name` we use in
+ * WC_2026_POTS. Mirrors the `FPL_TO_FD_TLA` pattern in
+ * `bootstrap-competitions.ts`: a small hand-maintained bridge for the cases
+ * where our reference list and the data source disagree on a country's name.
+ *
+ * Key is the football-data name (lower-cased at lookup time), value is the
+ * matching `WC_2026_POTS[].name`. `applyPotAssignments` consults this before
+ * falling back to a direct name match, so a WC team whose football-data name
+ * differs from our list still resolves to a pot.
+ *
+ * ┌──────────────────────────────────────────────────────────────────────┐
+ * │ TODO(#65 — UNVERIFIED ASSUMPTIONS, Sean to confirm against live feed): │
+ * │                                                                        │
+ * │ Every entry below is an EDUCATED GUESS at football-data.org's          │
+ * │ canonical WC team name. This branch was written WITHOUT live           │
+ * │ football-data creds, so NONE of these strings have been checked        │
+ * │ against an actual /competitions/WC/matches response. The #65 spike     │
+ * │ dumps the real team names — reconcile this map against that dump and   │
+ * │ delete / correct any entry that doesn't match. If football-data        │
+ * │ actually returns the same name we already use, drop that entry         │
+ * │ (the direct name match handles it).                                    │
+ * │                                                                        │
+ * │ Assumed aliases (football-data name → our WC_2026_POTS name):          │
+ * │   'Korea Republic'            → 'South Korea'                          │
+ * │   'Czech Republic'            → 'Czechia'                              │
+ * │   'Türkiye' / 'Turkiye'       → 'Turkey'                               │
+ * │   'Cape Verde'                → 'Cape Verde Islands'                   │
+ * │   'DR Congo' / 'Congo DR'     → 'Congo DR'                             │
+ * │   'Bosnia and Herzegovina' /                                           │
+ * │     'Bosnia-Herzegovina'      → 'Bosnia-Herzegovina'                   │
+ * │   'Curacao'                   → 'Curaçao' (ASCII fallback for the ç)   │
+ * │   'Côte d'Ivoire' / 'Cote d'Ivoire' /                                │
+ * │     'Ivory Coast'             → 'Ivory Coast'                          │
+ * │   'USA' / 'United States of America' → 'United States'                │
+ * │                                                                        │
+ * │ Entries that map a name onto itself are defensive no-ops — harmless    │
+ * │ if football-data already matches our list, but they keep the full set  │
+ * │ of guessed spellings documented in one place for the #65 reconcile.    │
+ * └──────────────────────────────────────────────────────────────────────┘
+ */
+export const FD_NAME_TO_WC_POT_NAME: Record<string, string> = {
+	'korea republic': 'South Korea',
+	'czech republic': 'Czechia',
+	türkiye: 'Turkey',
+	turkiye: 'Turkey',
+	'cape verde': 'Cape Verde Islands',
+	'dr congo': 'Congo DR',
+	'congo dr': 'Congo DR',
+	'bosnia and herzegovina': 'Bosnia-Herzegovina',
+	'bosnia-herzegovina': 'Bosnia-Herzegovina',
+	curacao: 'Curaçao',
+	'ivory coast': 'Ivory Coast',
+	"côte d'ivoire": 'Ivory Coast',
+	"cote d'ivoire": 'Ivory Coast',
+	usa: 'United States',
+	'united states of america': 'United States',
+}
+
 export function getPotFor(footballDataId: string): FifaPot | null {
 	if (!footballDataId) return null
 	return WC_2026_POTS.find((t) => t.footballDataId === footballDataId)?.pot ?? null
 }
 
+/**
+ * Resolve a football-data team name to a FIFA pot. Tries, in order:
+ *   1. the alias map (football-data name → our reference name), then
+ *   2. a direct case-insensitive match against WC_2026_POTS[].name.
+ * Returns null when neither resolves — callers treat that as "untagged".
+ */
 export function potForTeamName(name: string): FifaPot | null {
-	return WC_2026_POTS.find((t) => t.name.toLowerCase() === name.toLowerCase())?.pot ?? null
+	const aliased = FD_NAME_TO_WC_POT_NAME[name.toLowerCase()]
+	const target = (aliased ?? name).toLowerCase()
+	return WC_2026_POTS.find((t) => t.name.toLowerCase() === target)?.pot ?? null
 }

--- a/src/lib/game/apply-pot-assignments.test.ts
+++ b/src/lib/game/apply-pot-assignments.test.ts
@@ -13,6 +13,7 @@ const { dbMock } = vi.hoisted(() => ({
 }))
 vi.mock('@/lib/db', () => ({ db: dbMock }))
 
+import { WC_2026_POTS } from '@/lib/data/wc-pots'
 import { applyPotAssignments } from './bootstrap-competitions'
 
 describe('applyPotAssignments', () => {
@@ -53,8 +54,7 @@ describe('applyPotAssignments', () => {
 		expect(result.unmatched).toEqual([])
 	})
 
-	it('reports unmatched teams (e.g. unfilled playoff winner)', async () => {
-		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+	it('THROWS naming the unmatched team(s) when any WC team has no pot', async () => {
 		dbMock.query.round.findMany.mockResolvedValue([
 			{
 				fixtures: [{ homeTeamId: 't-known', awayTeamId: 't-unknown' }],
@@ -65,13 +65,53 @@ describe('applyPotAssignments', () => {
 			{ id: 't-unknown', name: 'Italy', externalIds: {} }, // not in WC_2026_POTS
 		] as never)
 
+		// Fail-loud: an untagged WC team blocks cup creation + zeroes tier-diff,
+		// so we surface it at sync time rather than warning and limping on.
+		await expect(applyPotAssignments('c1')).rejects.toThrow(/Italy/)
+	})
+
+	it('resolves football-data canonical names via the alias map', async () => {
+		// These are the names football-data is assumed to return that differ from
+		// WC_2026_POTS — they must resolve through FD_NAME_TO_WC_POT_NAME, not the
+		// direct name match. (Assumed spellings; see TODO(#65) in wc-pots.ts.)
+		dbMock.query.round.findMany.mockResolvedValue([
+			{
+				fixtures: [
+					{ homeTeamId: 't-kor', awayTeamId: 't-cze' },
+					{ homeTeamId: 't-tur', awayTeamId: 't-cgo' },
+				],
+			},
+		] as never)
+		dbMock.query.team.findMany.mockResolvedValue([
+			{ id: 't-kor', name: 'Korea Republic', externalIds: {} },
+			{ id: 't-cze', name: 'Czech Republic', externalIds: {} },
+			{ id: 't-tur', name: 'Türkiye', externalIds: {} },
+			{ id: 't-cgo', name: 'DR Congo', externalIds: {} },
+		] as never)
+
+		const result = await applyPotAssignments('c1')
+		expect(result.matched).toBe(4)
+		expect(result.unmatched).toEqual([])
+	})
+
+	it('prefers football-data ID over name when WC_2026_POTS is backfilled', async () => {
+		// Team name is deliberately wrong; only a backfilled ID can match it.
+		// Skips automatically while WC_2026_POTS carries no footballDataId (today).
+		const withId = WC_2026_POTS.find((p) => p.footballDataId)
+		if (!withId) return
+		dbMock.query.round.findMany.mockResolvedValue([
+			{ fixtures: [{ homeTeamId: 't', awayTeamId: 't' }] },
+		] as never)
+		dbMock.query.team.findMany.mockResolvedValue([
+			{
+				id: 't',
+				name: 'Not A Real Country Name',
+				externalIds: { football_data: withId.footballDataId },
+			},
+		] as never)
+
 		const result = await applyPotAssignments('c1')
 		expect(result.matched).toBe(1)
-		expect(result.unmatched).toEqual(['Italy'])
-		expect(warn).toHaveBeenCalledWith(
-			expect.stringContaining('not in WC_2026_POTS'),
-			expect.stringContaining('Italy'),
-		)
-		warn.mockRestore()
+		expect(result.unmatched).toEqual([])
 	})
 })

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -3,7 +3,7 @@ import { FootballDataAdapter } from '@/lib/data/football-data'
 import { FplAdapter, type FplPreFetched } from '@/lib/data/fpl'
 import { enqueuePollScoresAt } from '@/lib/data/qstash'
 import type { CompetitionAdapter } from '@/lib/data/types'
-import { WC_2026_POTS } from '@/lib/data/wc-pots'
+import { type FifaPot, potForTeamName, WC_2026_POTS } from '@/lib/data/wc-pots'
 import { db } from '@/lib/db'
 import { settleFixture } from '@/lib/game/settle'
 import { competition, fixture, round, team } from '@/lib/schema/competition'
@@ -463,30 +463,40 @@ export async function applyPotAssignments(
 	const unmatched: string[] = []
 	for (const t of teams) {
 		const fdId = (t.externalIds as Record<string, string | number> | null)?.football_data
-		// Match by football-data ID first (when WC_2026_POTS has been backfilled
-		// from /competitions/WC/teams), fall back to team name. Name matching
-		// covers the common case today: pots are seeded with names only and
-		// football-data uses canonical country names that align with the list.
-		const entry =
+		// Resolve a pot in three tiers, preferring the most precise:
+		//   1. football-data ID — exact, used once WC_2026_POTS[].footballDataId
+		//      is backfilled from /competitions/WC/teams (the #65 spike).
+		//   2. name alias map — bridges the cases where football-data's canonical
+		//      name differs from our reference list (see FD_NAME_TO_WC_POT_NAME).
+		//   3. direct name match — the common case where the names already align.
+		// potForTeamName() folds tiers 2 and 3 together (alias-then-name).
+		const pot: FifaPot | null =
 			(fdId
-				? WC_2026_POTS.find((p) => p.footballDataId && p.footballDataId === String(fdId))
-				: undefined) ?? WC_2026_POTS.find((p) => p.name.toLowerCase() === t.name.toLowerCase())
-		if (!entry) {
+				? (WC_2026_POTS.find((p) => p.footballDataId && p.footballDataId === String(fdId))?.pot ??
+					null)
+				: null) ?? potForTeamName(t.name)
+		if (pot == null) {
 			unmatched.push(t.name)
 			continue
 		}
 		await db
 			.update(team)
 			.set({
-				externalIds: { ...(t.externalIds ?? {}), fifa_pot: entry.pot },
+				externalIds: { ...(t.externalIds ?? {}), fifa_pot: pot },
 			})
 			.where(eq(team.id, t.id))
 		matched++
 	}
+	// Fail loudly. A WC team with no pot makes cup-tier maths silently return 0
+	// (so underdog picks go unrewarded) AND blocks cup game creation entirely
+	// (api/games refuses when any team lacks fifa_pot). Both are silent-until-
+	// someone-tries-to-play failures, so we surface the gap at sync time instead.
+	// Mirrors mergeFootballDataIds, which throws on missing football-data IDs.
+	// The likely cause is a football-data name that isn't in WC_2026_POTS or its
+	// FD_NAME_TO_WC_POT_NAME alias map — the error names the unmatched team(s).
 	if (unmatched.length > 0) {
-		console.warn(
-			`[bootstrap] ${unmatched.length} WC team(s) not in WC_2026_POTS — cup tier-difference will be 0:`,
-			unmatched.join(', '),
+		throw new Error(
+			`applyPotAssignments: ${unmatched.length}/${teams.length} WC team(s) have no FIFA pot — cup mode would be uncreatable and tier-diff would silently be 0: ${unmatched.join(', ')}. Add the team(s) to WC_2026_POTS, or add a football-data name alias to FD_NAME_TO_WC_POT_NAME in src/lib/data/wc-pots.ts.`,
 		)
 	}
 	return { matched, unmatched }


### PR DESCRIPTION
Closes #67.

## Problem

All 48 `WC_2026_POTS` entries have an empty `footballDataId`, so `applyPotAssignments` matched teams by **exact lower-cased name only**. Several of our reference names won't match what football-data.org returns (e.g. South Korea → "Korea Republic", Czechia → "Czech Republic", Turkey → "Türkiye", plus Cape Verde Islands, Congo DR, Bosnia-Herzegovina, Curaçao, Ivory Coast). Any single mismatch leaves a WC team untagged, which:

- **blocks cup game creation entirely** — `/api/games` refuses to create a cup game when any team lacks `fifa_pot`, and
- **silently zeroes cup tier-diff maths** — `cup-tier.ts` reads `external_ids.fifa_pot` and returns 0 when missing, so underdog picks go unrewarded.

The old code only `console.warn`ed on a gap, so this would surface only when someone tried to create a cup game.

## Fix (structural)

- **Name alias map.** New `FD_NAME_TO_WC_POT_NAME` in `src/lib/data/wc-pots.ts`, mirroring the existing `FPL_TO_FD_TLA` pattern in `bootstrap-competitions.ts`. `potForTeamName` now resolves **alias → direct name**.
- **Three-tier matching** in `applyPotAssignments`: football-data ID → alias → name (ID-first, ready for when #65 backfills IDs).
- **Fail loud.** `applyPotAssignments` now **throws** (was warn-only) when any WC team remains untagged, naming the team(s). Same contract as `mergeFootballDataIds`. It still returns `{ matched, unmatched }` on success, and short-circuits to `{0, []}` when the WC competition has no fixtures yet (pre-draw), so it only throws once real teams exist.

## ⚠️ Unverified assumptions — needs #65 to confirm

I do **not** have prod football-data creds, so **none of the alias spellings have been checked against a real `/competitions/WC/matches` response.** Every entry in `FD_NAME_TO_WC_POT_NAME` is an educated guess. A prominent `TODO(#65)` block in `src/lib/data/wc-pots.ts` lists each assumed alias for reconciliation once the #65 spike dumps the real team names. The *structure* (alias map + fail-loud) is the deliverable; the exact strings are the part to verify.

## Tests

- `apply-pot-assignments.test.ts`: rewrote the warn-only case to assert it **throws** naming the team; added alias-resolution and ID-preference cases.
- `wc-pots.test.ts`: added alias-map invariants (every target is a real pot name, every alias resolves, keys are lower-cased) plus spot-checks of the headline mismatches.

## Gates

- `just typecheck` ✅
- `just lint` ✅ (3 pre-existing warnings in untouched files; my 4 files are clean)
- `just test` ✅ 441 passed
- `just build` ✅
- `just smoke` ✅ 24 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)