### PR TITLE
feat(classic): lockable, visible advance picks for future rounds

### DIFF
--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -225,24 +225,28 @@ export default async function GameDetailPage({
 		: null
 
 	const pickSection =
-		game.currentRound && isAlive && !roundDeadlinePassed ? (
-			game.gameMode === 'classic' && classicPickData ? (
-				<ClassicPick
-					gameId={game.id}
-					roundId={game.currentRound.id}
-					roundName={classicPickData.roundName}
-					roundNumber={classicPickData.roundNumber}
-					competitionId={classicPickData.competitionId}
-					deadline={classicPickData.deadline}
-					fixtures={classicPickData.fixtures}
-					usedTeamsByRound={classicPickData.usedTeamsByRound}
-					existingPickTeamId={classicPickData.existingPickTeamId}
-					existingPickFixtureId={classicPickData.existingPickFixtureId}
-					chain={classicPlannerData?.chain}
-					futureRounds={classicPlannerData?.futureRounds}
-					actingAs={actingAsForPickUI}
-				/>
-			) : game.gameMode === 'turbo' && turboPickData ? (
+		game.currentRound && isAlive && game.gameMode === 'classic' && classicPickData ? (
+			// Classic stays interactive even after the current deadline passes: the
+			// current round locks (read-only) but the player can still lock in real
+			// picks for upcoming rounds.
+			<ClassicPick
+				gameId={game.id}
+				roundId={game.currentRound.id}
+				roundName={classicPickData.roundName}
+				roundNumber={classicPickData.roundNumber}
+				competitionId={classicPickData.competitionId}
+				deadline={classicPickData.deadline}
+				fixtures={classicPickData.fixtures}
+				usedTeamsByRound={classicPickData.usedTeamsByRound}
+				existingPickTeamId={classicPickData.existingPickTeamId}
+				existingPickFixtureId={classicPickData.existingPickFixtureId}
+				chain={classicPlannerData?.chain}
+				futureRounds={classicPlannerData?.futureRounds}
+				currentRoundClosed={roundDeadlinePassed}
+				actingAs={actingAsForPickUI}
+			/>
+		) : game.currentRound && isAlive && !roundDeadlinePassed ? (
+			game.gameMode === 'turbo' && turboPickData ? (
 				<TurboPick
 					gameId={game.id}
 					roundId={game.currentRound.id}

--- a/src/app/api/picks/[gameId]/[roundId]/route.test.ts
+++ b/src/app/api/picks/[gameId]/[roundId]/route.test.ts
@@ -49,6 +49,7 @@ const OPEN_ROUND_FAR_FUTURE = {
 	id: 'r1',
 	number: 5,
 	status: 'open' as const,
+	competitionId: 'c1',
 	deadline: new Date('2099-01-01T00:00:00Z'),
 	fixtures: [
 		{
@@ -72,9 +73,11 @@ const CLASSIC_GAME_ADMIN = {
 	modeConfig: {},
 	competitionId: 'c1',
 	competition: { id: 'c1', type: 'league' },
-	// Pick validation now gates on `game.currentRoundId === roundId` (see
-	// src/lib/picks/validate.ts). The test posts picks for round id 'r1', so
-	// the game's currentRoundId must point at 'r1' for the pick to be accepted.
+	// Classic pick validation gates on the TARGET round being non-past + deadline
+	// open (see src/lib/picks/validate.ts) — NOT on currentRoundId equality, so a
+	// player can lock an advance pick for a future round. currentRoundId is left
+	// pointing at 'r1' here only for realism; the open/far-future round status is
+	// what makes the pick valid.
 	currentRoundId: 'r1',
 }
 
@@ -199,5 +202,84 @@ describe('POST /api/picks/[gameId]/[roundId] — actingAs + un-elimination', () 
 		expect(body.id).toBe('p-new')
 		// No un-elimination update should have been invoked
 		expect(db.update).not.toHaveBeenCalled()
+	})
+})
+
+describe('POST /api/picks/[gameId]/[roundId] — classic advance picks (C1)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.mocked(requireSession).mockResolvedValue({ user: { id: 'u-self' } } as never)
+	})
+
+	it('accepts a locked advance pick for a future round that is not the game current round', async () => {
+		// Game's current round is some other round; the player posts to 'r1', a
+		// future round whose own deadline is still open. This is the C1 fix:
+		// previously rejected with "Round is not open for picks".
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({
+			...CLASSIC_GAME_ADMIN,
+			createdBy: 'u-someone-else',
+			currentRoundId: 'r-current',
+		} as never)
+		vi.mocked(db.query.gamePlayer.findFirst).mockResolvedValueOnce({
+			id: 'gp-self',
+			userId: 'u-self',
+			gameId: 'g1',
+			status: 'alive',
+		} as never)
+		vi.mocked(db.query.round.findFirst).mockResolvedValue(OPEN_ROUND_FAR_FUTURE as never)
+		vi.mocked(db.query.pick.findMany).mockResolvedValue([] as never)
+		mockDeleteChain()
+		mockInsertReturning([{ id: 'p-new', teamId: 't-home', roundId: 'r1' }])
+
+		const res = await POST(makeReq({ teamId: 't-home', fixtureId: 'fx1' }), params)
+		expect(res.status).toBe(201)
+		const body = await res.json()
+		expect(body.id).toBe('p-new')
+	})
+
+	it('rejects a pick for a round in a different competition', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({
+			...CLASSIC_GAME_ADMIN,
+			createdBy: 'u-someone-else',
+		} as never)
+		vi.mocked(db.query.gamePlayer.findFirst).mockResolvedValueOnce({
+			id: 'gp-self',
+			userId: 'u-self',
+			gameId: 'g1',
+			status: 'alive',
+		} as never)
+		// Round belongs to competition 'c2', game is in 'c1'.
+		vi.mocked(db.query.round.findFirst).mockResolvedValue({
+			...OPEN_ROUND_FAR_FUTURE,
+			competitionId: 'c2',
+		} as never)
+
+		const res = await POST(makeReq({ teamId: 't-home', fixtureId: 'fx1' }), params)
+		expect(res.status).toBe(400)
+		const body = await res.json()
+		expect(body.error).toBe('Round not in this game')
+	})
+
+	it('rejects a pick for a round that has already been played', async () => {
+		vi.mocked(db.query.game.findFirst).mockResolvedValue({
+			...CLASSIC_GAME_ADMIN,
+			createdBy: 'u-someone-else',
+		} as never)
+		vi.mocked(db.query.gamePlayer.findFirst).mockResolvedValueOnce({
+			id: 'gp-self',
+			userId: 'u-self',
+			gameId: 'g1',
+			status: 'alive',
+		} as never)
+		vi.mocked(db.query.round.findFirst).mockResolvedValue({
+			...OPEN_ROUND_FAR_FUTURE,
+			status: 'completed',
+		} as never)
+		vi.mocked(db.query.pick.findMany).mockResolvedValue([] as never)
+
+		const res = await POST(makeReq({ teamId: 't-home', fixtureId: 'fx1' }), params)
+		expect(res.status).toBe(400)
+		const body = await res.json()
+		expect(body.error).toBe('Round has already been played')
 	})
 })

--- a/src/app/api/picks/[gameId]/[roundId]/route.ts
+++ b/src/app/api/picks/[gameId]/[roundId]/route.ts
@@ -77,6 +77,13 @@ export async function POST(request: Request, { params }: { params: Params }) {
 	if (!roundData) {
 		return NextResponse.json({ error: 'Round not found' }, { status: 404 })
 	}
+	// The round must belong to this game's competition. Previously the classic
+	// path's `currentRoundId === roundId` check implied this; now that advance
+	// picks are allowed for non-current rounds, guard it explicitly so a player
+	// can't submit picks against a round in some other competition.
+	if (roundData.competitionId !== gameData.competitionId) {
+		return NextResponse.json({ error: 'Round not in this game' }, { status: 400 })
+	}
 
 	const now = new Date()
 
@@ -132,7 +139,11 @@ export async function POST(request: Request, { params }: { params: Params }) {
 			{
 				teamId,
 				playerStatus: targetGamePlayer.status,
-				isCurrentRound: gameData.currentRoundId === roundId,
+				// A round is "past" once it's been settled/completed for this game.
+				// Completed rounds always have a passed deadline, so this never
+				// blocks a still-pickable round — it just gives a clearer reason
+				// for already-played rounds. Current + future-open rounds pass.
+				isPastRound: roundData.status === 'completed',
 				deadline: roundData.deadline,
 				now,
 				usedTeamIds,

--- a/src/components/picks/classic-pick.tsx
+++ b/src/components/picks/classic-pick.tsx
@@ -19,9 +19,8 @@ export interface ClassicPickFixture {
 }
 
 export interface ClassicPickPlanHandlers {
-	onPlan: (roundId: string, teamId: string, autoSubmit: boolean) => Promise<void>
-	onRemove: (roundId: string) => Promise<void>
-	onToggleAuto: (roundId: string, autoSubmit: boolean) => Promise<void>
+	/** Commit/replace a locked real pick for a future round. */
+	onLock: (roundId: string, teamId: string) => Promise<void>
 }
 
 interface ClassicPickProps {
@@ -38,6 +37,12 @@ interface ClassicPickProps {
 	chain?: { slots: ChainSlot[]; summary: ChainSummary }
 	futureRounds?: PlannerRoundInput[]
 	planHandlers?: ClassicPickPlanHandlers
+	/**
+	 * True when the current round's deadline has passed (and the game hasn't yet
+	 * advanced). The current-round fixtures lock, but the player can still lock
+	 * in real picks for upcoming rounds via the planner below.
+	 */
+	currentRoundClosed?: boolean
 	/** When set, the admin is picking on behalf of this player. */
 	actingAs?: { gamePlayerId: string; userName: string }
 }
@@ -61,6 +66,7 @@ export function ClassicPick({
 	chain,
 	futureRounds,
 	planHandlers,
+	currentRoundClosed = false,
 	actingAs,
 }: ClassicPickProps) {
 	const router = useRouter()
@@ -265,57 +271,66 @@ export function ClassicPick({
 			</div>
 		)
 
-	// Default handlers perform the standard REST calls against the planned-picks
-	// endpoints. Callers can override via `planHandlers` for tests/storybook.
+	// Locking an upcoming pick commits a REAL pick against that round (editable
+	// by re-picking until that round's own deadline) — the same endpoint the
+	// current round uses. Callers can override via `planHandlers` for tests.
 	const resolvedHandlers: ClassicPickPlanHandlers = planHandlers ?? {
-		onPlan: async (rid, tid, auto) => {
-			const res = await fetch(`/api/games/${gameId}/planned-picks`, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ roundId: rid, teamId: tid, autoSubmit: auto }),
-			})
-			if (!res.ok) {
-				const body = await res.json().catch(() => ({ error: 'Failed to save plan' }))
-				throw new Error(body.error ?? 'Failed to save plan')
-			}
-			router.refresh()
-		},
-		onRemove: async (rid) => {
-			const res = await fetch(`/api/games/${gameId}/planned-picks/${rid}`, { method: 'DELETE' })
-			if (!res.ok) {
-				const body = await res.json().catch(() => ({ error: 'Failed to clear plan' }))
-				throw new Error(body.error ?? 'Failed to clear plan')
-			}
-			router.refresh()
-		},
-		onToggleAuto: async (rid, auto) => {
-			// To toggle auto-submit we re-post the existing plan (upsert) with the new flag.
-			// The server-side POST handler does a delete+insert so this is idempotent.
-			const existing = futureRounds?.find((r) => r.roundId === rid)
-			if (!existing?.plannedTeamId) return
-			const res = await fetch(`/api/games/${gameId}/planned-picks`, {
+		onLock: async (rid, tid) => {
+			const res = await fetch(`/api/picks/${gameId}/${rid}`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({
-					roundId: rid,
-					teamId: existing.plannedTeamId,
-					autoSubmit: auto,
+					teamId: tid,
+					...(actingAs ? { actingAs: actingAs.gamePlayerId } : {}),
 				}),
 			})
 			if (!res.ok) {
-				const body = await res.json().catch(() => ({ error: 'Failed to toggle auto-submit' }))
-				throw new Error(body.error ?? 'Failed to toggle auto-submit')
+				const body = await res.json().catch(() => ({ error: 'Failed to lock in pick' }))
+				throw new Error(body.error ?? 'Failed to lock in pick')
 			}
 			router.refresh()
 		},
 	}
 
+	// When the current round's deadline has passed (game not yet advanced) the
+	// current-round fixtures lock — show a read-only summary, not the editable
+	// picker. Upcoming-round locking below stays available.
+	const closedRoundCard = (
+		<div className="rounded-lg border border-border bg-card p-4">
+			{existingPickTeamId && lockedTeam && lockedOpponent ? (
+				<div className="flex items-center gap-3">
+					<TeamBadge shortName={lockedTeam.shortName} size="lg" />
+					<div>
+						<div className="text-xs uppercase tracking-wide text-muted-foreground font-semibold">
+							{roundName} · picks locked
+						</div>
+						<div className="font-display text-lg font-semibold">
+							{lockedTeam.name}{' '}
+							<span className="text-sm text-muted-foreground font-normal">
+								vs {lockedOpponent.name} ({lockedSide})
+							</span>
+						</div>
+					</div>
+				</div>
+			) : (
+				<div className="text-sm text-muted-foreground text-center">
+					{roundName} closed — picks locked. Live scores and standings update below.
+				</div>
+			)}
+		</div>
+	)
+
 	return (
 		<div className="space-y-4">
 			{chain && <ChainRibbon slots={chain.slots} summary={chain.summary} />}
-			<div>{currentRoundCard}</div>
+			<div>{currentRoundClosed ? closedRoundCard : currentRoundCard}</div>
 			{futureRounds && futureRounds.length > 0 && (
-				<PlannerSection gameId={gameId} rounds={futureRounds} handlers={resolvedHandlers} />
+				<PlannerSection
+					gameId={gameId}
+					rounds={futureRounds}
+					handlers={resolvedHandlers}
+					defaultOpen={currentRoundClosed}
+				/>
 			)}
 		</div>
 	)
@@ -330,22 +345,25 @@ function PlannerSection({
 	gameId,
 	rounds,
 	handlers,
+	defaultOpen = false,
 }: {
 	gameId: string
 	rounds: PlannerRoundInput[]
 	handlers: ClassicPickPlanHandlers
+	defaultOpen?: boolean
 }) {
 	const storageKey = `lps.planner-open.${gameId}`
-	// Default closed — the planner is an optional power-user feature.
-	const [open, setOpen] = useState(false)
+	const [open, setOpen] = useState(defaultOpen)
 	const [error, setError] = useState<string | null>(null)
 
 	// Hydrate the open/closed preference from localStorage after mount to avoid
-	// SSR/client markup mismatches.
+	// SSR/client markup mismatches. An explicit saved preference wins over the
+	// default in both directions.
 	useEffect(() => {
 		try {
 			const saved = window.localStorage.getItem(storageKey)
 			if (saved === 'open') setOpen(true)
+			else if (saved === 'closed') setOpen(false)
 		} catch {
 			// ignore — localStorage access can throw in some browsers
 		}
@@ -370,7 +388,7 @@ function PlannerSection({
 		}
 	}
 
-	const plannedCount = rounds.filter((r) => r.plannedTeamId).length
+	const lockedCount = rounds.filter((r) => r.lockedTeamId).length
 
 	return (
 		<div className="rounded-xl border border-border bg-card">
@@ -381,10 +399,10 @@ function PlannerSection({
 				className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-muted/40 rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
 			>
 				<div>
-					<div className="font-semibold text-sm">Plan ahead</div>
+					<div className="font-semibold text-sm">Lock in upcoming picks</div>
 					<div className="text-xs text-muted-foreground">
 						{rounds.length} upcoming {rounds.length === 1 ? 'gameweek' : 'gameweeks'} ·{' '}
-						{plannedCount} planned
+						{lockedCount} locked
 					</div>
 				</div>
 				{open ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
@@ -407,11 +425,8 @@ function PlannerSection({
 							fixturesTbc={r.fixturesTbc}
 							fixtures={r.fixtures}
 							usedTeams={r.usedTeams}
-							plannedTeamId={r.plannedTeamId}
-							plannedAutoSubmit={r.plannedAutoSubmit}
-							onPlan={(rid, tid, auto) => guard(() => handlers.onPlan(rid, tid, auto))}
-							onRemove={(rid) => guard(() => handlers.onRemove(rid))}
-							onToggleAuto={(rid, auto) => guard(() => handlers.onToggleAuto(rid, auto))}
+							lockedTeamId={r.lockedTeamId}
+							onLock={(rid, tid) => guard(() => handlers.onLock(rid, tid))}
 						/>
 					))}
 				</div>

--- a/src/components/picks/planner-round.tsx
+++ b/src/components/picks/planner-round.tsx
@@ -1,8 +1,6 @@
 'use client'
 
-import { useState } from 'react'
 import { LocalDateTime } from '@/components/local-datetime'
-import { cn } from '@/lib/utils'
 import { FixtureRow } from './fixture-row'
 
 export interface PlannerFixture {
@@ -39,22 +37,20 @@ interface PlannerRoundProps {
 	fixturesTbc: boolean
 	fixtures: PlannerFixture[]
 	usedTeams: UsedInfo[]
-	plannedTeamId: string | null
-	plannedAutoSubmit: boolean
-	onPlan: (roundId: string, teamId: string, autoSubmit: boolean) => Promise<void>
-	onRemove: (roundId: string) => Promise<void>
-	onToggleAuto: (roundId: string, autoSubmit: boolean) => Promise<void>
+	/** The team the player has locked in (a committed real pick) for this round. */
+	lockedTeamId: string | null
+	/** Commit/replace a locked real pick for this round. */
+	onLock: (roundId: string, teamId: string) => Promise<void>
 }
 
 export function PlannerRound(props: PlannerRoundProps) {
-	const [pending, setPending] = useState(false)
 	if (props.fixturesTbc) {
 		return (
 			<div className="rounded-xl border border-border bg-muted/30 px-3 py-3 opacity-55">
 				<div className="flex justify-between items-center">
 					<div className="font-semibold text-sm">{props.roundLabel} · Fixtures TBC</div>
 					<span className="text-[11px] text-muted-foreground">
-						Planner unlocks when fixtures are published
+						Opens for picks when fixtures are published
 					</span>
 				</div>
 			</div>
@@ -77,40 +73,17 @@ export function PlannerRound(props: PlannerRoundProps) {
 						</div>
 					)}
 				</div>
-				<label
-					className={cn(
-						'flex items-center gap-2 text-[11px] text-muted-foreground cursor-pointer',
-						pending && 'opacity-50',
-					)}
-				>
-					<span>Auto-submit</span>
-					<input
-						type="checkbox"
-						className="sr-only peer"
-						checked={props.plannedAutoSubmit}
-						disabled={pending || !props.plannedTeamId}
-						onChange={async (e) => {
-							setPending(true)
-							try {
-								await props.onToggleAuto(props.roundId, e.target.checked)
-							} finally {
-								setPending(false)
-							}
-						}}
-					/>
-					<span className="relative w-7 h-4 bg-muted rounded-full peer-checked:bg-[#7c3aed]">
-						<span className="absolute top-[2px] left-[2px] w-3 h-3 bg-white rounded-full transition-all peer-checked:left-[14px]" />
+				{props.lockedTeamId && (
+					<span className="text-[11px] font-semibold text-[var(--alive)] uppercase tracking-wide">
+						Locked in
 					</span>
-				</label>
+				)}
 			</div>
 			{props.fixtures.map((f) => {
 				const homeUsed = props.usedTeams.find((u) => u.teamId === f.homeTeam.id)
 				const awayUsed = props.usedTeams.find((u) => u.teamId === f.awayTeam.id)
-				const homeIsPlan = f.homeTeam.id === props.plannedTeamId
-				const awayIsPlan = f.awayTeam.id === props.plannedTeamId
-				const planKind: 'auto-locked' | 'tentative' = props.plannedAutoSubmit
-					? 'auto-locked'
-					: 'tentative'
+				const homeIsLocked = f.homeTeam.id === props.lockedTeamId
+				const awayIsLocked = f.awayTeam.id === props.lockedTeamId
 				return (
 					<FixtureRow
 						key={f.id}
@@ -128,41 +101,24 @@ export function PlannerRound(props: PlannerRoundProps) {
 						}}
 						kickoff={f.kickoff ?? undefined}
 						homeState={
-							homeIsPlan
-								? { kind: planKind }
+							homeIsLocked
+								? { kind: 'auto-locked' }
 								: homeUsed
 									? { kind: homeUsed.kind, label: homeUsed.label }
 									: undefined
 						}
 						awayState={
-							awayIsPlan
-								? { kind: planKind }
+							awayIsLocked
+								? { kind: 'auto-locked' }
 								: awayUsed
 									? { kind: awayUsed.kind, label: awayUsed.label }
 									: undefined
 						}
-						onPickHome={
-							homeUsed
-								? undefined
-								: () => props.onPlan(props.roundId, f.homeTeam.id, props.plannedAutoSubmit)
-						}
-						onPickAway={
-							awayUsed
-								? undefined
-								: () => props.onPlan(props.roundId, f.awayTeam.id, props.plannedAutoSubmit)
-						}
+						onPickHome={homeUsed ? undefined : () => props.onLock(props.roundId, f.homeTeam.id)}
+						onPickAway={awayUsed ? undefined : () => props.onLock(props.roundId, f.awayTeam.id)}
 					/>
 				)
 			})}
-			{props.plannedTeamId && (
-				<button
-					type="button"
-					className="mt-2 text-[11px] text-muted-foreground underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 rounded"
-					onClick={() => props.onRemove(props.roundId)}
-				>
-					Clear plan
-				</button>
-			)}
 		</div>
 	)
 }

--- a/src/lib/game/classic-planner-view.test.ts
+++ b/src/lib/game/classic-planner-view.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { buildChainSlots, buildPlannerRounds, type FutureRoundRow } from './classic-planner-view'
+
+function futureRound(
+	overrides: Partial<FutureRoundRow> & { id: string; number: number },
+): FutureRoundRow {
+	return {
+		name: `GW${overrides.number}`,
+		label: `GW${overrides.number}`,
+		deadline: new Date('2099-01-01T00:00:00Z'),
+		fixtures: [
+			{
+				id: `${overrides.id}-fx`,
+				kickoff: new Date('2099-01-01T12:00:00Z'),
+				homeTeam: {
+					id: 'home',
+					name: 'Home',
+					shortName: 'HOM',
+					badgeUrl: null,
+					primaryColor: null,
+				},
+				awayTeam: {
+					id: 'away',
+					name: 'Away',
+					shortName: 'AWY',
+					badgeUrl: null,
+					primaryColor: null,
+				},
+			},
+		],
+		...overrides,
+	}
+}
+
+describe('buildPlannerRounds — locked advance picks', () => {
+	it('marks a future round with a real locked pick as locked', () => {
+		const rounds = buildPlannerRounds({
+			futureRounds: [futureRound({ id: 'r5', number: 5 })],
+			pastPicks: [],
+			lockedPicks: [{ roundId: 'r5', roundNumber: 5, teamId: 'home' }],
+		})
+		expect(rounds[0].lockedTeamId).toBe('home')
+	})
+
+	it('has no locked team when the round has no real pick', () => {
+		const rounds = buildPlannerRounds({
+			futureRounds: [futureRound({ id: 'r5', number: 5 })],
+			pastPicks: [],
+			lockedPicks: [],
+		})
+		expect(rounds[0].lockedTeamId).toBeNull()
+	})
+
+	it('labels a team locked in another future round as PICKED, not selectable here', () => {
+		const rounds = buildPlannerRounds({
+			futureRounds: [futureRound({ id: 'r5', number: 5 }), futureRound({ id: 'r6', number: 6 })],
+			pastPicks: [],
+			lockedPicks: [{ roundId: 'r5', roundNumber: 5, teamId: 'home' }],
+		})
+		const r6 = rounds.find((r) => r.roundId === 'r6')
+		const used = r6?.usedTeams.find((u) => u.teamId === 'home')
+		expect(used).toEqual({ teamId: 'home', label: 'PICKED GW5', kind: 'used' })
+	})
+
+	it('keeps past-round picks marked as USED', () => {
+		const rounds = buildPlannerRounds({
+			futureRounds: [futureRound({ id: 'r5', number: 5 })],
+			pastPicks: [{ roundNumber: 2, teamId: 'home' }],
+			lockedPicks: [],
+		})
+		expect(rounds[0].usedTeams).toContainEqual({ teamId: 'home', label: 'USED GW2', kind: 'used' })
+	})
+})
+
+describe('buildChainSlots — locked future picks render as locked', () => {
+	const baseRounds = [
+		{ id: 'r4', number: 4, name: null, label: 'GW4', status: 'completed' as const },
+		{ id: 'r5', number: 5, name: null, label: 'GW5', status: 'upcoming' as const },
+	]
+
+	it('renders a locked future pick as a planned-locked slot', () => {
+		const { slots, summary } = buildChainSlots({
+			rounds: baseRounds,
+			pastPicks: [],
+			currentPick: null,
+			lockedPicks: [{ roundId: 'r5', teamId: 'home', teamShortName: 'HOM', teamColour: null }],
+			currentRoundId: 'r4',
+			upcomingRoundsFixturesTbc: new Set(),
+			totalTeams: 20,
+		})
+		const r5 = slots.find((s) => s.roundId === 'r5')
+		expect(r5?.state).toEqual({ kind: 'planned-locked', teamShort: 'HOM', teamColour: null })
+		expect(summary.planned).toBe(1)
+	})
+})

--- a/src/lib/game/classic-planner-view.ts
+++ b/src/lib/game/classic-planner-view.ts
@@ -25,8 +25,8 @@ export interface PlannerRoundInput {
 	fixturesTbc: boolean
 	fixtures: PlannerFixture[]
 	usedTeams: UsedInfo[]
-	plannedTeamId: string | null
-	plannedAutoSubmit: boolean
+	/** The team the player has locked in (committed a real pick for) this round, if any. */
+	lockedTeamId: string | null
 }
 
 export interface ChainRoundRow {
@@ -45,10 +45,9 @@ export interface ChainPastPickRow {
 	teamColour: string | null
 }
 
-export interface ChainPlannedPickRow {
+export interface ChainLockedPickRow {
 	roundId: string
 	teamId: string
-	autoSubmit: boolean
 	teamShortName: string
 	teamColour: string | null
 }
@@ -63,7 +62,8 @@ export interface BuildChainSlotsInput {
 	rounds: ChainRoundRow[]
 	pastPicks: ChainPastPickRow[] // completed rounds only (result != pending)
 	currentPick: ChainCurrentPickInfo | null
-	plannedPicks: ChainPlannedPickRow[]
+	/** Real picks the player has locked in for future (not-yet-current) rounds. */
+	lockedPicks: ChainLockedPickRow[]
 	currentRoundId: string | null
 	upcomingRoundsFixturesTbc: Set<string>
 	totalTeams: number
@@ -74,29 +74,10 @@ export function buildChainSlots(input: BuildChainSlotsInput): {
 	summary: ChainSummary
 } {
 	const pastById = new Map(input.pastPicks.map((p) => [p.roundId, p]))
-	const planById = new Map(input.plannedPicks.map((p) => [p.roundId, p]))
+	const lockedById = new Map(input.lockedPicks.map((p) => [p.roundId, p]))
 
 	const slots: ChainSlot[] = input.rounds.map((r) => {
 		if (r.id === input.currentRoundId) {
-			const plan = planById.get(r.id)
-			if (plan) {
-				return {
-					roundId: r.id,
-					roundNumber: r.number,
-					roundLabel: r.label,
-					state: plan.autoSubmit
-						? {
-								kind: 'planned-locked',
-								teamShort: plan.teamShortName,
-								teamColour: plan.teamColour,
-							}
-						: {
-								kind: 'planned',
-								teamShort: plan.teamShortName,
-								teamColour: plan.teamColour,
-							},
-				}
-			}
 			return {
 				roundId: r.id,
 				roundNumber: r.number,
@@ -138,24 +119,18 @@ export function buildChainSlots(input: BuildChainSlotsInput): {
 			}
 		}
 
-		// Upcoming round — planned or empty or tbc
-		const plan = planById.get(r.id)
-		if (plan) {
+		// Upcoming round — locked (real advance pick) or empty or tbc
+		const locked = lockedById.get(r.id)
+		if (locked) {
 			return {
 				roundId: r.id,
 				roundNumber: r.number,
 				roundLabel: r.label,
-				state: plan.autoSubmit
-					? {
-							kind: 'planned-locked',
-							teamShort: plan.teamShortName,
-							teamColour: plan.teamColour,
-						}
-					: {
-							kind: 'planned',
-							teamShort: plan.teamShortName,
-							teamColour: plan.teamColour,
-						},
+				state: {
+					kind: 'planned-locked',
+					teamShort: locked.teamShortName,
+					teamColour: locked.teamColour,
+				},
 			}
 		}
 
@@ -177,10 +152,10 @@ export function buildChainSlots(input: BuildChainSlotsInput): {
 	})
 
 	const played = input.pastPicks.length
-	const planned = input.plannedPicks.length
+	const planned = input.lockedPicks.length
 	const usedCount = new Set<string>([
 		...input.pastPicks.map((p) => p.teamId),
-		...input.plannedPicks.map((p) => p.teamId),
+		...input.lockedPicks.map((p) => p.teamId),
 	]).size
 	const availableTeams = Math.max(0, input.totalTeams - usedCount)
 
@@ -219,26 +194,27 @@ export interface FutureRoundRow {
 export interface BuildPlannerRoundsInput {
 	futureRounds: FutureRoundRow[]
 	pastPicks: Array<{ roundNumber: number; teamId: string }>
-	plannedPicks: Array<{ roundNumber: number; teamId: string; autoSubmit: boolean; roundId: string }>
+	/** Real picks the player has locked in for future rounds. */
+	lockedPicks: Array<{ roundNumber: number; teamId: string; roundId: string }>
 }
 
 /**
  * Build the PlannerRound inputs for every upcoming round.
- * Applies cascading "used" labels — a pick in an earlier planned gameweek
- * locks that team out of later gameweeks automatically.
+ * Applies cascading "used" labels — a team locked into an earlier gameweek
+ * is locked out of later gameweeks automatically.
  */
 export function buildPlannerRounds(input: BuildPlannerRoundsInput): PlannerRoundInput[] {
 	const sortedFutures = [...input.futureRounds].sort((a, b) => a.number - b.number)
 
 	return sortedFutures.map((r) => {
 		const fixturesTbc = r.fixtures.length === 0
-		const plan = input.plannedPicks.find((p) => p.roundId === r.id)
-		const plannedTeamId = plan?.teamId ?? null
-		const plannedAutoSubmit = plan?.autoSubmit ?? false
+		const locked = input.lockedPicks.find((p) => p.roundId === r.id)
+		const lockedTeamId = locked?.teamId ?? null
 
 		// A team is "used" for this round if:
 		//   - it was picked in a past (completed) round, OR
-		//   - it is planned for any OTHER round (planned in this round is handled by plannedTeamId).
+		//   - it is locked into any OTHER future round (the lock for this round is
+		//     handled by lockedTeamId).
 		const usedTeams: UsedInfo[] = []
 		for (const pp of input.pastPicks) {
 			usedTeams.push({
@@ -247,12 +223,12 @@ export function buildPlannerRounds(input: BuildPlannerRoundsInput): PlannerRound
 				kind: 'used',
 			})
 		}
-		for (const plp of input.plannedPicks) {
-			if (plp.roundId === r.id) continue
+		for (const lp of input.lockedPicks) {
+			if (lp.roundId === r.id) continue
 			usedTeams.push({
-				teamId: plp.teamId,
-				label: `PLANNED GW${plp.roundNumber}`,
-				kind: 'planned-elsewhere',
+				teamId: lp.teamId,
+				label: `PICKED GW${lp.roundNumber}`,
+				kind: 'used',
 			})
 		}
 
@@ -284,8 +260,7 @@ export function buildPlannerRounds(input: BuildPlannerRoundsInput): PlannerRound
 			fixturesTbc,
 			fixtures,
 			usedTeams,
-			plannedTeamId,
-			plannedAutoSubmit,
+			lockedTeamId,
 		}
 	})
 }

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -6,8 +6,8 @@ import { db } from '@/lib/db'
 import {
 	buildChainSlots,
 	buildPlannerRounds,
+	type ChainLockedPickRow,
 	type ChainPastPickRow,
-	type ChainPlannedPickRow,
 	type ChainRoundRow,
 	type FutureRoundRow,
 } from '@/lib/game/classic-planner-view'
@@ -18,7 +18,7 @@ import { evaluateCupPicks } from '@/lib/game-logic/cup'
 import { computeTierDifference } from '@/lib/game-logic/cup-tier'
 import { calculatePot } from '@/lib/game-logic/prizes'
 import { fixture, round, team } from '@/lib/schema/competition'
-import { game, type gamePlayer, pick, plannedPick } from '@/lib/schema/game'
+import { game, type gamePlayer, pick } from '@/lib/schema/game'
 import { payment } from '@/lib/schema/payment'
 
 export async function getGameDetail(gameId: string, userId: string) {
@@ -1390,17 +1390,13 @@ export async function getClassicPlannerData(
 	})
 	if (!gameData) return null
 
-	// Pull the player's picks (all rounds) and plans in parallel.
-	const [playerPicks, playerPlans] = await Promise.all([
-		db.query.pick.findMany({
-			where: and(eq(pick.gameId, gameId), eq(pick.gamePlayerId, gamePlayerId)),
-			with: { round: true, team: true },
-		}),
-		db.query.plannedPick.findMany({
-			where: eq(plannedPick.gamePlayerId, gamePlayerId),
-			with: { round: true, team: true },
-		}),
-	])
+	// Pull the player's picks across all rounds. With lockable advance picks,
+	// a pick can exist for a future (not-yet-current) round, so we classify
+	// each pick as past / current / locked-future below.
+	const playerPicks = await db.query.pick.findMany({
+		where: and(eq(pick.gameId, gameId), eq(pick.gamePlayerId, gamePlayerId)),
+		with: { round: true, team: true },
+	})
 
 	const now = new Date()
 	const currentRoundNumber = currentRoundId
@@ -1419,11 +1415,17 @@ export async function getClassicPlannerData(
 		}),
 	}))
 
-	// Past picks are every pick for a round that isn't the current round (i.e.
-	// something already in the past — draws/losses/wins/saves). We include the
-	// current-round pick separately so the ribbon can render it as 'current'.
+	// A pick is a locked ADVANCE pick when it's for a round later than the
+	// game's current round (the C1 feature). Anything for an earlier round is
+	// in the past; the current-round pick is handled separately for the ribbon.
+	const isFuturePick = (p: (typeof playerPicks)[number]) =>
+		p.roundId !== currentRoundId &&
+		currentRoundNumber != null &&
+		p.round != null &&
+		p.round.number > currentRoundNumber
+
 	const pastPicks: ChainPastPickRow[] = playerPicks
-		.filter((p) => p.roundId !== currentRoundId)
+		.filter((p) => p.roundId !== currentRoundId && !isFuturePick(p))
 		.map((p) => ({
 			roundId: p.roundId,
 			teamId: p.teamId,
@@ -1431,6 +1433,8 @@ export async function getClassicPlannerData(
 			teamShortName: p.team.shortName,
 			teamColour: p.team.primaryColor,
 		}))
+
+	const lockedFuturePicks = playerPicks.filter(isFuturePick)
 
 	const currentPickRow = currentRoundId
 		? playerPicks.find((p) => p.roundId === currentRoundId)
@@ -1443,10 +1447,9 @@ export async function getClassicPlannerData(
 			}
 		: null
 
-	const plannedPicksChain: ChainPlannedPickRow[] = playerPlans.map((p) => ({
+	const lockedPicksChain: ChainLockedPickRow[] = lockedFuturePicks.map((p) => ({
 		roundId: p.roundId,
 		teamId: p.teamId,
-		autoSubmit: p.autoSubmit,
 		teamShortName: p.team.shortName,
 		teamColour: p.team.primaryColor,
 	}))
@@ -1473,7 +1476,7 @@ export async function getClassicPlannerData(
 		rounds,
 		pastPicks,
 		currentPick,
-		plannedPicks: plannedPicksChain,
+		lockedPicks: lockedPicksChain,
 		currentRoundId,
 		upcomingRoundsFixturesTbc,
 		totalTeams,
@@ -1509,28 +1512,20 @@ export async function getClassicPlannerData(
 			})),
 		}))
 
-	// Past picks & plans keyed by round number (for the "USED GW3" labels).
+	// Past + current picks count as "used" in the planner (for the "USED GW3"
+	// labels). Locked future picks are passed separately so each future round
+	// shows its own lock and greys out teams locked into other future rounds.
 	const pastPicksForPlanner = playerPicks
-		.filter((p) => p.roundId !== currentRoundId && p.round)
+		.filter((p) => !isFuturePick(p) && p.round)
 		.map((p) => ({ roundNumber: p.round.number, teamId: p.teamId }))
-	// Treat the current-round pick as "used" in future planner views too.
-	if (currentPickRow?.round) {
-		pastPicksForPlanner.push({
-			roundNumber: currentPickRow.round.number,
-			teamId: currentPickRow.teamId,
-		})
-	}
-	const plannedPicksForPlanner = playerPlans.map((p) => ({
-		roundId: p.roundId,
-		roundNumber: p.round.number,
-		teamId: p.teamId,
-		autoSubmit: p.autoSubmit,
-	}))
+	const lockedPicksForPlanner = lockedFuturePicks
+		.filter((p) => p.round)
+		.map((p) => ({ roundId: p.roundId, roundNumber: p.round.number, teamId: p.teamId }))
 
 	const futureRounds = buildPlannerRounds({
 		futureRounds: futureRoundRows,
 		pastPicks: pastPicksForPlanner,
-		plannedPicks: plannedPicksForPlanner,
+		lockedPicks: lockedPicksForPlanner,
 	})
 
 	return { chain, futureRounds }

--- a/src/lib/picks/validate.test.ts
+++ b/src/lib/picks/validate.test.ts
@@ -4,7 +4,7 @@ import { validateClassicPick, validateCupPicks, validateTurboPicks } from './val
 describe('validateClassicPick', () => {
 	const base = {
 		playerStatus: 'alive' as const,
-		isCurrentRound: true,
+		isPastRound: false,
 		deadline: new Date(Date.now() + 3600000),
 		now: new Date(),
 		usedTeamIds: ['used-1', 'used-2'],
@@ -20,10 +20,21 @@ describe('validateClassicPick', () => {
 			reason: 'Player is not alive',
 		})
 	})
-	it('rejects when not the game current round', () => {
-		expect(validateClassicPick({ ...base, teamId: 'team-a', isCurrentRound: false })).toEqual({
+	it('accepts an advance pick for a future round whose deadline has not passed', () => {
+		// Classic players can lock in a real pick for a future round, not just the
+		// game's current round, as long as the target round's own deadline is open.
+		expect(
+			validateClassicPick({
+				...base,
+				teamId: 'team-a',
+				deadline: new Date(Date.now() + 7 * 24 * 3600000),
+			}),
+		).toEqual({ valid: true })
+	})
+	it('rejects a round that has already been played', () => {
+		expect(validateClassicPick({ ...base, teamId: 'team-a', isPastRound: true })).toEqual({
 			valid: false,
-			reason: 'Round is not open for picks',
+			reason: 'Round has already been played',
 		})
 	})
 	it('rejects past deadline', () => {

--- a/src/lib/picks/validate.ts
+++ b/src/lib/picks/validate.ts
@@ -4,11 +4,13 @@ export interface ClassicPickValidation {
 	teamId: string
 	playerStatus: 'alive' | 'eliminated' | 'winner'
 	/**
-	 * True iff this round is the game's currently-active round (`game.currentRoundId === roundId`).
-	 * Picks are only allowed on the game's current round; past rounds are completed and
-	 * future rounds aren't visible to the player yet for this game.
+	 * True iff this round has already been played for this game (its fixtures are
+	 * settled / the round is completed). Classic players may lock in a real pick
+	 * for the current round AND any future round whose own deadline is still open
+	 * — but never for a round that's already happened. The deadline check below
+	 * independently blocks picking a round whose deadline has passed.
 	 */
-	isCurrentRound: boolean
+	isPastRound: boolean
 	deadline: Date | null
 	now: Date
 	usedTeamIds: string[]
@@ -21,7 +23,7 @@ export function validateClassicPick(
 ): ValidationResult {
 	if (!opts.allowEliminatedRebuy && input.playerStatus !== 'alive')
 		return { valid: false, reason: 'Player is not alive' }
-	if (!input.isCurrentRound) return { valid: false, reason: 'Round is not open for picks' }
+	if (input.isPastRound) return { valid: false, reason: 'Round has already been played' }
 	if (input.deadline && input.now > input.deadline)
 		return { valid: false, reason: 'Deadline has passed' }
 	if (input.usedTeamIds.includes(input.teamId))


### PR DESCRIPTION
## What & why

Closes the C1 backlog item (classic-mode). Classic players could only pick the game's **current** round: `validateClassicPick` rejected any round where `game.currentRoundId !== roundId` *before* the deadline check. So once the current deadline passed (and the game hadn't yet advanced), there was no way to commit a pick for the next round — and the UI hid the pick interface entirely behind a dead-end "Round closed" panel, with only a buried, auto-submit-only planner.

This PR lets a classic player **lock in a real pick for any future round whose deadline is still open**, and keeps that interface **visible after the current deadline passes**.

> Classic-only by design: `turbo`/`cup` are single-round modes with no future rounds, so their validators are untouched.

## Backend
- `validateClassicPick` now gates on the **target round** (`isPastRound` + the round's own deadline) instead of `isCurrentRound`. A "past" round is one already settled (`status='completed'`), which always has a passed deadline — so this never opens a stale round. Committing an advance pick is safe: `processDeadlineLock` and `submitPlannedPick` both skip a round that already has a real pick.
- Pick route: removing the `currentRoundId` equality check lost the implicit guarantee that the round belongs to this game's competition, so I added an **explicit competition-match guard** (all modes).

## UI
- "Plan ahead" → **"Lock in upcoming picks"**: each future round commits a **real** pick via `/api/picks` (editable by re-picking until that round's deadline), shown as **"Locked in"** — not an auto-submit plan.
- The classic pick surface stays visible after the current deadline passes: the current round shows a read-only **closed card** while the upcoming-picks planner **auto-expands**.
- Planner data is sourced from real picks (past vs locked-future) instead of `planned_pick` rows.

## Deferred (separate PR)
The auto-submit / `planned_pick` backend (table, API, cron, qstash, round-lifecycle scheduling) is left **intact and dormant** — its teardown is a follow-up PR, as agreed.

## Verification
- ✅ typecheck · Biome · unit **443** (+8 new: validator, route advance-pick/cross-competition/already-played, planner view-builders) · smoke **24** · `next build`
- ✅ dev-server E2E: classic game page renders pre- and post-deadline; advance-pick `POST /api/picks/<future-round>` → **201**; page then renders the pick as **"Locked in"**.