### PR TITLE
fix(cup,turbo): single-round completion + wipeout rule; game-mode docs rework

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ drizzle/                  # Generated migrations
 - **Route protection**: `proxy.ts` (Next.js 16 replacement for middleware) redirects unauthenticated requests. Public paths: `/login`, `/signup`, `/api/auth`.
 - **Database**: No RLS — authorization enforced in TypeScript. All IDs are UUIDs. `numeric` columns (entry_fee, amounts) are strings in TypeScript for arbitrary precision.
 - **Types**: Inferred from Drizzle schema via `$inferSelect` / `$inferInsert`. See `src/lib/types.ts`.
-- **Game modes**: `classic` (one pick per round), `turbo` (10 predictions ranked by confidence), `cup` (like turbo with lives/handicap system).
+- **Game modes**: `classic` is the only **multi-round** mode — one pick per round, survive round to round, last person standing. `turbo` and `cup` are **single-round**: N confidence-ranked predictions in one gameweek/round, longest streak of correct picks wins (no eliminations-to-advance, no carry-over). `cup` is turbo plus a tier handicap + lives. See `docs/game-modes/` for the authoritative per-mode spec.
 - **Secrets**: Doppler is the production secrets source. Local dev uses `.env.local` (gitignored).
 - **Testing**: Vitest for unit tests. Game logic lives in pure functions for easy testing. Tests run against local Postgres in CI.
 - **Linting**: Biome for linting + formatting. Pre-commit hook via husky + lint-staged.

--- a/docs/game-modes/README.md
+++ b/docs/game-modes/README.md
@@ -6,7 +6,7 @@ Read this README first for the cross-cutting state machines. The per-mode docs b
 
 - [classic.md](./classic.md) — one pick per round, last person standing
 - [turbo.md](./turbo.md) — ten ranked predictions, highest streak wins
-- [cup.md](./cup.md) — tier-handicapped knockout with lives system
+- [cup.md](./cup.md) — single-round, like turbo, with a tier handicap + lives
 
 ---
 
@@ -14,7 +14,7 @@ Read this README first for the cross-cutting state machines. The per-mode docs b
 
 **The settlement model is per-fixture.** When a fixture transitions to `finished`, every pick on it is settled in the same write — `pick.result` + `goals_scored` (+ `life_gained` / `life_spent` for cup) persist immediately, mode-specific elimination fires (classic), and the game's auto-completion is checked. This matches the predecessor app's `process_pick_results_on_fixture_update` DB trigger.
 
-Round completion is **emergent** — a round becomes `completed` when every fixture in it has been settled. Game advancement happens at the same point.
+Round completion is **emergent** — a round becomes `completed` when every fixture in it has been settled. At that point **classic** advances to the next round (it is the only multi-round mode); **turbo and cup are single-round** and instead auto-complete, crowning the longest streak. There is no game-level advancement for turbo/cup.
 
 There is no round-batched processing step. Picks on later-finishing fixtures stay `pending` until their own fixture settles.
 
@@ -26,11 +26,10 @@ flowchart LR
     C --> D[per-pick: settle pick.result + goals]
     D --> E[classic: eliminate if non-win<br/>past starting round]
     E --> F[cup: reevaluateCupGame — whole-game re-eval]
-    F --> G[check game completion<br/>per-mode]
-    G -->|alive=1| H[winner declared]
-    G -->|alive=0| I[mass-extinction tiebreaker]
-    G -->|alive≥2| J{all round<br/>fixtures finished?}
-    J -->|yes| K[advance to next round]
+    F --> G{game mode?}
+    G -->|classic — multi-round| Gc[alive=1 → winner; alive=0 → mass-extinction tiebreaker;<br/>alive≥2 + round fully settled → advance to next round]
+    G -->|turbo / cup — single-round| J{round fully settled?}
+    J -->|yes| K[crown longest streak<br/>turboTiebreaker / cupTiebreaker; complete — no advance]
     J -->|no| Z
 ```
 
@@ -50,13 +49,13 @@ Four entities, each with their own status. Most operations advance more than one
 ```mermaid
 stateDiagram-v2
     [*] --> active: POST /api/games (status='active', currentRoundId=first pickable round)
-    active --> completed: applyAutoCompletion (last-alive / rounds-exhausted / mass-extinction)
+    active --> completed: applyAutoCompletion (classic: last-alive / rounds-exhausted / mass-extinction;<br/>turbo + cup: longest streak once their single round fully settles)
     completed --> [*]
 ```
 
 ### Round state
 
-Each game's round flips `open` independently — `openRoundForGame` is called when a game first lands on a round (creation or advance). The flip to `completed` is also per-game: when settleFixture sees the round's last fixture get settled, it marks the round complete and advances the game. Multiple games on the same competition observe the same `round.status` value — that's why pick gating uses `round.deadline`, not `round.status`.
+Each game's round flips `open` independently — `openRoundForGame` is called when a game first lands on a round (creation or, for classic, advance). The flip to `completed` is also per-game: when settleFixture sees the round's last fixture get settled, it marks the round complete. For **classic** that then advances the game to the next round; for **turbo and cup** (single-round) it completes the game instead. Multiple games on the same competition observe the same `round.status` value — that's why pick gating uses `round.deadline`, not `round.status`.
 
 ```mermaid
 stateDiagram-v2

--- a/docs/game-modes/README.md
+++ b/docs/game-modes/README.md
@@ -4,9 +4,15 @@ This directory documents the runtime behaviour of every supported game mode. It 
 
 Read this README first for the cross-cutting state machines. The per-mode docs below cover anything mode-specific.
 
-- [classic.md](./classic.md) — one pick per round, last person standing
-- [turbo.md](./turbo.md) — ten ranked predictions, highest streak wins
-- [cup.md](./cup.md) — single-round, like turbo, with a tier handicap + lives
+## Modes at a glance
+
+| Mode | Rounds/game | Picks | Wins by | Eliminations? |
+|---|---|---|---|---|
+| [**classic**](./classic.md) | **many** (advances round→round) | 1 team/round | last player still alive | yes — a non-win knocks you out |
+| [**turbo**](./turbo.md) | **1** | N, confidence-ranked | longest streak of correct picks | no |
+| [**cup**](./cup.md) | **1** | up to N (partial ok) | longest streak of correct picks | no — lives extend the streak |
+
+`classic` is the only multi-round mode. `turbo` and `cup` play a single round (one gameweek) and crown the longest streak of correct picks; `cup` adds a tier handicap (pick underdogs or level ties, never a big favourite) and lives (underdog wins earn them; a life saves one wrong call to keep your streak alive).
 
 ---
 
@@ -14,7 +20,7 @@ Read this README first for the cross-cutting state machines. The per-mode docs b
 
 **The settlement model is per-fixture.** When a fixture transitions to `finished`, every pick on it is settled in the same write — `pick.result` + `goals_scored` (+ `life_gained` / `life_spent` for cup) persist immediately, mode-specific elimination fires (classic), and the game's auto-completion is checked. This matches the predecessor app's `process_pick_results_on_fixture_update` DB trigger.
 
-Round completion is **emergent** — a round becomes `completed` when every fixture in it has been settled. At that point **classic** advances to the next round (it is the only multi-round mode); **turbo and cup are single-round** and instead auto-complete, crowning the longest streak. There is no game-level advancement for turbo/cup.
+Round completion is **emergent** — a round becomes `completed` when every fixture in it has been settled. At that point **classic** advances to the next round; **turbo** and **cup** auto-complete on the longest streak (they play a single round).
 
 There is no round-batched processing step. Picks on later-finishing fixtures stay `pending` until their own fixture settles.
 
@@ -27,9 +33,9 @@ flowchart LR
     D --> E[classic: eliminate if non-win<br/>past starting round]
     E --> F[cup: reevaluateCupGame — whole-game re-eval]
     F --> G{game mode?}
-    G -->|classic — multi-round| Gc[alive=1 → winner; alive=0 → mass-extinction tiebreaker;<br/>alive≥2 + round fully settled → advance to next round]
-    G -->|turbo / cup — single-round| J{round fully settled?}
-    J -->|yes| K[crown longest streak<br/>turboTiebreaker / cupTiebreaker; complete — no advance]
+    G -->|classic| Gc[alive=1 → winner; alive=0 → mass-extinction tiebreaker;<br/>alive≥2 + round fully settled → advance to next round]
+    G -->|turbo / cup| J{round fully settled?}
+    J -->|yes| K[crown longest streak<br/>turboTiebreaker / cupTiebreaker; complete]
     J -->|no| Z
 ```
 
@@ -49,13 +55,13 @@ Four entities, each with their own status. Most operations advance more than one
 ```mermaid
 stateDiagram-v2
     [*] --> active: POST /api/games (status='active', currentRoundId=first pickable round)
-    active --> completed: applyAutoCompletion (classic: last-alive / rounds-exhausted / mass-extinction;<br/>turbo + cup: longest streak once their single round fully settles)
+    active --> completed: applyAutoCompletion (classic: last-alive / rounds-exhausted / mass-extinction;<br/>turbo + cup: longest streak once the round fully settles)
     completed --> [*]
 ```
 
 ### Round state
 
-Each game's round flips `open` independently — `openRoundForGame` is called when a game first lands on a round (creation or, for classic, advance). The flip to `completed` is also per-game: when settleFixture sees the round's last fixture get settled, it marks the round complete. For **classic** that then advances the game to the next round; for **turbo and cup** (single-round) it completes the game instead. Multiple games on the same competition observe the same `round.status` value — that's why pick gating uses `round.deadline`, not `round.status`.
+Each game's round flips `open` independently — `openRoundForGame` is called when a game first lands on a round (creation or, for classic, advance). The flip to `completed` is also per-game: when settleFixture sees the round's last fixture settle, it marks the round complete — which advances classic to the next round, or completes the game for turbo/cup. Multiple games on the same competition observe the same `round.status` value — that's why pick gating uses `round.deadline`, not `round.status`.
 
 ```mermaid
 stateDiagram-v2

--- a/docs/game-modes/README.md
+++ b/docs/game-modes/README.md
@@ -20,7 +20,7 @@ Read this README first for the cross-cutting state machines. The per-mode docs b
 
 **The settlement model is per-fixture.** When a fixture transitions to `finished`, every pick on it is settled in the same write — `pick.result` + `goals_scored` (+ `life_gained` / `life_spent` for cup) persist immediately, mode-specific elimination fires (classic), and the game's auto-completion is checked. This matches the predecessor app's `process_pick_results_on_fixture_update` DB trigger.
 
-Round completion is **emergent** — a round becomes `completed` when every fixture in it has been settled. At that point **classic** advances to the next round; **turbo** and **cup** auto-complete on the longest streak (they play a single round).
+Round completion is **emergent** — a round becomes `completed` when every fixture in it has been settled. At that point **classic** advances to the next round; **turbo** and **cup** auto-complete on the longest streak (they play a single round) — or refund everyone with no winner if every player got every pick wrong (a total wipeout).
 
 There is no round-batched processing step. Picks on later-finishing fixtures stay `pending` until their own fixture settles.
 
@@ -35,7 +35,7 @@ flowchart LR
     F --> G{game mode?}
     G -->|classic| Gc[alive=1 → winner; alive=0 → mass-extinction tiebreaker;<br/>alive≥2 + round fully settled → advance to next round]
     G -->|turbo / cup| J{round fully settled?}
