### PR TITLE
fix(cup): never crown an eliminated player; wipeout refunds the pot

### DIFF
--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -29,6 +29,7 @@ import {
 import { settleFixture } from '@/lib/game/settle'
 import { round as roundTable } from '@/lib/schema/competition'
 import { game, gamePlayer, pick } from '@/lib/schema/game'
+import { payment, payout } from '@/lib/schema/payment'
 import {
 	finishFixture,
 	liveFixture,
@@ -443,6 +444,66 @@ describe('lifecycle: cup-WC', () => {
 
 		// Same pick results, same lives, same statuses.
 		expect(afterSecond.map((p) => p.result).sort()).toEqual(afterFirst.map((p) => p.result).sort())
+	})
+
+	it('cup wipeout: everyone busts → NO winner, pot refunded, no payout, game completed', async () => {
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		const fav = await makeTeam({ name: 'Favourite', shortName: 'FAV', fifaPot: 1 })
+		const dog = await makeTeam({ name: 'Underdog', shortName: 'DOG', fifaPot: 4 })
+		const r1 = await makeRound(compId, { number: 1, status: 'open' })
+		const fx = await makeFixture({ roundId: r1, homeTeamId: fav, awayTeamId: dog })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'cup',
+			currentRoundId: r1,
+			modeConfig: { numberOfPicks: 1, startingLives: 0 },
+		})
+		const gpA = await makePlayer({ gameId, userId: 'u-a', livesRemaining: 0 })
+		const gpB = await makePlayer({ gameId, userId: 'u-b', livesRemaining: 0 })
+		// Both back the underdog (away) — a legal cup pick — and the underdog
+		// LOSES, so both players' streaks break with no lives left → everyone out.
+		await makePick({
+			gameId,
+			gamePlayerId: gpA,
+			roundId: r1,
+			teamId: dog,
+			fixtureId: fx,
+			confidenceRank: 1,
+			predictedResult: 'away_win',
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpB,
+			roundId: r1,
+			teamId: dog,
+			fixtureId: fx,
+			confidenceRank: 1,
+			predictedResult: 'away_win',
+		})
+		// Two collected entry payments form the pot.
+		await db.insert(payment).values([
+			{ gameId, userId: 'u-a', amount: '10.00', status: 'paid', paidAt: new Date() },
+			{ gameId, userId: 'u-b', amount: '10.00', status: 'claimed' },
+		])
+
+		// Favourite (home, pot 1) wins 2-0 → both underdog picks lose → both bust.
+		await finishFixture(fx, 2, 0)
+		await settleFixture(fx)
+
+		const players = await db.query.gamePlayer.findMany({ where: eq(gamePlayer.gameId, gameId) })
+		expect(players.every((p) => p.status === 'eliminated')).toBe(true)
+		expect(players.some((p) => p.status === 'winner')).toBe(false)
+
+		// Pot refunded, no payout written.
+		const pays = await db.query.payment.findMany({ where: eq(payment.gameId, gameId) })
+		expect(pays.every((p) => p.status === 'refunded')).toBe(true)
+		const payouts = await db.query.payout.findMany({ where: eq(payout.gameId, gameId) })
+		expect(payouts.length).toBe(0)
+
+		// Game completed (not stuck active).
+		const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+		expect(g?.status).toBe('completed')
 	})
 })
 

--- a/src/lib/game/auto-complete.test.ts
+++ b/src/lib/game/auto-complete.test.ts
@@ -156,29 +156,42 @@ describe('checkCupCompletion', () => {
 		expect(result.winnerPlayerIds).toEqual(['p1'])
 	})
 
