### PR TITLE
fix(cup): completion engine — confirmed elimination, round-1 reprieve, consecutive-wipeout refund

### DIFF
--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -582,6 +582,56 @@ describe('lifecycle: cup-WC', () => {
 		const payouts = await db.query.payout.findMany({ where: eq(payout.gameId, gameId) })
 		expect(payouts.length).toBe(0)
 	})
+
+	it('cup confirmed elimination: a settled lower-rank loss does NOT eliminate while rank-1 is pending', async () => {
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		const t1 = await makeTeam({ name: 'T1', shortName: 'T1', fifaPot: 2 })
+		const t2 = await makeTeam({ name: 'T2', shortName: 'T2', fifaPot: 2 })
+		const t3 = await makeTeam({ name: 'T3', shortName: 'T3', fifaPot: 2 })
+		const t4 = await makeTeam({ name: 'T4', shortName: 'T4', fifaPot: 2 })
+		const r1 = await makeRound(compId, { number: 1, status: 'open' })
+		const fxRank1 = await makeFixture({ roundId: r1, homeTeamId: t1, awayTeamId: t2 })
+		const fxRank2 = await makeFixture({ roundId: r1, homeTeamId: t3, awayTeamId: t4 })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'cup',
+			currentRoundId: r1,
+			modeConfig: { numberOfPicks: 2, startingLives: 0 },
+		})
+		const gp = await makePlayer({ gameId, userId: 'u-a', livesRemaining: 0 })
+		// rank-1 on t1 (fxRank1 — will stay pending); rank-2 on t3 (fxRank2).
+		await makePick({
+			gameId,
+			gamePlayerId: gp,
+			roundId: r1,
+			teamId: t1,
+			fixtureId: fxRank1,
+			confidenceRank: 1,
+			predictedResult: 'home_win',
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gp,
+			roundId: r1,
+			teamId: t3,
+			fixtureId: fxRank2,
+			confidenceRank: 2,
+			predictedResult: 'home_win',
+		})
+
+		// Only the rank-2 fixture finishes — t3 (home) loses. rank-1 still pending.
+		await finishFixture(fxRank2, 0, 1)
+		await settleFixture(fxRank2)
+
+		// Elimination is NOT confirmed: the rank-1 pick hasn't been scored.
+		const player = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gp) })
+		expect(player?.status).toBe('alive')
+		// And the rank-2 result stays pending (can't be confirmed before rank-1).
+		const playerPicks = await db.query.pick.findMany({ where: eq(pick.gamePlayerId, gp) })
+		const rank2 = playerPicks.find((p) => p.fixtureId === fxRank2)
+		expect(rank2?.result).toBe('pending')
+	})
 })
 
 /* ────────────────────────────────────────────────────────────────────── */