-    J -->|yes| K[crown longest streak<br/>turboTiebreaker / cupTiebreaker; complete]
+    J -->|yes| K[skip ranks everyone lost, then crown longest streak<br/>turboTiebreaker / cupTiebreaker;<br/>total wipeout → refund all, no winner; complete]
     J -->|no| Z
 ```
 

--- a/docs/game-modes/classic.md
+++ b/docs/game-modes/classic.md
@@ -1,6 +1,6 @@
 # Classic mode
 
-Last person standing. One pick per round; if your team doesn't win, you're out.
+Last person standing, played over **many rounds** — the only multi-round mode. One pick per round; if your team doesn't win, you're out; survive and you advance to the next round.
 
 > Read [README.md](./README.md) first for the cross-cutting settlement model and state machines.
 

--- a/docs/game-modes/cup.md
+++ b/docs/game-modes/cup.md
@@ -7,7 +7,7 @@
 ## Pick mechanics
 
 - **Picks:** up to `modeConfig.numberOfPicks` (default 10–12). Cup allows **partial rankings** — 1..N picks submittable, unlike turbo.
-- **Win condition:** the **longest streak** of correct ranked picks. Once every fixture in the round is settled, players are ranked by `cupTiebreaker` (streak → lives → goals) and the longest streak takes the pot. A streak that *broke* can still win if it's the longest — the winner is whoever got furthest, not only survivors. (The edge case where **every** player breaks their streak is undecided — see the OPEN note under Settlement.)
+- **Win condition:** the **longest streak** of correct ranked picks — a *consecutive* run of surviving picks (win / draw_success / saved_by_life) counted in confidence-rank order. Once every fixture in the round is settled, players are ranked by `cupTiebreaker` (streak → lives → goals) and the longest streak takes the pot. A streak that *broke* can still win if it's the longest — the winner is whoever got furthest, not only survivors. Leading ranks that **everyone** got wrong are skipped first (the wipeout rule, under Settlement).
 - **Tier handicap:** every cup competition has a tier system that pushes picks toward underdogs — **where a team's tier comes from is per-competition**. `computeTierDifference` returns the difference from the home team's perspective (positive = home is the stronger side).
   - **WC (`competition.type === 'group_knockout'`):** FIFA pots (1=best, 4=worst); returns `awayPot - homePot`. Implemented.
   - **FA Cup (`competition.type === 'knockout'`):** difference in league tier (a higher-division side outranks a lower one). **Intended for the FA Cup extension (Jan 2027); not yet implemented** — `computeTierDifference` currently returns 0 for `knockout`, so a cup game on a knockout competition carries no handicap until then.
@@ -54,9 +54,17 @@ sequenceDiagram
 
 The winner is decided only once the round is fully settled.
 
-The re-eval is **idempotent**: re-running it with the same fixture states produces the same writes. Picks on fixtures without scores stay `'pending'`. The streak (and any elimination from it) is **confirmed only on the contiguous settled prefix from rank 1** — evaluation stops at the first pending pick, so a lower-ranked loss can't break a streak while a higher-confidence pick is still unplayed. The live UI still *projects* those later results; only confirmed state is finalised. Once the streak is confirmed broken, later settled picks persist as `'loss'`.
+The re-eval is **idempotent**: re-running it with the same fixture states produces the same writes. Picks on fixtures without scores stay `'pending'`. The streak (and any elimination from it) is **confirmed only on the contiguous settled prefix from rank 1** — evaluation stops at the first pending pick, so a lower-ranked loss can't break a streak while a higher-confidence pick is still unplayed. The live UI still *projects* those later results; only confirmed state is finalised. Once the streak is confirmed broken the player is eliminated, but **every** player's picks still settle to their true result — a genuine win after the break persists as `'win'` (only draws/losses after the break persist as `'loss'`, since no life can save them). Those later results feed the wipeout rule below, so settlement evaluates eliminated players too, not just survivors.
 
-> **OPEN (code session owns this):** what happens when **every** player breaks their streak in the round (no survivor) — e.g. everyone's most-confident pick loses — is an undecided design question: **no winner + full refund** vs **best-tiebreaker-takes-the-pot** (the longest, possibly zero, streak wins on lives/goals). This was the `d8360e69` incident. Do NOT encode a resolution here until it's settled in the engine.
+### Wipeout rule (winner determination)
+
+`checkCupCompletion` crowns the longest streak, but first applies the **wipeout rule** to decide *where* the streak count begins (`resolveWipeout`):
+
+- **Skip leading universal-loss ranks.** If rank 1 was a loss for *every* player it's discarded and the streak count restarts from rank 2; if rank 2 was also universally lost, from rank 3; and so on — the rebased start is the lowest rank any player got right. Each player's streak is then the consecutive run of surviving picks from that start, so a player who lost rank 1 alongside everyone else can still win on ranks 2+.
+- **Total wipeout → full refund.** If *no* rank has a single correct pick anywhere (every player got every pick wrong), there is no winner: the game completes with `reason: 'cup-total-wipeout'`, every stake is refunded (`payment.status = 'refunded'`), and no payout is written.
+- **No lives carry into the rebased start.** Discarded leading ranks are all losses, and lives are *earned* only by winning underdogs — so a player enters the rebased start with only their `startingLives`. The rebase changes where the streak is counted, not the lives tally; `cupTiebreaker` still breaks ties on final lives → goals.
+
+This is a cross-player, winner-determination concern, **distinct** from the per-player confirmed-prefix rule above: the confirmed-prefix rule bounds *which* picks are settled (stop at the first pending pick); the wipeout rule rebases *where* the streak begins (skip leading ranks everyone lost). It resolves the `d8360e69` incident, where the old tiebreaker counted every scattered win — including wins logged after a streak had already broken — and mis-crowned an eliminated player.
 
 Persisted bookkeeping (new columns introduced with this design):
 
@@ -86,7 +94,7 @@ stateDiagram-v2
     }
 ```
 
-Once `streakBroken=true`, every subsequent pick in rank order is a `'loss'` regardless of result. Lives spent earlier remain spent.
+Once `streakBroken=true`, no later pick can be saved by a life — subsequent draws and losses persist as `'loss'`. A subsequent genuine **win** still persists as `'win'` (and still earns underdog lives); it just can't extend the already-broken streak. Lives spent earlier remain spent. Those later win rows are what let the wipeout rule rebase a streak onto ranks after a universal loss.
 
 ## Player state machine
 
@@ -146,9 +154,12 @@ See [`docs/superpowers/specs/2026-05-12-fixture-cancellation-handling-design.md`
 - 3-tier underdog wins → +3 lives persisted on the pick, `gamePlayer.livesRemaining` updated.
 - Re-eval idempotency: settling the same fixture twice produces the same state.
 
+`scripts/smoke/lifecycle.smoke.test.ts`, `lifecycle: cup wipeout rule` (on a `knockout` competition — also exercises the tier-diff=0 path):
+
+- Leading universal-loss rank skipped: everyone loses rank 1, fixtures settle in rank order, and the player who wins rank 2 is crowned (not refunded) — proving eliminated players' later picks settle.
+- Total wipeout: every player gets every pick wrong → game completes, no winner, no payout, every `payment` refunded.
+
 Not yet covered:
 - 1-tier and 2-tier underdog wins.
 - Draw success / saved-by-life paths end-to-end.
-- Streak-broken state propagating across remaining picks.
-- Cup mode on `knockout` competition (FA Cup) — confirms tier-diff=0 path.
 - Cup pick on a fixture that finishes out of confidence-rank order (re-eval correctness).

--- a/docs/game-modes/cup.md
+++ b/docs/game-modes/cup.md
@@ -1,13 +1,13 @@
 # Cup mode
 
-**Single-round** mode — one gameweek / round of fixtures, exactly like turbo, plus a tier handicap and a lives system. Players rank cup fixtures by confidence and the **longest streak** of correct picks wins. Picking underdogs wins lives on a win, picking a >1-tier favourite is forbidden, and a life lets you survive an occasional wrong call to extend your streak. The competition may span many rounds (group stage → knockout → final), but a cup *game* is bound to ONE of them — there is no game-level carry-over or advancement to another round (that is classic-only).
+**Single-round** mode — turbo plus a tier handicap and a lives system. Players rank one round's fixtures by confidence and the **longest streak** of correct picks wins. The handicap pushes you toward underdogs: a >1-tier favourite is forbidden, and beating an underdog earns lives; a life buys back one wrong call to keep your streak going. (The competition may span many rounds — group → knockout → final — but a cup *game* is bound to one; no carry-over or advancement, that's classic-only.)
 
 > Read [README.md](./README.md) first for the cross-cutting settlement model.
 
 ## Pick mechanics
 
 - **Picks:** up to `modeConfig.numberOfPicks` (default 10–12). Cup allows **partial rankings** — 1..N picks submittable, unlike turbo.
-- **Win condition:** the **longest streak** of correct ranked picks within the single round. Once every fixture in the round is settled, all players are ranked by `cupTiebreaker` (streak → lives → goals) and the longest streak takes the pot — a player whose streak *broke* can still win if it's the longest. No eliminations-to-advance, no carry-over to another round.
+- **Win condition:** the **longest streak** of correct ranked picks. Once every fixture in the round is settled, players are ranked by `cupTiebreaker` (streak → lives → goals) and the longest streak takes the pot. A streak that *broke* can still win if it's the longest — the winner is whoever got furthest, not only survivors. (The edge case where **every** player breaks their streak is undecided — see the OPEN note under Settlement.)
 - **Tier handicap:** for `competition.type === 'group_knockout'` (WC), `computeTierDifference` returns `awayPot - homePot` — positive when home is the stronger side (FIFA pots: 1=best, 4=worst). Non-`group_knockout` cup competitions (FA Cup `knockout`) get tier diff 0 — no handicap, no per-pick lives mechanic.
 
 ## Tier ↔ outcome table
@@ -43,13 +43,13 @@ sequenceDiagram
     Complete->>Complete: round fully settled?
     alt yes
         Complete->>Complete: checkCupCompletion → crown the LONGEST streak (cupTiebreaker)