-	it('mass extinction tiebreaks streak then lives then goals', async () => {
+	it('cup wipeout: when everyone is eliminated, NO winner — game ends for a pot refund (a losing pick must never win)', async () => {
 		dbMock.query.gamePlayer.findMany.mockResolvedValue([
 			{ id: 'p1', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
 			{ id: 'p2', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
 		] as never)
-		// p1: 5 successful picks, 7 goals; p2: 5 successful picks, 12 goals
-		dbMock.query.pick.findMany.mockResolvedValue([
-			{ gamePlayerId: 'p1', result: 'win', goalsScored: 3 },
-			{ gamePlayerId: 'p1', result: 'win', goalsScored: 2 },
-			{ gamePlayerId: 'p1', result: 'draw', goalsScored: 1 },
-			{ gamePlayerId: 'p1', result: 'saved_by_life', goalsScored: 1 },
-			{ gamePlayerId: 'p1', result: 'win', goalsScored: 0 },
-			{ gamePlayerId: 'p2', result: 'win', goalsScored: 4 },
-			{ gamePlayerId: 'p2', result: 'win', goalsScored: 4 },
-			{ gamePlayerId: 'p2', result: 'win', goalsScored: 4 },
-			{ gamePlayerId: 'p2', result: 'draw', goalsScored: 0 },
-			{ gamePlayerId: 'p2', result: 'saved_by_life', goalsScored: 0 },
+
+		const result = await checkCupCompletion('g1', 'c1', 'r1', 3)
+		expect(result.completed).toBe(true)
+		expect(result.winnerPlayerIds).toEqual([])
+		expect(result.reason).toBe('cup-wipeout-refund')
+	})
+
+	it('cup wipeout across rounds: last survivors both lose a LATER round → no winner (no goals-decided crowning)', async () => {
+		// Mirrors the real incident: others went out in R1, the final two both
+		// lost in R2, and a winner was wrongly decided on goals via mass-extinction.
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([
+			{ id: 'a', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+			{ id: 'b', status: 'eliminated', eliminatedRoundId: 'r2', livesRemaining: 0 },
+			{ id: 'c', status: 'eliminated', eliminatedRoundId: 'r2', livesRemaining: 0 },
+		] as never)
+
+		// pick.findMany is intentionally NOT mocked: the fixed code must not run a
+		// goals tiebreak here. If it tried, this test would throw.
+		const result = await checkCupCompletion('g1', 'c1', 'r2', 2)
+		expect(result.completed).toBe(true)
+		expect(result.winnerPlayerIds).toEqual([])
+		expect(result.reason).toBe('cup-wipeout-refund')
+	})
+
+	it('cup: degenerate 0-alive with no eliminated cohort this round does not complete', async () => {
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([
+			{ id: 'p1', status: 'eliminated', eliminatedRoundId: 'r-old', livesRemaining: 0 },
 		] as never)
 
 		const result = await checkCupCompletion('g1', 'c1', 'r1', 3)
-		// streak ties (5=5), lives ties (0=0), goals: p2 wins 12 > 7
-		expect(result.reason).toBe('mass-extinction')
-		expect(result.winnerPlayerIds).toEqual(['p2'])
+		expect(result.completed).toBe(false)
 	})
 
 	it('rounds-exhausted with multiple alive uses cup tiebreaker', async () => {

--- a/src/lib/game/auto-complete.ts
+++ b/src/lib/game/auto-complete.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gt } from 'drizzle-orm'
+import { and, asc, eq, gt, inArray } from 'drizzle-orm'
 import { db } from '@/lib/db'
 import {
 	classicTiebreaker,
@@ -16,6 +16,7 @@ export type CompletionReason =
 	| 'mass-extinction'
 	| 'rounds-exhausted'
 	| 'turbo-single-round'
+	| 'cup-wipeout-refund'
 
 export interface CompletionCheckResult {
 	completed: boolean
@@ -137,12 +138,16 @@ export async function checkCupCompletion(
 	}
 
 	if (alive.length === 0) {
+		// Cup: a broken streak (a loss with no lives left) means elimination — a
+		// player who lost can NEVER win. When everyone is out there is no rightful
+		// winner; the game ends with no payout and the pot is refunded (see
+		// applyNoWinnerRefund). This is deliberately NOT the classic "best
+		// eliminated player" mass-extinction tiebreaker.
 		const cohort = allPlayers.filter(
 			(p) => p.status === 'eliminated' && p.eliminatedRoundId === completedRoundId,
 		)
 		if (cohort.length === 0) return { completed: false, winnerPlayerIds: [] }
-		const winners = await tiebreakCup(gameId, cohort)
-		return { completed: true, winnerPlayerIds: winners, reason: 'mass-extinction' }
+		return { completed: true, winnerPlayerIds: [], reason: 'cup-wipeout-refund' }
 	}
 
 	const hasNext = await nextRoundExists(competitionId, completedRoundNumber)
@@ -186,6 +191,24 @@ export async function applyAutoCompletion(
 			})),
 		)
 	}
+
+	await db
+		.update(game)
+		.set({ status: 'completed', currentRoundId: null })
+		.where(eq(game.id, gameId))
+}
+
+/**
+ * Cup wipeout completion: every remaining player's streak broke, so there is no
+ * rightful winner. End the game with NO payout and refund every entrant's
+ * collected (paid/claimed) payment. Pending/unpaid rows are left as-is — there
+ * was no money in them to return.
+ */
+export async function applyNoWinnerRefund(gameId: string): Promise<void> {
+	await db
+		.update(payment)
+		.set({ status: 'refunded', refundedAt: new Date() })
+		.where(and(eq(payment.gameId, gameId), inArray(payment.status, ['paid', 'claimed'])))
 
 	await db
 		.update(game)

--- a/src/lib/game/settle.ts
+++ b/src/lib/game/settle.ts
@@ -2,6 +2,7 @@ import { and, asc, eq, gt, inArray } from 'drizzle-orm'
 import { db } from '@/lib/db'
 import {
 	applyAutoCompletion,
+	applyNoWinnerRefund,
 	checkClassicCompletion,
 	checkCupCompletion,
 	checkTurboCompletion,
@@ -420,7 +421,12 @@ async function checkAndMaybeCompleteOrAdvance(
 	} else if (g.gameMode === 'cup') {
 		const completion = await checkCupCompletion(gameId, g.competitionId, roundId, roundNumber)
 		if (completion.completed) {
-			await applyAutoCompletion(gameId, completion.winnerPlayerIds)
+			if (completion.reason === 'cup-wipeout-refund') {
+				// Everyone's streak broke — no winner, refund the pot.
+				await applyNoWinnerRefund(gameId)
+			} else {
+				await applyAutoCompletion(gameId, completion.winnerPlayerIds)
+			}
 			result.gamesCompleted.push(gameId)
 			return
 		}


### PR DESCRIPTION
## The bug (live cup game `d8360e69…`)
A cup player was crowned **winner despite a losing pick**. Root cause: `checkCupCompletion` reused the **classic** "mass-extinction" tiebreaker — when every remaining player's streak had broken (the final two both lost in round 2, decided on **goals**), it crowned the "best loser" via `tiebreakCup` and wrote a payout. In cup mode, a broken streak means *eliminated* — a losing pick must never win.

## The fix
`checkCupCompletion`: when `alive == 0`, return a new `cup-wipeout-refund` outcome instead of running the tiebreak. `settle.ts` routes that to a new **`applyNoWinnerRefund()`** which ends the game with **no winner** and refunds the collected (`paid`/`claimed`) payments. Classic and turbo are untouched (classic's mass-extinction is intentional there).

## Verification
- **Unit** (`auto-complete.test.ts`): both wipeout shapes — everyone busts round 1, *and* the finalists lose a later round (the real incident) — now return no winner.
- **Smoke** (real Postgres): wipeout → no winner, payments `refunded`, **no payout row**, game `completed`.
- Full smoke (25) + unit (436) + biome + build all green.

## ⚠️ Does NOT fix the already-broken game
Settlement only runs on fixture transitions; a `completed` game never re-evaluates. So `d8360e69…` keeps its wrong winner/payout until a **separate, reviewed data correction** is applied (un-crown the player → eliminated, delete the payout, refund payments). I'll prepare that against prod once I've inspected the live rows.

Closes the cup half of the launch incident (U1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)