--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -29,6 +29,7 @@ import {
 import { settleFixture } from '@/lib/game/settle'
 import { round as roundTable } from '@/lib/schema/competition'
 import { game, gamePlayer, pick } from '@/lib/schema/game'
+import { payment, payout } from '@/lib/schema/payment'
 import {
 	finishFixture,
 	liveFixture,
@@ -443,6 +444,143 @@ describe('lifecycle: cup-WC', () => {
 
 		// Same pick results, same lives, same statuses.
 		expect(afterSecond.map((p) => p.result).sort()).toEqual(afterFirst.map((p) => p.result).sort())
+	})
+
+	it('cup round-1 wipeout → reprieve: everyone reset to alive and advanced to round 2 (no winner)', async () => {
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		const fav = await makeTeam({ name: 'Favourite', shortName: 'FAV', fifaPot: 1 })
+		const dog = await makeTeam({ name: 'Underdog', shortName: 'DOG', fifaPot: 4 })
+		const r1 = await makeRound(compId, { number: 1, status: 'open' })
+		const r2 = await makeRound(compId, {
+			number: 2,
+			status: 'upcoming',
+			deadline: new Date(Date.now() + 86_400_000),
+		})
+		const fx1 = await makeFixture({ roundId: r1, homeTeamId: fav, awayTeamId: dog })
+		await makeFixture({ roundId: r2, homeTeamId: fav, awayTeamId: dog }) // r2 must have a fixture to advance into
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'cup',
+			currentRoundId: r1,
+			modeConfig: { numberOfPicks: 1, startingLives: 0 },
+		})
+		const gpA = await makePlayer({ gameId, userId: 'u-a', livesRemaining: 0 })
+		const gpB = await makePlayer({ gameId, userId: 'u-b', livesRemaining: 0 })
+		// Both back the underdog (legal); favourite wins → both bust MD1.
+		await makePick({
+			gameId,
+			gamePlayerId: gpA,
+			roundId: r1,
+			teamId: dog,
+			fixtureId: fx1,
+			confidenceRank: 1,
+			predictedResult: 'away_win',
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpB,
+			roundId: r1,
+			teamId: dog,
+			fixtureId: fx1,
+			confidenceRank: 1,
+			predictedResult: 'away_win',
+		})
+
+		await finishFixture(fx1, 2, 0)
+		await settleFixture(fx1)
+
+		// Reprieve: nobody crowned; everyone reset to alive and advanced to round 2.
+		const players = await db.query.gamePlayer.findMany({ where: eq(gamePlayer.gameId, gameId) })
+		expect(players.every((p) => p.status === 'alive')).toBe(true)
+		expect(players.every((p) => p.eliminatedRoundId === null)).toBe(true)
+		const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+		expect(g?.status).toBe('active')
+		expect(g?.currentRoundId).toBe(r2)
+		const r1After = await db.query.round.findFirst({ where: eq(roundTable.id, r1) })
+		expect(r1After?.status).toBe('completed')
+	})
+
+	it('cup double wipeout: bust round 1 (reprieve) then bust round 2 → no winner + refund', async () => {
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		const fav = await makeTeam({ name: 'Favourite', shortName: 'FAV', fifaPot: 1 })
+		const dog = await makeTeam({ name: 'Underdog', shortName: 'DOG', fifaPot: 4 })
+		const r1 = await makeRound(compId, { number: 1, status: 'open' })
+		const r2 = await makeRound(compId, {
+			number: 2,
+			status: 'upcoming',
+			deadline: new Date(Date.now() + 86_400_000),
+		})
+		const fx1 = await makeFixture({ roundId: r1, homeTeamId: fav, awayTeamId: dog })
+		const fx2 = await makeFixture({ roundId: r2, homeTeamId: fav, awayTeamId: dog })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'cup',
+			currentRoundId: r1,
+			modeConfig: { numberOfPicks: 1, startingLives: 0 },
+		})
+		const gpA = await makePlayer({ gameId, userId: 'u-a', livesRemaining: 0 })
+		const gpB = await makePlayer({ gameId, userId: 'u-b', livesRemaining: 0 })
+		await db.insert(payment).values([
+			{ gameId, userId: 'u-a', amount: '10.00', status: 'paid', paidAt: new Date() },
+			{ gameId, userId: 'u-b', amount: '10.00', status: 'paid', paidAt: new Date() },
+		])
+
+		// Round 1: both bust → reprieve to round 2.
+		await makePick({
+			gameId,
+			gamePlayerId: gpA,
+			roundId: r1,
+			teamId: dog,
+			fixtureId: fx1,
+			confidenceRank: 1,
+			predictedResult: 'away_win',
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpB,
+			roundId: r1,
+			teamId: dog,
+			fixtureId: fx1,
+			confidenceRank: 1,
+			predictedResult: 'away_win',
+		})
+		await finishFixture(fx1, 2, 0)
+		await settleFixture(fx1)
+		const mid = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+		expect(mid?.currentRoundId).toBe(r2) // reprieved + advanced
+
+		// Round 2: both bust again → total wipeout (cohort == all) → refund.
+		await makePick({
+			gameId,
+			gamePlayerId: gpA,
+			roundId: r2,
+			teamId: dog,
+			fixtureId: fx2,
+			confidenceRank: 1,
+			predictedResult: 'away_win',
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpB,
+			roundId: r2,
+			teamId: dog,
+			fixtureId: fx2,
+			confidenceRank: 1,
+			predictedResult: 'away_win',
+		})
+		await finishFixture(fx2, 2, 0)
+		await settleFixture(fx2)
+
+		const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+		expect(g?.status).toBe('completed')
+		const players = await db.query.gamePlayer.findMany({ where: eq(gamePlayer.gameId, gameId) })
+		expect(players.some((p) => p.status === 'winner')).toBe(false)
+		const pays = await db.query.payment.findMany({ where: eq(payment.gameId, gameId) })
+		expect(pays.every((p) => p.status === 'refunded')).toBe(true)
+		const payouts = await db.query.payout.findMany({ where: eq(payout.gameId, gameId) })
+		expect(payouts.length).toBe(0)
 	})
 })
 