-        Complete->>Complete: applyAutoCompletion, round.status=completed (single round — no advance)
+        Complete->>Complete: applyAutoCompletion; round.status=completed; game complete
     else no
         Complete->>Complete: wait for remaining fixtures
     end
 ```
 
-Like turbo, cup is **single-round**: the winner is decided only once the round is fully settled, and the game never advances to another round.
+The winner is decided only once the round is fully settled.
 
 The re-eval is **idempotent**: re-running it with the same fixture states produces the same writes. Picks on fixtures without scores stay `'pending'`. The streak (and any elimination from it) is **confirmed only on the contiguous settled prefix from rank 1** — evaluation stops at the first pending pick, so a lower-ranked loss can't break a streak while a higher-confidence pick is still unplayed. The live UI still *projects* those later results; only confirmed state is finalised. Once the streak is confirmed broken, later settled picks persist as `'loss'`.
 

--- a/docs/game-modes/cup.md
+++ b/docs/game-modes/cup.md
@@ -8,7 +8,10 @@
 
 - **Picks:** up to `modeConfig.numberOfPicks` (default 10–12). Cup allows **partial rankings** — 1..N picks submittable, unlike turbo.
 - **Win condition:** the **longest streak** of correct ranked picks. Once every fixture in the round is settled, players are ranked by `cupTiebreaker` (streak → lives → goals) and the longest streak takes the pot. A streak that *broke* can still win if it's the longest — the winner is whoever got furthest, not only survivors. (The edge case where **every** player breaks their streak is undecided — see the OPEN note under Settlement.)
-- **Tier handicap:** for `competition.type === 'group_knockout'` (WC), `computeTierDifference` returns `awayPot - homePot` — positive when home is the stronger side (FIFA pots: 1=best, 4=worst). Non-`group_knockout` cup competitions (FA Cup `knockout`) get tier diff 0 — no handicap, no per-pick lives mechanic.
+- **Tier handicap:** every cup competition has a tier system that pushes picks toward underdogs — **where a team's tier comes from is per-competition**. `computeTierDifference` returns the difference from the home team's perspective (positive = home is the stronger side).
+  - **WC (`competition.type === 'group_knockout'`):** FIFA pots (1=best, 4=worst); returns `awayPot - homePot`. Implemented.
+  - **FA Cup (`competition.type === 'knockout'`):** difference in league tier (a higher-division side outranks a lower one). **Intended for the FA Cup extension (Jan 2027); not yet implemented** — `computeTierDifference` currently returns 0 for `knockout`, so a cup game on a knockout competition carries no handicap until then.
+  - **`league`:** no handicap (cup mode is not offered on league competitions).
 
 ## Tier ↔ outcome table
 

--- a/docs/game-modes/cup.md
+++ b/docs/game-modes/cup.md
@@ -1,13 +1,13 @@
 # Cup mode
 
-Tier-handicapped predictions with a lives system. Players rank cup fixtures by confidence; picking underdogs wins lives on a win, picking a >1-tier favourite is forbidden, and lives let you survive an occasional wrong call.
+**Single-round** mode — one gameweek / round of fixtures, exactly like turbo, plus a tier handicap and a lives system. Players rank cup fixtures by confidence and the **longest streak** of correct picks wins. Picking underdogs wins lives on a win, picking a >1-tier favourite is forbidden, and a life lets you survive an occasional wrong call to extend your streak. The competition may span many rounds (group stage → knockout → final), but a cup *game* is bound to ONE of them — there is no game-level carry-over or advancement to another round (that is classic-only).
 
 > Read [README.md](./README.md) first for the cross-cutting settlement model.
 
 ## Pick mechanics
 
 - **Picks:** up to `modeConfig.numberOfPicks` (default 10–12). Cup allows **partial rankings** — 1..N picks submittable, unlike turbo.
-- **Win condition:** survive every round until the last, then ranked by `cupTiebreaker` (streak / lives / goals).
+- **Win condition:** the **longest streak** of correct ranked picks within the single round. Once every fixture in the round is settled, all players are ranked by `cupTiebreaker` (streak → lives → goals) and the longest streak takes the pot — a player whose streak *broke* can still win if it's the longest. No eliminations-to-advance, no carry-over to another round.
 - **Tier handicap:** for `competition.type === 'group_knockout'` (WC), `computeTierDifference` returns `awayPot - homePot` — positive when home is the stronger side (FIFA pots: 1=best, 4=worst). Non-`group_knockout` cup competitions (FA Cup `knockout`) get tier diff 0 — no handicap, no per-pick lives mechanic.
 
 ## Tier ↔ outcome table
@@ -40,15 +40,20 @@ sequenceDiagram
     Settle->>ReEval: per cup game touched
     Note over ReEval: For each alive player:<br/>1. Collect their picks for the current round<br/>2. Filter to picks whose fixture has scores<br/>3. Run evaluateCupPicks in rank order<br/>4. Persist per-pick: result, goalsScored,<br/>   life_gained, life_spent<br/>5. Persist gamePlayer.livesRemaining +<br/>   eliminated flag
     Settle->>Complete: per game
-    Complete->>Complete: checkCupCompletion
-    alt alive=1 / 0 / rounds-exhausted
-        Complete->>Complete: applyAutoCompletion
-    else round fully settled
-        Complete->>Complete: round.status=completed, advance
+    Complete->>Complete: round fully settled?
+    alt yes
+        Complete->>Complete: checkCupCompletion → crown the LONGEST streak (cupTiebreaker)
+        Complete->>Complete: applyAutoCompletion, round.status=completed (single round — no advance)
+    else no
+        Complete->>Complete: wait for remaining fixtures
     end
 ```
 
-The re-eval is **idempotent**: re-running it with the same fixture states produces the same writes. Picks on fixtures without scores stay `'pending'`. Picks past a projected streak break are persisted as `'loss'` immediately when their fixture finishes.
+Like turbo, cup is **single-round**: the winner is decided only once the round is fully settled, and the game never advances to another round.
+
+The re-eval is **idempotent**: re-running it with the same fixture states produces the same writes. Picks on fixtures without scores stay `'pending'`. The streak (and any elimination from it) is **confirmed only on the contiguous settled prefix from rank 1** — evaluation stops at the first pending pick, so a lower-ranked loss can't break a streak while a higher-confidence pick is still unplayed. The live UI still *projects* those later results; only confirmed state is finalised. Once the streak is confirmed broken, later settled picks persist as `'loss'`.
+
+> **OPEN (code session owns this):** what happens when **every** player breaks their streak in the round (no survivor) — e.g. everyone's most-confident pick loses — is an undecided design question: **no winner + full refund** vs **best-tiebreaker-takes-the-pot** (the longest, possibly zero, streak wins on lives/goals). This was the `d8360e69` incident. Do NOT encode a resolution here until it's settled in the engine.
 
 Persisted bookkeeping (new columns introduced with this design):
 
@@ -85,9 +90,9 @@ Once `streakBroken=true`, every subsequent pick in rank order is a `'loss'` rega
 ```mermaid
 stateDiagram-v2
     [*] --> alive: starts with modeConfig.startingLives lives (default 0)
-    alive --> alive: round processed, streak intact
-    alive --> eliminated: round processed, streakBroken=true (no lives left)
-    alive --> winner: last-alive / rounds-exhausted / mass-extinction tiebreaker
+    alive --> eliminated: streak broke — a loss with no life to save it
+    alive --> winner: longest streak when the single round completes
+    eliminated --> winner: longest streak when the round completes (a long BROKEN streak can still be the longest)
 ```
 
 Lives are **earned**, not handed out — `startingLives` defaults to 0. The creator can raise it for a more forgiving game.
@@ -143,5 +148,4 @@ Not yet covered:
 - Draw success / saved-by-life paths end-to-end.
 - Streak-broken state propagating across remaining picks.
 - Cup mode on `knockout` competition (FA Cup) — confirms tier-diff=0 path.
-- Multi-round cup with advancement.
 - Cup pick on a fixture that finishes out of confidence-rank order (re-eval correctness).

--- a/docs/game-modes/turbo.md
+++ b/docs/game-modes/turbo.md
@@ -9,8 +9,8 @@ Predict N fixtures (default 10) in a single round, ranked by confidence. Longest
 - **Picks:** exactly `modeConfig.numberOfPicks` (default 10) — submitted in one request, no partial rankings.
   - `predictedResult`: `home_win` / `draw` / `away_win`
   - `confidenceRank`: 1..N, no duplicates, no gaps
-- **Win condition:** longest streak of correct predictions sorted by rank ascending — first wrong prediction ends the streak; later corrects don't count.
-- **Tiebreaker:** longest streak first, then total goals in streak.
+- **Win condition:** longest streak of correct predictions sorted by rank ascending — first wrong prediction ends the streak; later corrects don't count. Leading ranks that **everyone** got wrong are skipped first (the wipeout rule, under Settlement), so the streak count restarts from the first rank anyone got right.
+- **Tiebreaker:** longest streak first, then total goals in streak. Turbo has no lives — goals are the only tiebreak.
 
 ## Settlement (per fixture)
 
@@ -30,8 +30,9 @@ sequenceDiagram
     Settle->>Complete: per game touched
     Complete->>Complete: all round fixtures finished?
     alt yes
-        Complete->>Complete: collectTurboPlayerResults → evaluateTurboPicks per player
-        Complete->>Complete: applyAutoCompletion (turboTiebreaker)
+        Complete->>Complete: collectTurboPlayerResults (rank-ordered settled picks per player)
+        Complete->>Complete: checkTurboCompletion → resolveWipeout → turboTiebreaker
+        Complete->>Complete: applyAutoCompletion (winner) OR refund all (total wipeout)
         Complete->>Complete: round.status = completed
     else no
         Complete->>Complete: wait for remaining fixtures
@@ -40,15 +41,26 @@ sequenceDiagram
 
 **Per-fixture settle, round-batched completion.** A turbo pick is settled (`win` or `loss`) the moment its fixture finishes. The round completion + winner determination wait for every fixture in the round to be settled — turbo's streak is rank-ordered across all picks.
 
+### Wipeout rule (winner determination)
+
+`checkTurboCompletion` applies the same wipeout rule as cup (`resolveWipeout`), minus lives:
+
+- **Skip leading universal-loss ranks.** If rank 1 was wrong for *every* player it's discarded and the streak count restarts from rank 2 (and so on — the rebased start is the lowest rank any player got right). Each player's streak is the consecutive run of correct picks from that start.
+- **Total wipeout → full refund.** If *no* rank has a single correct pick anywhere, there's no winner: the game completes with `reason: 'turbo-total-wipeout'`, every stake is refunded (`payment.status = 'refunded'`), and no payout is written.
+- **Tiebreak is goals only** (no lives mechanic in turbo): rebased streak → goals-in-streak.
+
 ## Player state machine
 
 ```mermaid
 stateDiagram-v2
     [*] --> alive
     alive --> winner: applyAutoCompletion (turbo-single-round; turboTiebreaker selects winners)
+    alive --> alive: total wipeout — no winner, every stake refunded
     note right of winner
         Turbo never eliminates mid-round.
         Multiple winners possible on perfect tie (split pot).
+        On a total wipeout there is no winner: players stay alive,
+        the game completes, and all payments are refunded.
     end note
 ```
 