--- a/src/lib/game/auto-complete.test.ts
+++ b/src/lib/game/auto-complete.test.ts
@@ -156,12 +156,15 @@ describe('checkCupCompletion', () => {
 		expect(result.winnerPlayerIds).toEqual(['p1'])
 	})
 
-	it('mass extinction tiebreaks streak then lives then goals', async () => {
+	it('round-2 mass-extinction crowns the best of the just-eliminated cohort (streak→lives→goals)', async () => {
+		// p3 went out in round 1; p1 + p2 survived to round 2 and both bust there.
+		// cohort (eliminated this round) < all players → normal crown, NOT refund.
 		dbMock.query.gamePlayer.findMany.mockResolvedValue([
-			{ id: 'p1', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
-			{ id: 'p2', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+			{ id: 'p1', status: 'eliminated', eliminatedRoundId: 'r2', livesRemaining: 0 },
+			{ id: 'p2', status: 'eliminated', eliminatedRoundId: 'r2', livesRemaining: 0 },
+			{ id: 'p3', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
 		] as never)
-		// p1: 5 successful picks, 7 goals; p2: 5 successful picks, 12 goals
+		// p1: streak 5, 7 goals; p2: streak 5, 12 goals → p2 on goals. p3 not in cohort.
 		dbMock.query.pick.findMany.mockResolvedValue([
 			{ gamePlayerId: 'p1', result: 'win', goalsScored: 3 },
 			{ gamePlayerId: 'p1', result: 'win', goalsScored: 2 },
@@ -173,10 +176,52 @@ describe('checkCupCompletion', () => {
 			{ gamePlayerId: 'p2', result: 'win', goalsScored: 4 },
 			{ gamePlayerId: 'p2', result: 'draw', goalsScored: 0 },
 			{ gamePlayerId: 'p2', result: 'saved_by_life', goalsScored: 0 },
+			{ gamePlayerId: 'p3', result: 'win', goalsScored: 99 },
 		] as never)
 
-		const result = await checkCupCompletion('g1', 'c1', 'r1', 3)
-		// streak ties (5=5), lives ties (0=0), goals: p2 wins 12 > 7
+		const result = await checkCupCompletion('g1', 'c1', 'r2', 2)
+		expect(result.reason).toBe('mass-extinction')
+		expect(result.winnerPlayerIds).toEqual(['p2'])
+	})
+
+	it('round-1 wipeout → reprieve signal (no winner; whole field advances to round 2)', async () => {
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([
+			{ id: 'p1', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+			{ id: 'p2', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+		] as never)
+		dbMock.query.round.findFirst.mockResolvedValue({ id: 'r2', number: 2 } as never)
+
+		const result = await checkCupCompletion('g1', 'c1', 'r1', 1)
+		expect(result.completed).toBe(false)
+		expect(result.reason).toBe('cup-round1-reprieve')
+		expect(result.winnerPlayerIds).toEqual([])
+	})
+
+	it('total wipeout in round 2 after a reprieve (cohort == all players) → no winner + refund', async () => {
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([
+			{ id: 'p1', status: 'eliminated', eliminatedRoundId: 'r2', livesRemaining: 0 },
+			{ id: 'p2', status: 'eliminated', eliminatedRoundId: 'r2', livesRemaining: 0 },
+		] as never)
+		dbMock.query.round.findFirst.mockResolvedValue(null as never)
+
+		const result = await checkCupCompletion('g1', 'c1', 'r2', 2)
+		expect(result.completed).toBe(true)
+		expect(result.winnerPlayerIds).toEqual([])
+		expect(result.reason).toBe('cup-wipeout-refund')
+	})
+
+	it('round-1 wipeout with NO next round (single-round cup) crowns best — no reprieve', async () => {
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([
+			{ id: 'p1', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+			{ id: 'p2', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+		] as never)
+		dbMock.query.round.findFirst.mockResolvedValue(null as never)
+		dbMock.query.pick.findMany.mockResolvedValue([
+			{ gamePlayerId: 'p1', result: 'win', goalsScored: 3 },
+			{ gamePlayerId: 'p2', result: 'win', goalsScored: 9 },
+		] as never)
+
+		const result = await checkCupCompletion('g1', 'c1', 'r1', 1)
 		expect(result.reason).toBe('mass-extinction')
 		expect(result.winnerPlayerIds).toEqual(['p2'])
 	})

--- a/src/lib/game/auto-complete.ts
+++ b/src/lib/game/auto-complete.ts
@@ -16,6 +16,8 @@ export type CompletionReason =
 	| 'mass-extinction'
 	| 'rounds-exhausted'
 	| 'turbo-single-round'
+	| 'cup-round1-reprieve'
+	| 'cup-wipeout-refund'
 
 export interface CompletionCheckResult {
 	completed: boolean
@@ -141,6 +143,27 @@ export async function checkCupCompletion(
 			(p) => p.status === 'eliminated' && p.eliminatedRoundId === completedRoundId,
 		)
 		if (cohort.length === 0) return { completed: false, winnerPlayerIds: [] }
+
+		const hasNext = await nextRoundExists(competitionId, completedRoundNumber)
+
+		// Round-1 reprieve: a mass loss in the FIRST round crowns nobody — the
+		// whole field advances to round 2 and competes again (the caller resets
+		// everyone to alive + advances). Only when there's a next round to go to;
+		// a single-round cup falls through to a normal mass-extinction crown.
+		if (completedRoundNumber === 1 && hasNext) {
+			return { completed: false, winnerPlayerIds: [], reason: 'cup-round1-reprieve' }
+		}
+
+		// Consecutive-wipeout refund: after a round-1 reprieve the whole field
+		// carries into round 2. If THAT round is also a total wipeout there's no
+		// rightful winner → refund. cohort == all players ⟺ nobody survived an
+		// earlier round ⟺ this field only exists because round 1 was reprieved.
+		if (completedRoundNumber > 1 && cohort.length === allPlayers.length) {
+			return { completed: true, winnerPlayerIds: [], reason: 'cup-wipeout-refund' }
+		}
+
+		// Normal mass-extinction: crown the best of the just-eliminated cohort by
+		// tiebreaker. A losing pick winning here is intended.
 		const winners = await tiebreakCup(gameId, cohort)
 		return { completed: true, winnerPlayerIds: winners, reason: 'mass-extinction' }
 	}

--- a/src/lib/game/auto-complete.ts
+++ b/src/lib/game/auto-complete.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gt } from 'drizzle-orm'
+import { and, asc, eq, gt, inArray } from 'drizzle-orm'
 import { db } from '@/lib/db'
 import {
 	classicTiebreaker,
@@ -209,6 +209,24 @@ export async function applyAutoCompletion(
 			})),
 		)
 	}
+
+	await db
+		.update(game)
+		.set({ status: 'completed', currentRoundId: null })
+		.where(eq(game.id, gameId))
+}
+
+/**
+ * No-winner completion: refund every entrant's collected (paid/claimed) payment,
+ * write no payout, and mark the game completed. Used when a cup/turbo game ends
+ * with no rightful winner — a total wipeout in the round following a round-1
+ * reprieve. Pending/unpaid rows are left as-is; no money was in them.
+ */
+export async function applyNoWinnerRefund(gameId: string): Promise<void> {
+	await db
+		.update(payment)
+		.set({ status: 'refunded', refundedAt: new Date() })
+		.where(and(eq(payment.gameId, gameId), inArray(payment.status, ['paid', 'claimed'])))
 
 	await db
 		.update(game)

--- a/src/lib/game/settle.ts
+++ b/src/lib/game/settle.ts
@@ -2,6 +2,7 @@ import { and, asc, eq, gt, inArray } from 'drizzle-orm'
 import { db } from '@/lib/db'
 import {
 	applyAutoCompletion,
+	applyNoWinnerRefund,
 	checkClassicCompletion,
 	checkCupCompletion,
 	checkTurboCompletion,
@@ -418,12 +419,31 @@ async function checkAndMaybeCompleteOrAdvance(
 			return
 		}
 	} else if (g.gameMode === 'cup') {
+		// No completion or reprieve until the round is fully settled — so every
+		// elimination is confirmed first. Mid-round, picks + confirmed
+		// eliminations are already updated by reevaluateCupGame upstream.
+		if (!allFinished) return
 		const completion = await checkCupCompletion(gameId, g.competitionId, roundId, roundNumber)
-		if (completion.completed) {
-			await applyAutoCompletion(gameId, completion.winnerPlayerIds)
+		if (completion.reason === 'cup-round1-reprieve') {
+			// Round-1 mass loss: crown nobody. Reset the whole field to a fresh
+			// alive state, then fall through to the shared round-complete + advance
+			// block, which moves everyone into round 2.
+			const startingLives = (g.modeConfig as { startingLives?: number } | null)?.startingLives ?? 0
+			await db
+				.update(gamePlayer)
+				.set({ status: 'alive', eliminatedRoundId: null, livesRemaining: startingLives })
+				.where(eq(gamePlayer.gameId, gameId))
+		} else if (completion.completed) {
+			if (completion.reason === 'cup-wipeout-refund') {
+				await applyNoWinnerRefund(gameId)
+			} else {
+				await applyAutoCompletion(gameId, completion.winnerPlayerIds)
+			}
 			result.gamesCompleted.push(gameId)
 			return
 		}
+		// Survivors remain (not completed, not reprieve) → fall through to the
+		// shared block below to advance them to the next round.
 	} else if (g.gameMode === 'turbo') {
 		if (!allFinished) return
 		const turboPlayerResults = await collectTurboPlayerResults(gameId, roundId)

--- a/src/lib/game/settle.ts
+++ b/src/lib/game/settle.ts
@@ -295,7 +295,13 @@ export async function reevaluateCupGame(gameId: string): Promise<boolean> {
 			const fx = g.currentRound.fixtures.find((f) => f.id === p.fixtureId)
 			if (!fx) continue
 			if (fx.status === 'cancelled') continue
-			if (fx.homeScore == null || fx.awayScore == null) continue
+			// Confirmed-elimination boundary: STOP at the first pending pick in
+			// rank order. The streak — and therefore elimination — past this
+			// point can't be confirmed until this higher-confidence pick is
+			// scored, so a lower-ranked loss must NOT eliminate the player yet.
+			// (Voided/cancelled picks above are skipped — the streak walks past
+			// them — but a genuinely unplayed pick halts confirmation here.)
+			if (fx.homeScore == null || fx.awayScore == null) break
 			settleable.push({ pickRow: p, fixture: fx })
 		}
 		if (settleable.length === 0) continue


### PR DESCRIPTION
Fixes the cup half of the live-launch incident (cup game `d8360e69` crowned an **eliminated** player + paid out £30, mid-MD1). Root cause was two bugs in the cup completion path; both are fixed here per the ruling agreed with Sean.

## The ruling (cup)
1. **Confirmed elimination only** — a player is eliminated only when the streak break is on the contiguous *settled* prefix from rank 1. A settled lower-rank loss must NOT eliminate while a higher-rank pick is still pending.
2. **No mid-round completion** — winner/reprieve/refund is evaluated only once the round is fully settled (never off a partial set of fixtures).
3. **Normal mass-extinction** → crown the best of the just-eliminated cohort by tiebreaker (a losing pick winning via tiebreaker is *intended*).
4. **Round-1 reprieve** — a mass loss in round 1 crowns nobody: reset the whole field to fresh alive and advance everyone to round 2.
5. **Consecutive-wipeout refund** — after a round-1 reprieve, if round 2 is also a total wipeout → no winner + refund.

## Changes
- `checkCupCompletion`: rules 3–5 (`cup-round1-reprieve` / `cup-wipeout-refund` / crown). Reprieve detected without a schema change (cohort-this-round == all players ⟺ field only exists via a round-1 reprieve).
- `settle.ts` cup dispatcher: gated on full-round settlement; performs the reprieve reset+advance and the refund (`applyNoWinnerRefund`).
- `reevaluateCupGame`: BREAKs at the first pending pick in rank order (rule 1) instead of skipping it.

## Verification
- Unit (`auto-complete.test.ts`): reprieve, refund, round-2 crown, single-round fallback, last-alive, rounds-exhausted.
- Smoke (real Postgres): round-1 reprieve (field reset + advanced to R2), double-wipeout refund (no winner, payments refunded, no payout), confirmed-elimination (settled rank-2 loss with rank-1 pending leaves the player alive).
- Full gates green: typecheck, biome, unit (437), smoke (27), build.

## Scope / follow-ups
- **Turbo multi-round** (same unified rules, no lives) is the next serial PR — turbo is unchanged here (still single-round), and no turbo game is live.
- **Live correction for `d8360e69`** (un-crown the wrong winner, void the £30 payout, reset+advance the field to round 2) is a separate, approval-gated step once this deploys — I'll show the exact changes before running anything against prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)