@@ -90,8 +102,9 @@ See [`docs/superpowers/specs/2026-05-12-fixture-cancellation-handling-design.md`
 `scripts/smoke/lifecycle.smoke.test.ts`, `lifecycle: turbo-PL`:
 
 - Per-fixture settle: pick 1 settles after fx1; pick 2 stays pending; game stays active. Then pick 2 settles after fx2 → game auto-completes.
+- Total wipeout: every player's only pick is wrong → game completes, no winner, no payout, every `payment` refunded.
 
 Not yet covered:
 - Multi-player turbo with split pot on tied streaks.
 - All-correct streak (longest possible).
-- Streak-break-at-rank-1 (zero streak).
+- Leading universal-loss rank skipped (turbo rebase — covered by unit tests + the cup smoke scenario, which share `resolveWipeout`).

--- a/docs/game-modes/turbo.md
+++ b/docs/game-modes/turbo.md
@@ -1,6 +1,6 @@
 # Turbo mode
 
-Predict N fixtures (default 10) in a single round, ranked by confidence. Highest streak wins. Single-round format — the game auto-completes when the round is fully settled.
+Predict N fixtures (default 10) in a single round, ranked by confidence. Longest streak wins. Single-round format — the game auto-completes when the round is fully settled.
 
 > Read [README.md](./README.md) first for the cross-cutting settlement model.
 

--- a/scripts/smoke/cancellation.smoke.test.ts
+++ b/scripts/smoke/cancellation.smoke.test.ts
@@ -344,6 +344,11 @@ describe('cancellation: cup auto-skip', () => {
 			predictedResult: 'home_win',
 		})
 
+		// A third, unplayed fixture keeps the gameweek incomplete so we assert the
+		// mid-gameweek void/lives handling — a single-gameweek cup game only
+		// completes + crowns once every fixture is settled.
+		await makeFixture({ roundId: r1, homeTeamId: spain, awayTeamId: aus })
+
 		// Cancel rank 1's fixture. Rank 2 plays and home wins.
 		await cancelFixture(fx1)
 		await settleFixture(fx1)

--- a/scripts/smoke/helpers.ts
+++ b/scripts/smoke/helpers.ts
@@ -18,6 +18,7 @@ import {
 	team as teamTable,
 } from '@/lib/schema/competition'
 import { game, gamePlayer, pick } from '@/lib/schema/game'
+import { payment } from '@/lib/schema/payment'
 
 type CompetitionType = 'league' | 'knockout' | 'group_knockout'
 type DataSource = 'fpl' | 'football_data' | 'manual'
@@ -157,6 +158,24 @@ export async function makePlayer(opts: {
 		})
 		.returning()
 	return gp.id
+}
+
+export async function makePayment(opts: {
+	gameId: string
+	userId: string
+	amount?: string
+	status?: 'pending' | 'claimed' | 'paid' | 'refunded'
+}): Promise<string> {
+	const [p] = await db
+		.insert(payment)
+		.values({
+			gameId: opts.gameId,
+			userId: opts.userId,
+			amount: opts.amount ?? '10.00',
+			status: opts.status ?? 'paid',
+		})
+		.returning()
+	return p.id
 }
 
 export async function makePick(opts: {

--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -381,6 +381,11 @@ describe('lifecycle: cup-WC', () => {
 			predictedResult: 'away_win',
 		})
 
+		// A second, unplayed fixture keeps the gameweek incomplete, so this test
+		// asserts MID-gameweek life/streak state — a single-gameweek cup game only
+		// completes + crowns once every fixture in the gameweek is settled.
+		await makeFixture({ roundId: r1, homeTeamId: spain, awayTeamId: cv })
+
 		// Cape Verde (away, pot 4) wins 1-0 over Spain (home, pot 1) — 3-tier upset.
 		await finishFixture(fx, 0, 1)
 		await settleFixture(fx)

--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -29,12 +29,14 @@ import {
 import { settleFixture } from '@/lib/game/settle'
 import { round as roundTable } from '@/lib/schema/competition'
 import { game, gamePlayer, pick } from '@/lib/schema/game'
+import { payment, payout } from '@/lib/schema/payment'
 import {
 	finishFixture,
 	liveFixture,
 	makeCompetition,
 	makeFixture,
 	makeGame,
+	makePayment,
 	makePick,
 	makePlayer,
 	makeRound,
@@ -334,6 +336,55 @@ describe('lifecycle: turbo-PL', () => {
 		g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
 		expect(g?.status).toBe('completed')
 	})
+
+	it('total wipeout refunds everyone and crowns no one', async () => {
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const a = await makeTeam({ name: 'A', shortName: 'A' })
+		const b = await makeTeam({ name: 'B', shortName: 'B' })
+		const r1 = await makeRound(compId, { number: 1, status: 'open' })
+		const fx = await makeFixture({ roundId: r1, homeTeamId: a, awayTeamId: b })
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'turbo',
+			currentRoundId: r1,
+			modeConfig: { numberOfPicks: 1 },
+		})
+		const gp1 = await makePlayer({ gameId, userId: 'u1' })
+		const gp2 = await makePlayer({ gameId, userId: 'u2' })
+		await makePayment({ gameId, userId: 'u1' })
+		await makePayment({ gameId, userId: 'u2' })
+		// Both predict home_win; away wins → every pick wrong.
+		await makePick({
+			gameId,
+			gamePlayerId: gp1,
+			roundId: r1,
+			teamId: a,
+			fixtureId: fx,
+			confidenceRank: 1,
+			predictedResult: 'home_win',
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gp2,
+			roundId: r1,
+			teamId: a,
+			fixtureId: fx,
+			confidenceRank: 1,
+			predictedResult: 'home_win',
+		})
+
+		await finishFixture(fx, 0, 2)
+		await settleFixture(fx)
+
+		const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+		expect(g?.status).toBe('completed')
+		const players = await db.query.gamePlayer.findMany({ where: eq(gamePlayer.gameId, gameId) })
+		expect(players.some((p) => p.status === 'winner')).toBe(false)
+		const payouts = await db.query.payout.findMany({ where: eq(payout.gameId, gameId) })
+		expect(payouts.length).toBe(0)
+		const payments = await db.query.payment.findMany({ where: eq(payment.gameId, gameId) })
+		expect(payments.every((p) => p.status === 'refunded')).toBe(true)
+	})
 })
 
 /* ────────────────────────────────────────────────────────────────────── */
@@ -448,6 +499,161 @@ describe('lifecycle: cup-WC', () => {
 
 		// Same pick results, same lives, same statuses.
 		expect(afterSecond.map((p) => p.result).sort()).toEqual(afterFirst.map((p) => p.result).sort())
+	})
+})
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* cup wipeout rule (single-gameweek winner determination)                 */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe('lifecycle: cup wipeout rule', () => {
+	it('skips a leading universal-loss rank and crowns the rebased longest streak', async () => {
+		// FA-Cup-style knockout (tier diff 0, no lives mechanic), 2 fixtures.
+		const compId = await makeCompetition({ type: 'knockout', dataSource: 'football_data' })
+		const a1 = await makeTeam({ name: 'A1', shortName: 'A1' })
+		const b1 = await makeTeam({ name: 'B1', shortName: 'B1' })
+		const a2 = await makeTeam({ name: 'A2', shortName: 'A2' })
+		const b2 = await makeTeam({ name: 'B2', shortName: 'B2' })
+		const r1 = await makeRound(compId, { number: 1, status: 'open' })
+		const fx1 = await makeFixture({ roundId: r1, homeTeamId: a1, awayTeamId: b1 })
+		const fx2 = await makeFixture({ roundId: r1, homeTeamId: a2, awayTeamId: b2 })
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'cup',
+			currentRoundId: r1,
+			modeConfig: { numberOfPicks: 2, startingLives: 0 },
+		})
+		const gpA = await makePlayer({ gameId, userId: 'u-a', livesRemaining: 0 })
+		const gpB = await makePlayer({ gameId, userId: 'u-b', livesRemaining: 0 })
+		await makePayment({ gameId, userId: 'u-a' })
+		await makePayment({ gameId, userId: 'u-b' })
+		// Rank 1 (fx1): BOTH pick the home side, which loses → universal loss.
+		await makePick({
+			gameId,
+			gamePlayerId: gpA,
+			roundId: r1,
+			teamId: a1,
+			fixtureId: fx1,
+			confidenceRank: 1,
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpB,
+			roundId: r1,
+			teamId: a1,
+			fixtureId: fx1,
+			confidenceRank: 1,
+		})
+		// Rank 2 (fx2): A picks the home side (wins), B picks the away side (loses).
+		await makePick({
+			gameId,
+			gamePlayerId: gpA,
+			roundId: r1,
+			teamId: a2,
+			fixtureId: fx2,
+			confidenceRank: 2,
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpB,
+			roundId: r1,
+			teamId: b2,
+			fixtureId: fx2,
+			confidenceRank: 2,
+		})
+
+		// Settle in confidence-rank order — the order that used to strand the
+		// eliminated players' rank-2 picks as `pending`.
+		await finishFixture(fx1, 0, 2) // home (a1) loses → both lose rank 1
+		await settleFixture(fx1)
+		await finishFixture(fx2, 2, 0) // home (a2) wins → A wins rank 2, B loses rank 2
+		await settleFixture(fx2)
+
+		const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+		expect(g?.status).toBe('completed')
+
+		// A restarts the streak from rank 2 and wins; B does not.
+		const playerA = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gpA) })
+		const playerB = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gpB) })
+		expect(playerA?.status).toBe('winner')
+		expect(playerB?.status).not.toBe('winner')
+
+		// It's a real win, not a refund: a payout exists, no payment is refunded.
+		const payouts = await db.query.payout.findMany({ where: eq(payout.gameId, gameId) })
+		expect(payouts.map((p) => p.userId)).toEqual(['u-a'])
+		const payments = await db.query.payment.findMany({ where: eq(payment.gameId, gameId) })
+		expect(payments.every((p) => p.status === 'paid')).toBe(true)
+	})
+
+	it('refunds everyone and crowns no one on a total wipeout', async () => {
+		const compId = await makeCompetition({ type: 'knockout', dataSource: 'football_data' })
+		const a1 = await makeTeam({ name: 'A1', shortName: 'A1' })
+		const b1 = await makeTeam({ name: 'B1', shortName: 'B1' })
+		const a2 = await makeTeam({ name: 'A2', shortName: 'A2' })
+		const b2 = await makeTeam({ name: 'B2', shortName: 'B2' })
+		const r1 = await makeRound(compId, { number: 1, status: 'open' })
+		const fx1 = await makeFixture({ roundId: r1, homeTeamId: a1, awayTeamId: b1 })
+		const fx2 = await makeFixture({ roundId: r1, homeTeamId: a2, awayTeamId: b2 })
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'cup',
+			currentRoundId: r1,
+			modeConfig: { numberOfPicks: 2, startingLives: 0 },
+		})
+		const gpA = await makePlayer({ gameId, userId: 'u-a', livesRemaining: 0 })
+		const gpB = await makePlayer({ gameId, userId: 'u-b', livesRemaining: 0 })
+		await makePayment({ gameId, userId: 'u-a', amount: '10.00' })
+		await makePayment({ gameId, userId: 'u-b', amount: '10.00' })
+		// Every player gets every pick wrong (always pick the home side; home loses both).
+		await makePick({
+			gameId,
+			gamePlayerId: gpA,
+			roundId: r1,
+			teamId: a1,
+			fixtureId: fx1,
+			confidenceRank: 1,
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpB,
+			roundId: r1,
+			teamId: a1,
+			fixtureId: fx1,
+			confidenceRank: 1,
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpA,
+			roundId: r1,
+			teamId: a2,
+			fixtureId: fx2,
+			confidenceRank: 2,
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpB,
+			roundId: r1,
+			teamId: a2,
+			fixtureId: fx2,
+			confidenceRank: 2,
+		})
+
+		await finishFixture(fx1, 0, 2)
+		await settleFixture(fx1)
+		await finishFixture(fx2, 0, 2)
+		await settleFixture(fx2)
+
+		const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+		expect(g?.status).toBe('completed')
+		expect(g?.currentRoundId).toBeNull()
+
+		// No winner, no payout, every stake refunded.
+		const winners = await db.query.gamePlayer.findMany({ where: eq(gamePlayer.gameId, gameId) })
+		expect(winners.some((p) => p.status === 'winner')).toBe(false)
+		const payouts = await db.query.payout.findMany({ where: eq(payout.gameId, gameId) })
+		expect(payouts.length).toBe(0)
+		const payments = await db.query.payment.findMany({ where: eq(payment.gameId, gameId) })
+		expect(payments.every((p) => p.status === 'refunded')).toBe(true)
 	})
 })
 

--- a/src/lib/game-logic/auto-complete-tiebreakers.test.ts
+++ b/src/lib/game-logic/auto-complete-tiebreakers.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { classicTiebreaker, cupTiebreaker, turboTiebreaker } from './auto-complete-tiebreakers'
+import {
+	classicTiebreaker,
+	cupTiebreaker,
+	resolveWipeout,
+	turboTiebreaker,
+	type WipeoutPlayerInput,
+} from './auto-complete-tiebreakers'
 
 describe('classicTiebreaker', () => {
 	it('picks the sole top scorer', () => {
@@ -104,5 +110,154 @@ describe('cupTiebreaker', () => {
 				{ gamePlayerId: 'b', cumulativeStreak: 10, livesRemaining: 2, cumulativeGoals: 18 },
 			]),
 		).toEqual(['a', 'b'])
+	})
+})
+
+describe('resolveWipeout', () => {
+	const p = (
+		gamePlayerId: string,
+		picks: Array<[rank: number, correct: boolean, goals?: number]>,
+		livesRemaining = 0,
+	): WipeoutPlayerInput => ({
+		gamePlayerId,
+		livesRemaining,
+		picks: picks.map(([rank, correct, goals = 0]) => ({ rank, correct, goals })),
+	})
+
+	it('computes a consecutive streak from rank 1 when rank 1 has a winner', () => {
+		const out = resolveWipeout([
+			p('a', [
+				[1, true],
+				[2, true],
+				[3, true],
+			]),
+			p('b', [
+				[1, true],
+				[2, false],
+				[3, true],
+			]),
+		])
+		expect(out.totalWipeout).toBe(false)
+		expect(out.startingRank).toBe(1)
+		expect(out.scores).toEqual([
+			{ gamePlayerId: 'a', streak: 3, goalsInStreak: 0, livesRemaining: 0 },
+			{ gamePlayerId: 'b', streak: 1, goalsInStreak: 0, livesRemaining: 0 },
+		])
+	})
+
+	it('does NOT count correct picks that come after a streak break (the d8360e69 bug)', () => {
+		// b won rank 1, lost rank 2, then won ranks 3 & 4. The post-break wins must
+		// NOT inflate the streak — b's streak is 1, not 3.
+		const out = resolveWipeout([
+			p('a', [
+				[1, true],
+				[2, true],
+			]),
+			p('b', [
+				[1, true],
+				[2, false],
+				[3, true],
+				[4, true],
+			]),
+		])
+		expect(out.scores).toEqual([
+			{ gamePlayerId: 'a', streak: 2, goalsInStreak: 0, livesRemaining: 0 },
+			{ gamePlayerId: 'b', streak: 1, goalsInStreak: 0, livesRemaining: 0 },
+		])
+	})
+
+	it('skips a leading rank that was a universal loss (game starts from rank 2)', () => {
+		// Worked example: rank 1 wrong for everyone; from rank 2 A gets 2&3 right,
+		// B gets 2 wrong → A wins streak 2, B streak 0.
+		const out = resolveWipeout([
+			p('a', [
+				[1, false],
+				[2, true],
+				[3, true],
+			]),
+			p('b', [
+				[1, false],
+				[2, false],
+			]),
+		])
+		expect(out.totalWipeout).toBe(false)
+		expect(out.startingRank).toBe(2)
+		expect(out.scores).toEqual([
+			{ gamePlayerId: 'a', streak: 2, goalsInStreak: 0, livesRemaining: 0 },
+			{ gamePlayerId: 'b', streak: 0, goalsInStreak: 0, livesRemaining: 0 },
+		])
+	})
+
+	it('recurses past multiple consecutive universal-loss ranks', () => {
+		// ranks 1 and 2 are universal losses; rank 3 is the first surviving rank.
+		const out = resolveWipeout([
+			p('a', [
+				[1, false],
+				[2, false],
+				[3, true],
+				[4, true],
+			]),
+			p('b', [
+				[1, false],
+				[2, false],
+				[3, false],
+				[4, true],
+			]),
+		])
+		expect(out.startingRank).toBe(3)
+		expect(out.scores).toEqual([
+			{ gamePlayerId: 'a', streak: 2, goalsInStreak: 0, livesRemaining: 0 },
+			{ gamePlayerId: 'b', streak: 0, goalsInStreak: 0, livesRemaining: 0 },
+		])
+	})
+
+	it('flags a total wipeout when no rank has a single correct pick anywhere', () => {
+		const out = resolveWipeout([
+			p('a', [
+				[1, false],
+				[2, false],
+			]),
+			p('b', [
+				[1, false],
+				[2, false],
+				[3, false],
+			]),
+		])
+		expect(out.totalWipeout).toBe(true)
+		expect(out.startingRank).toBeNull()
+		expect(out.scores).toEqual([])
+	})
+
+	it('accumulates goals only for picks inside the streak', () => {
+		const out = resolveWipeout([
+			p('a', [
+				[1, true, 2],
+				[2, true, 3],
+				[3, false, 0],
+				[4, true, 9], // after the break — must not count
+			]),
+		])
+		expect(out.scores).toEqual([
+			{ gamePlayerId: 'a', streak: 2, goalsInStreak: 5, livesRemaining: 0 },
+		])
+	})
+
+	it('treats a rank gap (a voided pick excluded by the caller) as continuing the streak', () => {
+		// rank 2 was a voided fixture, so the caller omitted it. The streak walks
+		// past the gap: rank 1 + rank 3 are consecutive → streak 2.
+		const out = resolveWipeout([
+			p('a', [
+				[1, true, 1],
+				[3, true, 2],
+			]),
+		])
+		expect(out.scores).toEqual([
+			{ gamePlayerId: 'a', streak: 2, goalsInStreak: 3, livesRemaining: 0 },
+		])
+	})
+
+	it('carries livesRemaining through for the cup tiebreak', () => {
+		const out = resolveWipeout([p('a', [[1, true]], 3)])
+		expect(out.scores[0].livesRemaining).toBe(3)
 	})
 })

--- a/src/lib/game-logic/auto-complete-tiebreakers.ts
+++ b/src/lib/game-logic/auto-complete-tiebreakers.ts
@@ -45,3 +45,86 @@ export function cupTiebreaker(players: CupTiebreakerInput[]): string[] {
 	const topGoals = maxBy(topLives, (p) => p.cumulativeGoals)
 	return topGoals.map((p) => p.gamePlayerId)
 }
+
+// -- Wipeout rule (single-round modes: turbo + cup) --
+//
+// The winner is the longest *consecutive* streak of correct picks counted from
+// rank 1 — but leading ranks that were a UNIVERSAL loss (every player got that
+// rank wrong) are skipped, so the game effectively "restarts" from the first
+// rank anyone got right. This is a cross-player, winner-determination-layer
+// concern: the per-player evaluator can't see whether a rank was universally
+// lost. It also fixes the inflated-streak bug where scattered post-break wins
+// used to count toward the streak — here the streak stops at the first miss.
+//
+// Distinct from the "confirmed prefix / stop at first pending" rule in the
+// per-player evaluator: that bounds *which* picks are settled; this rebases
+// *where* the streak count begins, across all players.
+
+export interface WipeoutPickOutcome {
+	/** confidence rank (1 = most confident). */
+	rank: number
+	/** did this pick keep the streak alive (turbo: predicted right; cup: win / draw_success / saved_by_life). */
+	correct: boolean
+	/** goals to add to the goals tiebreak if this pick is inside the streak (0 otherwise). */
+	goals: number
+}
+
+export interface WipeoutPlayerInput {
+	gamePlayerId: string
+	/** settled, non-void picks in any order (sorted internally by rank). */
+	picks: WipeoutPickOutcome[]
+	/** final lives — cup tiebreak only; pass 0 for turbo. */
+	livesRemaining: number
+}
+
+export interface WipeoutScore {
+	gamePlayerId: string
+	streak: number
+	goalsInStreak: number
+	livesRemaining: number
+}
+
+export interface WipeoutOutcome {
+	/** true when no rank had a single correct pick anywhere → full refund, no winner. */
+	totalWipeout: boolean
+	/** lowest rank any player got right; null on a total wipeout. */
+	startingRank: number | null
+	/** per-player streak rebased to startingRank; empty on a total wipeout. */
+	scores: WipeoutScore[]
+}
+
+export function resolveWipeout(players: WipeoutPlayerInput[]): WipeoutOutcome {
+	// Starting rank = the lowest rank at which any player has a correct pick.
+	// This subsumes the "skip leading universal-loss ranks" recursion: a rank
+	// every player got wrong has no correct pick, so it's never the minimum.
+	let startingRank: number | null = null
+	for (const player of players) {
+		for (const pk of player.picks) {
+			if (pk.correct && (startingRank === null || pk.rank < startingRank)) {
+				startingRank = pk.rank
+			}
+		}
+	}
+	if (startingRank === null) {
+		return { totalWipeout: true, startingRank: null, scores: [] }
+	}
+
+	const start = startingRank
+	const scores = players.map((player) => {
+		const ordered = player.picks.filter((pk) => pk.rank >= start).sort((a, b) => a.rank - b.rank)
+		let streak = 0
+		let goalsInStreak = 0
+		for (const pk of ordered) {
+			if (!pk.correct) break
+			streak++
+			goalsInStreak += pk.goals
+		}
+		return {
+			gamePlayerId: player.gamePlayerId,
+			streak,
+			goalsInStreak,
+			livesRemaining: player.livesRemaining,
+		}
+	})
+	return { totalWipeout: false, startingRank, scores }
+}

--- a/src/lib/game/auto-complete.test.ts
+++ b/src/lib/game/auto-complete.test.ts
@@ -116,34 +116,113 @@ describe('checkClassicCompletion', () => {
 })
 
 describe('checkTurboCompletion', () => {
-	it('always completes', () => {
+	// Build a turbo player from [rank, correct, goals] tuples.
+	const tp = (
+		gamePlayerId: string,
+		picks: Array<[rank: number, correct: boolean, goals?: number]>,
+	) => ({
+		gamePlayerId,
+		livesRemaining: 0,
+		picks: picks.map(([rank, correct, goals = 0]) => ({ rank, correct, goals })),
+	})
+
+	it('crowns the longest streak and always completes', () => {
 		const result = checkTurboCompletion([
-			{ gamePlayerId: 'p1', streak: 7, goalsInStreak: 12 },
-			{ gamePlayerId: 'p2', streak: 5, goalsInStreak: 99 },
+			tp('p1', [
+				[1, true, 4],
+				[2, true, 4],
+				[3, true, 4],
+			]),
+			tp('p2', [
+				[1, true, 9],
+				[2, false],
+			]),
 		])
 		expect(result.completed).toBe(true)
 		expect(result.reason).toBe('turbo-single-round')
 		expect(result.winnerPlayerIds).toEqual(['p1'])
 	})
 
+	it('tiebreaks equal streaks by goals (no lives in turbo)', () => {
+		const result = checkTurboCompletion([
+			tp('p1', [
+				[1, true, 1],
+				[2, true, 1],
+			]),
+			tp('p2', [
+				[1, true, 5],
+				[2, true, 5],
+			]),
+		])
+		expect(result.winnerPlayerIds).toEqual(['p2'])
+	})
+
 	it('splits on full tie', () => {
 		const result = checkTurboCompletion([
-			{ gamePlayerId: 'p1', streak: 5, goalsInStreak: 8 },
-			{ gamePlayerId: 'p2', streak: 5, goalsInStreak: 8 },
+			tp('p1', [
+				[1, true, 4],
+				[2, true, 4],
+			]),
+			tp('p2', [
+				[1, true, 4],
+				[2, true, 4],
+			]),
 		])
 		expect(result.completed).toBe(true)
 		expect(result.winnerPlayerIds.sort()).toEqual(['p1', 'p2'])
 	})
 
-	it('completes with empty winners when no players', () => {
+	it('skips a leading universal-loss rank, then crowns the rebased streak', () => {
+		const result = checkTurboCompletion([
+			tp('p1', [
+				[1, false],
+				[2, true, 2],
+				[3, true, 3],
+			]),
+			tp('p2', [
+				[1, false],
+				[2, false],
+			]),
+		])
+		expect(result.reason).toBe('turbo-single-round')
+		expect(result.winnerPlayerIds).toEqual(['p1'])
+	})
+
+	it('refunds (no winner) on a total wipeout — everyone got every pick wrong', () => {
+		const result = checkTurboCompletion([
+			tp('p1', [
+				[1, false],
+				[2, false],
+			]),
+			tp('p2', [
+				[1, false],
+				[2, false],
+			]),
+		])
+		expect(result.completed).toBe(true)
+		expect(result.reason).toBe('turbo-total-wipeout')
+		expect(result.refund).toBe(true)
+		expect(result.winnerPlayerIds).toEqual([])
+	})
+
+	it('completes with empty winners (no refund) when no players', () => {
 		const result = checkTurboCompletion([])
 		expect(result.completed).toBe(true)
 		expect(result.winnerPlayerIds).toEqual([])
+		expect(result.refund).toBeFalsy()
 	})
 })
 
 describe('checkCupCompletion (single gameweek — longest streak)', () => {
 	beforeEach(() => vi.clearAllMocks())
+
+	// Cup pick rows carry a confidenceRank; the streak is now rank-ordered.
+	const cupPick = (
+		gamePlayerId: string,
+		confidenceRank: number,
+		result: string,
+		goalsScored = 0,
+	) => ({ gamePlayerId, confidenceRank, result, goalsScored })
 
 	it('crowns the longest streak across all players (tiebreak streak→lives→goals)', async () => {
 		dbMock.query.gamePlayer.findMany.mockResolvedValue([
@@ -152,16 +231,16 @@ describe('checkCupCompletion (single gameweek — longest streak)', () => {
 		] as never)
 		// both streak 5; p1 = 7 goals, p2 = 12 goals → p2 on the goals tiebreak
 		dbMock.query.pick.findMany.mockResolvedValue([
-			{ gamePlayerId: 'p1', result: 'win', goalsScored: 3 },
-			{ gamePlayerId: 'p1', result: 'win', goalsScored: 2 },
-			{ gamePlayerId: 'p1', result: 'draw', goalsScored: 1 },
-			{ gamePlayerId: 'p1', result: 'saved_by_life', goalsScored: 1 },
-			{ gamePlayerId: 'p1', result: 'win', goalsScored: 0 },
-			{ gamePlayerId: 'p2', result: 'win', goalsScored: 4 },
-			{ gamePlayerId: 'p2', result: 'win', goalsScored: 4 },
-			{ gamePlayerId: 'p2', result: 'win', goalsScored: 4 },
-			{ gamePlayerId: 'p2', result: 'draw', goalsScored: 0 },
-			{ gamePlayerId: 'p2', result: 'saved_by_life', goalsScored: 0 },
+			cupPick('p1', 1, 'win', 3),
+			cupPick('p1', 2, 'win', 2),
+			cupPick('p1', 3, 'draw', 1),
+			cupPick('p1', 4, 'saved_by_life', 1),
+			cupPick('p1', 5, 'win', 0),
+			cupPick('p2', 1, 'win', 4),
+			cupPick('p2', 2, 'win', 4),
+			cupPick('p2', 3, 'win', 4),
+			cupPick('p2', 4, 'draw', 0),
+			cupPick('p2', 5, 'saved_by_life', 0),
 		] as never)
 
 		const result = await checkCupCompletion('g1')
@@ -177,19 +256,78 @@ describe('checkCupCompletion (single gameweek — longest streak)', () => {
 		] as never)
 		// p-alive: 3 correct, never broke. p-broke: 5 correct then a loss (streak 5).
 		dbMock.query.pick.findMany.mockResolvedValue([
-			{ gamePlayerId: 'p-alive', result: 'win', goalsScored: 1 },
-			{ gamePlayerId: 'p-alive', result: 'win', goalsScored: 1 },
-			{ gamePlayerId: 'p-alive', result: 'win', goalsScored: 1 },
-			{ gamePlayerId: 'p-broke', result: 'win', goalsScored: 1 },
-			{ gamePlayerId: 'p-broke', result: 'win', goalsScored: 1 },
-			{ gamePlayerId: 'p-broke', result: 'win', goalsScored: 1 },
-			{ gamePlayerId: 'p-broke', result: 'win', goalsScored: 1 },
-			{ gamePlayerId: 'p-broke', result: 'win', goalsScored: 1 },
-			{ gamePlayerId: 'p-broke', result: 'loss', goalsScored: 0 },
+			cupPick('p-alive', 1, 'win', 1),
+			cupPick('p-alive', 2, 'win', 1),
+			cupPick('p-alive', 3, 'win', 1),
+			cupPick('p-broke', 1, 'win', 1),
+			cupPick('p-broke', 2, 'win', 1),
+			cupPick('p-broke', 3, 'win', 1),
+			cupPick('p-broke', 4, 'win', 1),
+			cupPick('p-broke', 5, 'win', 1),
+			cupPick('p-broke', 6, 'loss', 0),
 		] as never)
 
 		const result = await checkCupCompletion('g1')
 		expect(result.winnerPlayerIds).toEqual(['p-broke'])
+	})
+
+	it('does NOT count wins that come after the streak broke (the d8360e69 mis-crowning)', async () => {
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([
+			{ id: 'p-steady', status: 'alive', eliminatedRoundId: null, livesRemaining: 0 },
+			{ id: 'p-scattered', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+		] as never)
+		// p-scattered won 4 picks total but BROKE at rank 2 → real streak is 1.
+		// p-steady won ranks 1 & 2 cleanly → streak 2. p-steady must win.
+		dbMock.query.pick.findMany.mockResolvedValue([
+			cupPick('p-steady', 1, 'win', 1),
+			cupPick('p-steady', 2, 'win', 1),
+			cupPick('p-scattered', 1, 'win', 9),
+			cupPick('p-scattered', 2, 'loss', 0),
+			cupPick('p-scattered', 3, 'win', 9),
+			cupPick('p-scattered', 4, 'win', 9),
+			cupPick('p-scattered', 5, 'win', 9),
+		] as never)
+
+		const result = await checkCupCompletion('g1')
+		expect(result.winnerPlayerIds).toEqual(['p-steady'])
+	})
+
+	it('skips a leading universal-loss rank — the game restarts from rank 2', async () => {
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([
+			{ id: 'pA', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+			{ id: 'pB', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+		] as never)
+		// rank 1 lost for everyone. From rank 2: A wins 2 & 3, B loses 2.
+		dbMock.query.pick.findMany.mockResolvedValue([
+			cupPick('pA', 1, 'loss', 0),
+			cupPick('pA', 2, 'win', 1),
+			cupPick('pA', 3, 'win', 1),
+			cupPick('pB', 1, 'loss', 0),
+			cupPick('pB', 2, 'loss', 0),
+		] as never)
+
+		const result = await checkCupCompletion('g1')
+		expect(result.reason).toBe('cup-longest-streak')
+		expect(result.winnerPlayerIds).toEqual(['pA'])
+	})
+
+	it('refunds (no winner) on a total wipeout — every player got every pick wrong', async () => {
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([
+			{ id: 'pA', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+			{ id: 'pB', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+		] as never)
+		dbMock.query.pick.findMany.mockResolvedValue([
+			cupPick('pA', 1, 'loss', 0),
+			cupPick('pA', 2, 'loss', 0),
+			cupPick('pB', 1, 'loss', 0),
+			cupPick('pB', 2, 'loss', 0),
+		] as never)
+
+		const result = await checkCupCompletion('g1')
+		expect(result.completed).toBe(true)
+		expect(result.reason).toBe('cup-total-wipeout')
+		expect(result.refund).toBe(true)
+		expect(result.winnerPlayerIds).toEqual([])
 	})
 
 	it('tiebreaks equal streaks by lives', async () => {
@@ -199,16 +337,22 @@ describe('checkCupCompletion (single gameweek — longest streak)', () => {
 		] as never)
 		// equal streak 3; p2 has more lives → p2
 		dbMock.query.pick.findMany.mockResolvedValue([
-			{ gamePlayerId: 'p1', result: 'win', goalsScored: 5 },
-			{ gamePlayerId: 'p1', result: 'win', goalsScored: 5 },
-			{ gamePlayerId: 'p1', result: 'win', goalsScored: 5 },
-			{ gamePlayerId: 'p2', result: 'win', goalsScored: 1 },
-			{ gamePlayerId: 'p2', result: 'win', goalsScored: 1 },
-			{ gamePlayerId: 'p2', result: 'win', goalsScored: 1 },
+			cupPick('p1', 1, 'win', 5),
+			cupPick('p1', 2, 'win', 5),
+			cupPick('p1', 3, 'win', 5),
+			cupPick('p2', 1, 'win', 1),
+			cupPick('p2', 2, 'win', 1),
+			cupPick('p2', 3, 'win', 1),
 		] as never)
 
 		const result = await checkCupCompletion('g1')
 		expect(result.reason).toBe('cup-longest-streak')
 		expect(result.winnerPlayerIds).toEqual(['p2'])
+	})
+
+	it('ignores void picks and does not complete when there are no players', async () => {
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([] as never)
+		const result = await checkCupCompletion('g1')
+		expect(result.completed).toBe(false)
 	})
 })

--- a/src/lib/game/auto-complete.test.ts
+++ b/src/lib/game/auto-complete.test.ts
@@ -142,26 +142,15 @@ describe('checkTurboCompletion', () => {
 	})
 })
 
-describe('checkCupCompletion', () => {
+describe('checkCupCompletion (single gameweek — longest streak)', () => {
 	beforeEach(() => vi.clearAllMocks())
 
-	it('completes with last-alive when 1 alive', async () => {
-		dbMock.query.gamePlayer.findMany.mockResolvedValue([
-			{ id: 'p1', status: 'alive', eliminatedRoundId: null, livesRemaining: 2 },
-			{ id: 'p2', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
-		] as never)
-
-		const result = await checkCupCompletion('g1', 'c1', 'r1', 3)
-		expect(result.reason).toBe('last-alive')
-		expect(result.winnerPlayerIds).toEqual(['p1'])
-	})
-
-	it('mass extinction tiebreaks streak then lives then goals', async () => {
+	it('crowns the longest streak across all players (tiebreak streak→lives→goals)', async () => {
 		dbMock.query.gamePlayer.findMany.mockResolvedValue([
 			{ id: 'p1', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
 			{ id: 'p2', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
 		] as never)
-		// p1: 5 successful picks, 7 goals; p2: 5 successful picks, 12 goals
+		// both streak 5; p1 = 7 goals, p2 = 12 goals → p2 on the goals tiebreak
 		dbMock.query.pick.findMany.mockResolvedValue([
 			{ gamePlayerId: 'p1', result: 'win', goalsScored: 3 },
 			{ gamePlayerId: 'p1', result: 'win', goalsScored: 2 },
@@ -175,19 +164,40 @@ describe('checkCupCompletion', () => {
 			{ gamePlayerId: 'p2', result: 'saved_by_life', goalsScored: 0 },
 		] as never)
 
-		const result = await checkCupCompletion('g1', 'c1', 'r1', 3)
-		// streak ties (5=5), lives ties (0=0), goals: p2 wins 12 > 7
-		expect(result.reason).toBe('mass-extinction')
+		const result = await checkCupCompletion('g1')
+		expect(result.completed).toBe(true)
+		expect(result.reason).toBe('cup-longest-streak')
 		expect(result.winnerPlayerIds).toEqual(['p2'])
 	})
 
-	it('rounds-exhausted with multiple alive uses cup tiebreaker', async () => {
+	it('a long BROKEN streak beats a short unbroken (alive) one — status is irrelevant, streak length wins', async () => {
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([
+			{ id: 'p-alive', status: 'alive', eliminatedRoundId: null, livesRemaining: 0 },
+			{ id: 'p-broke', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+		] as never)
+		// p-alive: 3 correct, never broke. p-broke: 5 correct then a loss (streak 5).
+		dbMock.query.pick.findMany.mockResolvedValue([
+			{ gamePlayerId: 'p-alive', result: 'win', goalsScored: 1 },
+			{ gamePlayerId: 'p-alive', result: 'win', goalsScored: 1 },
+			{ gamePlayerId: 'p-alive', result: 'win', goalsScored: 1 },
+			{ gamePlayerId: 'p-broke', result: 'win', goalsScored: 1 },
+			{ gamePlayerId: 'p-broke', result: 'win', goalsScored: 1 },
+			{ gamePlayerId: 'p-broke', result: 'win', goalsScored: 1 },
+			{ gamePlayerId: 'p-broke', result: 'win', goalsScored: 1 },
+			{ gamePlayerId: 'p-broke', result: 'win', goalsScored: 1 },
+			{ gamePlayerId: 'p-broke', result: 'loss', goalsScored: 0 },
+		] as never)
+
+		const result = await checkCupCompletion('g1')
+		expect(result.winnerPlayerIds).toEqual(['p-broke'])
+	})
+
+	it('tiebreaks equal streaks by lives', async () => {
 		dbMock.query.gamePlayer.findMany.mockResolvedValue([
 			{ id: 'p1', status: 'alive', eliminatedRoundId: null, livesRemaining: 1 },
 			{ id: 'p2', status: 'alive', eliminatedRoundId: null, livesRemaining: 3 },
 		] as never)
-		dbMock.query.round.findFirst.mockResolvedValue(null as never)
-		// equal streak: p1=3, p2=3; p2 has more lives
+		// equal streak 3; p2 has more lives → p2
 		dbMock.query.pick.findMany.mockResolvedValue([
 			{ gamePlayerId: 'p1', result: 'win', goalsScored: 5 },
 			{ gamePlayerId: 'p1', result: 'win', goalsScored: 5 },
@@ -197,8 +207,8 @@ describe('checkCupCompletion', () => {
 			{ gamePlayerId: 'p2', result: 'win', goalsScored: 1 },
 		] as never)
 
-		const result = await checkCupCompletion('g1', 'c1', 'r1', 7)
-		expect(result.reason).toBe('rounds-exhausted')
+		const result = await checkCupCompletion('g1')
+		expect(result.reason).toBe('cup-longest-streak')
 		expect(result.winnerPlayerIds).toEqual(['p2'])
 	})
 })

--- a/src/lib/game/auto-complete.ts
+++ b/src/lib/game/auto-complete.ts
@@ -1,10 +1,11 @@
-import { and, asc, eq, gt } from 'drizzle-orm'
+import { and, asc, eq, gt, inArray } from 'drizzle-orm'
 import { db } from '@/lib/db'
 import {
 	classicTiebreaker,
 	cupTiebreaker,
-	type TurboTiebreakerInput,
+	resolveWipeout,
 	turboTiebreaker,
+	type WipeoutPlayerInput,
 } from '@/lib/game-logic/auto-complete-tiebreakers'
 import { calculatePayouts, calculatePot } from '@/lib/game-logic/prizes'
 import { round } from '@/lib/schema/competition'
@@ -16,12 +17,16 @@ export type CompletionReason =
 	| 'mass-extinction'
 	| 'rounds-exhausted'
 	| 'turbo-single-round'
+	| 'turbo-total-wipeout'
 	| 'cup-longest-streak'
+	| 'cup-total-wipeout'
 
 export interface CompletionCheckResult {
 	completed: boolean
 	winnerPlayerIds: string[]
 	reason?: CompletionReason
+	/** total wipeout — every player got every pick wrong → refund everyone, no payout. */
+	refund?: boolean
 }
 
 async function nextRoundExists(
@@ -49,29 +54,6 @@ async function tiebreakClassicByGoals(
 			.reduce((sum, p) => sum + (p.goalsScored ?? 0), 0),
 	}))
 	return classicTiebreaker(inputs)
-}
-
-async function tiebreakCup(
-	gameId: string,
-	candidates: { id: string; livesRemaining: number }[],
-): Promise<string[]> {
-	const allPicks = await db.query.pick.findMany({
-		where: eq(pick.gameId, gameId),
-	})
-	const inputs = candidates.map((c) => {
-		const myPicks = allPicks.filter((p) => p.gamePlayerId === c.id)
-		const cumulativeStreak = myPicks.filter(
-			(p) => p.result === 'win' || p.result === 'draw' || p.result === 'saved_by_life',
-		).length
-		const cumulativeGoals = myPicks.reduce((sum, p) => sum + (p.goalsScored ?? 0), 0)
-		return {
-			gamePlayerId: c.id,
-			cumulativeStreak,
-			livesRemaining: c.livesRemaining,
-			cumulativeGoals,
-		}
-	})
-	return cupTiebreaker(inputs)
 }
 
 export async function checkClassicCompletion(
@@ -113,32 +95,93 @@ export async function checkClassicCompletion(
 	return { completed: false, winnerPlayerIds: [] }
 }
 
-export function checkTurboCompletion(playerScores: TurboTiebreakerInput[]): CompletionCheckResult {
-	const winners = turboTiebreaker(playerScores)
-	return {
-		completed: true,
-		winnerPlayerIds: winners,
-		reason: 'turbo-single-round',
+/**
+ * Turbo is a SINGLE round decided by the longest streak of correct predictions.
+ * The wipeout rule (see `resolveWipeout`) skips any leading ranks that were a
+ * universal loss, then crowns the longest rebased streak (tiebreak: goals — no
+ * lives in turbo). A total wipeout (no player got a single pick right anywhere)
+ * refunds everyone with no winner. The caller only invokes this once the round
+ * is fully settled.
+ */
+export function checkTurboCompletion(players: WipeoutPlayerInput[]): CompletionCheckResult {
+	if (players.length === 0) {
+		return { completed: true, winnerPlayerIds: [], reason: 'turbo-single-round' }
 	}
+	const outcome = resolveWipeout(players)
+	if (outcome.totalWipeout) {
+		return {
+			completed: true,
+			winnerPlayerIds: [],
+			reason: 'turbo-total-wipeout',
+			refund: true,
+		}
+	}
+	const winners = turboTiebreaker(
+		outcome.scores.map((s) => ({
+			gamePlayerId: s.gamePlayerId,
+			streak: s.streak,
+			goalsInStreak: s.goalsInStreak,
+		})),
+	)
+	return { completed: true, winnerPlayerIds: winners, reason: 'turbo-single-round' }
 }
 
 /**
  * Cup is a SINGLE gameweek decided by the longest streak (with the tier
  * handicap + lives folded into the streak). The caller only invokes this once
- * the whole gameweek is fully settled, so we simply crown the longest streak
- * across ALL players — `tiebreakCup` ranks by cumulative streak → lives →
- * goals. The winner can be a player whose streak *broke*: a long broken streak
- * still beats a short unbroken one. There is no per-round elimination winner
- * and no advancement — cup never spans gameweeks.
+ * the whole gameweek is fully settled.
+ *
+ * The streak is a *consecutive* run of surviving picks (win / draw_success /
+ * saved_by_life) counted in confidence-rank order — the wipeout rule
+ * (`resolveWipeout`) skips any leading ranks that were a universal loss, so the
+ * game restarts from the first rank anyone got right, then crowns the longest
+ * rebased streak (tiebreak: lives → goals). The winner can be a player whose
+ * streak later *broke*: a long broken streak still beats a short unbroken one.
+ * A total wipeout (no rank has a single correct pick anywhere) refunds everyone
+ * with no winner. No per-round elimination winner and no advancement — cup
+ * never spans gameweeks.
  */
 export async function checkCupCompletion(gameId: string): Promise<CompletionCheckResult> {
 	const allPlayers = await db.query.gamePlayer.findMany({
 		where: eq(gamePlayer.gameId, gameId),
 	})
 	if (allPlayers.length === 0) return { completed: false, winnerPlayerIds: [] }
-	const winners = await tiebreakCup(
-		gameId,
-		allPlayers.map((p) => ({ id: p.id, livesRemaining: p.livesRemaining })),
+
+	const allPicks = await db.query.pick.findMany({
+		where: eq(pick.gameId, gameId),
+	})
+	const players: WipeoutPlayerInput[] = allPlayers.map((p) => ({
+		gamePlayerId: p.id,
+		livesRemaining: p.livesRemaining,
+		picks: allPicks
+			.filter((pk) => pk.gamePlayerId === p.id)
+			// Settled, non-void picks only. Void (cancelled fixture) and pending
+			// picks contribute nothing — the streak walks past a void gap and stops
+			// at any pending pick (there should be none once the gameweek is done).
+			.filter((pk) => pk.result != null && pk.result !== 'void' && pk.result !== 'pending')
+			.map((pk) => ({
+				rank: pk.confidenceRank ?? 0,
+				correct: pk.result === 'win' || pk.result === 'draw' || pk.result === 'saved_by_life',
+				goals: pk.goalsScored ?? 0,
+			})),
+	}))
+
+	const outcome = resolveWipeout(players)
+	if (outcome.totalWipeout) {
+		return {
+			completed: true,
+			winnerPlayerIds: [],
+			reason: 'cup-total-wipeout',
+			refund: true,
+		}
+	}
+	const winners = cupTiebreaker(
+		outcome.scores.map((s) => ({
+			gamePlayerId: s.gamePlayerId,
+			cumulativeStreak: s.streak,
+			livesRemaining: s.livesRemaining,
+			cumulativeGoals: s.goalsInStreak,
+		})),
 	)
 	return { completed: true, winnerPlayerIds: winners, reason: 'cup-longest-streak' }
 }
@@ -146,7 +189,22 @@ export async function checkCupCompletion(gameId: string): Promise<CompletionChec
 export async function applyAutoCompletion(
 	gameId: string,
 	winnerPlayerIds: string[],
+	options?: { refund?: boolean },
 ): Promise<void> {
+	// Total wipeout: no winner. Refund every contributing stake and complete the
+	// game. No payout rows are written.
+	if (options?.refund) {
+		await db
+			.update(payment)
+			.set({ status: 'refunded', refundedAt: new Date() })
+			.where(and(eq(payment.gameId, gameId), inArray(payment.status, ['paid', 'claimed'])))
+		await db
+			.update(game)
+			.set({ status: 'completed', currentRoundId: null })
+			.where(eq(game.id, gameId))
+		return
+	}
+
 	if (winnerPlayerIds.length === 0) return
 
 	for (const playerId of winnerPlayerIds) {

--- a/src/lib/game/auto-complete.ts
+++ b/src/lib/game/auto-complete.ts
@@ -16,6 +16,7 @@ export type CompletionReason =
 	| 'mass-extinction'
 	| 'rounds-exhausted'
 	| 'turbo-single-round'
+	| 'cup-longest-streak'
 
 export interface CompletionCheckResult {
 	completed: boolean
@@ -121,37 +122,25 @@ export function checkTurboCompletion(playerScores: TurboTiebreakerInput[]): Comp
 	}
 }
 
-export async function checkCupCompletion(
-	gameId: string,
-	competitionId: string,
-	completedRoundId: string,
-	completedRoundNumber: number,
-): Promise<CompletionCheckResult> {
+/**
+ * Cup is a SINGLE gameweek decided by the longest streak (with the tier
+ * handicap + lives folded into the streak). The caller only invokes this once
+ * the whole gameweek is fully settled, so we simply crown the longest streak
+ * across ALL players — `tiebreakCup` ranks by cumulative streak → lives →
+ * goals. The winner can be a player whose streak *broke*: a long broken streak
+ * still beats a short unbroken one. There is no per-round elimination winner
+ * and no advancement — cup never spans gameweeks.
+ */
+export async function checkCupCompletion(gameId: string): Promise<CompletionCheckResult> {
 	const allPlayers = await db.query.gamePlayer.findMany({
 		where: eq(gamePlayer.gameId, gameId),
 	})
-	const alive = allPlayers.filter((p) => p.status === 'alive')
-
-	if (alive.length === 1) {
-		return { completed: true, winnerPlayerIds: [alive[0].id], reason: 'last-alive' }
-	}
-
-	if (alive.length === 0) {
-		const cohort = allPlayers.filter(
-			(p) => p.status === 'eliminated' && p.eliminatedRoundId === completedRoundId,
-		)
-		if (cohort.length === 0) return { completed: false, winnerPlayerIds: [] }
-		const winners = await tiebreakCup(gameId, cohort)
-		return { completed: true, winnerPlayerIds: winners, reason: 'mass-extinction' }
-	}
-
-	const hasNext = await nextRoundExists(competitionId, completedRoundNumber)
-	if (!hasNext) {
-		const winners = await tiebreakCup(gameId, alive)
-		return { completed: true, winnerPlayerIds: winners, reason: 'rounds-exhausted' }
-	}
-
-	return { completed: false, winnerPlayerIds: [] }
+	if (allPlayers.length === 0) return { completed: false, winnerPlayerIds: [] }
+	const winners = await tiebreakCup(
+		gameId,
+		allPlayers.map((p) => ({ id: p.id, livesRemaining: p.livesRemaining })),
+	)
+	return { completed: true, winnerPlayerIds: winners, reason: 'cup-longest-streak' }
 }
 
 export async function applyAutoCompletion(

--- a/src/lib/game/settle.ts
+++ b/src/lib/game/settle.ts
@@ -7,10 +7,10 @@ import {
 	checkTurboCompletion,
 } from '@/lib/game/auto-complete'
 import { openRoundForGame } from '@/lib/game/round-lifecycle'
+import type { WipeoutPlayerInput } from '@/lib/game-logic/auto-complete-tiebreakers'
 import { determinePickResult } from '@/lib/game-logic/common'
 import { evaluateCupPicks } from '@/lib/game-logic/cup'
 import { computeTierDifference } from '@/lib/game-logic/cup-tier'
-import { evaluateTurboPicks } from '@/lib/game-logic/turbo'
 import {
 	computeWcClassicAutoElims,
 	type WcFixture,
@@ -274,7 +274,15 @@ export async function reevaluateCupGame(gameId: string): Promise<boolean> {
 	let anyChanged = false
 
 	for (const player of g.players) {
-		if (player.status !== 'alive') continue
+		// Evaluate EVERY player's picks, not just the currently-alive ones. The
+		// wipeout rule (checkCupCompletion) needs the full rank-ordered result
+		// sequence for everyone, including players whose streak already broke —
+		// when a leading rank is a universal loss, an "eliminated" player can win
+		// the rebased streak from a later rank, so their later picks must settle
+		// rather than stay `pending`. evaluateCupPicks is idempotent and only ever
+		// sets `eliminated` (never revives), so re-running on a broken player is
+		// safe. Players with no picks (e.g. no-pick eliminations) fall through the
+		// `settleable.length === 0` guard below untouched.
 
 		const playerPicks = existingPicks
 			.filter((p) => p.gamePlayerId === player.id)
@@ -430,7 +438,7 @@ async function checkAndMaybeCompleteOrAdvance(
 		// advances across matchdays.
 		if (!allFinished) return
 		const completion = await checkCupCompletion(gameId)
-		await applyAutoCompletion(gameId, completion.winnerPlayerIds)
+		await applyAutoCompletion(gameId, completion.winnerPlayerIds, { refund: completion.refund })
 		result.gamesCompleted.push(gameId)
 		await db.update(round).set({ status: 'completed' }).where(eq(round.id, roundId))
 		result.roundsCompleted.push(roundId)
@@ -439,7 +447,7 @@ async function checkAndMaybeCompleteOrAdvance(
 		if (!allFinished) return
 		const turboPlayerResults = await collectTurboPlayerResults(gameId, roundId)
 		const completion = checkTurboCompletion(turboPlayerResults)
-		await applyAutoCompletion(gameId, completion.winnerPlayerIds)
+		await applyAutoCompletion(gameId, completion.winnerPlayerIds, { refund: completion.refund })
 		result.gamesCompleted.push(gameId)
 		// Mark the round complete; turbo doesn't advance (single-round mode).
 		await db.update(round).set({ status: 'completed' }).where(eq(round.id, roundId))
@@ -457,34 +465,32 @@ async function checkAndMaybeCompleteOrAdvance(
 	}
 }
 
-async function collectTurboPlayerResults(gameId: string, roundId: string) {
+async function collectTurboPlayerResults(
+	gameId: string,
+	roundId: string,
+): Promise<WipeoutPlayerInput[]> {
 	const players = await db.query.gamePlayer.findMany({
 		where: and(eq(gamePlayer.gameId, gameId), eq(gamePlayer.status, 'alive')),
 	})
 	const picks = await db.query.pick.findMany({
 		where: and(eq(pick.gameId, gameId), eq(pick.roundId, roundId)),
-		with: { fixture: true },
 	})
-	return players.map((p) => {
-		// Skip void picks — the streak evaluator walks past as if they
-		// weren't in the input. Equivalent to a 9-pick game when one
-		// fixture was cancelled.
-		const playerPicks = picks
+	return players.map((p) => ({
+		gamePlayerId: p.id,
+		// Turbo has no lives mechanic — the goals tiebreak settles ties.
+		livesRemaining: 0,
+		// Picks are already settled by settleTurboPickRow (result + goalsScored).
+		// Skip void picks — the streak walks past them as if they weren't in the
+		// input (equivalent to a 9-pick game when one fixture was cancelled).
+		picks: picks
 			.filter((pk) => pk.gamePlayerId === p.id)
-			.filter((pk) => pk.result !== 'void')
+			.filter((pk) => pk.result != null && pk.result !== 'void' && pk.result !== 'pending')
 			.map((pk) => ({
-				confidenceRank: pk.confidenceRank ?? 0,
-				predictedResult: (pk.predictedResult ?? 'draw') as 'home_win' | 'draw' | 'away_win',
-				homeScore: pk.fixture?.homeScore ?? 0,
-				awayScore: pk.fixture?.awayScore ?? 0,
-			}))
-		const turbo = evaluateTurboPicks(playerPicks)
-		return {
-			gamePlayerId: p.id,
-			streak: turbo.streak,
-			goalsInStreak: turbo.goalsInStreak,
-		}
-	})
+				rank: pk.confidenceRank ?? 0,
+				correct: pk.result === 'win',
+				goals: pk.goalsScored ?? 0,
+			})),
+	}))
 }
 
 async function runWcClassicAutoElims(gameId: string, currentRoundId: string): Promise<void> {

--- a/src/lib/game/settle.ts
+++ b/src/lib/game/settle.ts
@@ -294,7 +294,12 @@ export async function reevaluateCupGame(gameId: string): Promise<boolean> {
 			const fx = g.currentRound.fixtures.find((f) => f.id === p.fixtureId)
 			if (!fx) continue
 			if (fx.status === 'cancelled') continue
-			if (fx.homeScore == null || fx.awayScore == null) continue
+			// Confirmed-streak boundary: STOP at the first pending pick in rank
+			// order. A player's streak — and any elimination from it — can't be
+			// confirmed while a higher-confidence pick is still unplayed. The live
+			// UI projects later-settled results; the streak is only FINALISED on
+			// the contiguous settled prefix from rank 1.
+			if (fx.homeScore == null || fx.awayScore == null) break
 			settleable.push({ pickRow: p, fixture: fx })
 		}
 		if (settleable.length === 0) continue
@@ -418,12 +423,18 @@ async function checkAndMaybeCompleteOrAdvance(
 			return
 		}
 	} else if (g.gameMode === 'cup') {
-		const completion = await checkCupCompletion(gameId, g.competitionId, roundId, roundNumber)
-		if (completion.completed) {
-			await applyAutoCompletion(gameId, completion.winnerPlayerIds)
-			result.gamesCompleted.push(gameId)
-			return
-		}
+		// Cup is a SINGLE gameweek decided by the longest streak — exactly like
+		// turbo, just with the tier handicap + lives baked into the streak.
+		// Wait until the whole gameweek is settled, then crown the longest
+		// streak. Cup never eliminates-to-complete mid-gameweek and never
+		// advances across matchdays.
+		if (!allFinished) return
+		const completion = await checkCupCompletion(gameId)
+		await applyAutoCompletion(gameId, completion.winnerPlayerIds)
+		result.gamesCompleted.push(gameId)
+		await db.update(round).set({ status: 'completed' }).where(eq(round.id, roundId))
+		result.roundsCompleted.push(roundId)
+		return
 	} else if (g.gameMode === 'turbo') {
 		if (!allFinished) return
 		const turboPlayerResults = await collectTurboPlayerResults(gameId, roundId)


### PR DESCRIPTION
## What & why

Fixes how **single-round modes (cup + turbo) decide a winner**, and brings the
game-mode docs in line with the actual model. Triggered by the live World Cup
incident on cup game `d8360e69`, which crowned an *eliminated* player.

Two problems were tangled together: the engine had the wrong completion model
for cup, and the docs described cup as something it isn't.

## The model (now locked)

`classic` is the only **multi-round** mode (one pick per round, survive round
to round). `turbo` and `cup` are **single-round**: N confidence-ranked picks in
one gameweek, **longest streak of correct picks wins** — no eliminations-to-
advance, no carry-over. `cup` is turbo plus a tier handicap + lives.

## Changes

### 1. Cup single-gameweek completion (mirror turbo) — `4c48844`
Cup now waits for the whole gameweek to settle, then crowns the **longest
streak** (a streak that *broke* can still win if it's the longest). No
per-round elimination winner, no advancement across matchdays. Streak is
confirmed on the contiguous settled prefix from rank 1 (stops at the first
pending pick).

### 2. Wipeout rule — winner determination (`d4682d3`)
Resolves the OPEN design question that the `d8360e69` incident exposed. Applied
in `checkCupCompletion` + `checkTurboCompletion` via a new pure
`resolveWipeout`:

- **Skip leading universal-loss ranks.** If rank 1 was a loss for *every*
  player it's discarded and the streak count restarts from rank 2 (recursing as
  needed) — the rebased start is the lowest rank anyone got right. So a player
  who lost rank 1 alongside everyone else can still win on ranks 2+.
- **True consecutive streak.** The streak is now a consecutive run from the
  rebased start. This fixes the **root cause of the `d8360e69` mis-crowning**:
  the old cup tiebreaker counted *every* scattered success, including wins
  logged after a streak had already broken, which handed the trophy to an
  eliminated player.
- **Total wipeout → full refund.** If no rank has a single correct pick anywhere
  (everyone got everything wrong), there is no winner: the game completes, every
  stake is refunded (`payment.status = 'refunded'`), and no payout is written.
- **No lives carry into the rebased start** — discarded ranks are all losses,
  and lives are earned only by winning, so a player enters with `startingLives`.

Supporting fix: `reevaluateCupGame` no longer skips non-alive players, so an
eliminated player's later picks settle to their true result instead of
stranding as `pending` — required for the rebase to see wins on ranks after a
universal loss.

### 3. Game-mode docs rework — `4735284`, `641bd9a`, `ef3db3a` (+ this PR)
`docs/game-modes/` is the authoritative spec; it was describing cup as a
multi-round, advancing mode. This corrects and **substantially simplifies** it:

- Corrected cup from multi-round → single-round; scoped "advancement" language
  to classic only.
- Added a **"modes at a glance"** table (rounds/picks/wins-by/eliminations) and
  ran a clarity + de-duplication pass across `README.md` / `classic.md` /
  `turbo.md` / `cup.md`.
- Clarified the tier handicap is **per-competition**, not WC-only.
- Replaced the OPEN wipeout block in `cup.md` with the implemented rule (kept
  distinct from the per-player confirmed-prefix rule); documented the same
  rebase + total-wipeout refund in `turbo.md` (tiebreak = goals, no lives);
  updated the README settlement mermaid + "Wins by" prose.

## Tests
- **Unit:** `resolveWipeout` (skip / recurse / total-wipeout / goals-in-streak /
  void-gap); rank-aware `checkCupCompletion` incl. an explicit
  "post-break wins don't inflate the streak" case; new `checkTurboCompletion`
  signature with skip + total-wipeout.
- **Smoke** (`lifecycle.smoke.test.ts`): cup skip-leading-universal-loss crowns
  the rebased winner (proves eliminated players' later picks settle); cup total
  wipeout refunds + no payout; turbo total wipeout refunds + no payout.

## Verification
typecheck ✓ · unit 449 ✓ · smoke 27 ✓ · build ✓ (local, against a freshly
migrated DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)