### PR TITLE
fix(cup): freeze lives at elimination + raw-goals tiebreak backstop

### DIFF
--- a/docs/game-modes/cup.md
+++ b/docs/game-modes/cup.md
@@ -7,7 +7,7 @@
 ## Pick mechanics
 
 - **Picks:** up to `modeConfig.numberOfPicks` (default 10–12). Cup allows **partial rankings** — 1..N picks submittable, unlike turbo.
-- **Win condition:** the **longest streak** of correct ranked picks — a *consecutive* run of surviving picks (win / draw_success / saved_by_life) counted in confidence-rank order. Once every fixture in the round is settled, players are ranked by `cupTiebreaker` (streak → lives → goals) and the longest streak takes the pot. A streak that *broke* can still win if it's the longest — the winner is whoever got furthest, not only survivors. Leading ranks that **everyone** got wrong are skipped first (the wipeout rule, under Settlement).
+- **Win condition:** the **longest streak** of correct ranked picks — a *consecutive* run of surviving picks (win / draw_success / saved_by_life) counted in confidence-rank order. Once every fixture in the round is settled, players are ranked by `cupTiebreaker` — **streak → lives (frozen at elimination) → counted goals → raw goals** (see Tiebreaker order below) — and the longest streak takes the pot. A streak that *broke* can still win if it's the longest — the winner is whoever got furthest, not only survivors. Leading ranks that **everyone** got wrong are skipped first (the wipeout rule, under Settlement).
 - **Tier handicap:** every cup competition has a tier system that pushes picks toward underdogs — **where a team's tier comes from is per-competition**. `computeTierDifference` returns the difference from the home team's perspective (positive = home is the stronger side).
   - **WC (`competition.type === 'group_knockout'`):** FIFA pots (1=best, 4=worst); returns `awayPot - homePot`. Implemented.
   - **FA Cup (`competition.type === 'knockout'`):** difference in league tier (a higher-division side outranks a lower one). **Intended for the FA Cup extension (Jan 2027); not yet implemented** — `computeTierDifference` currently returns 0 for `knockout`, so a cup game on a knockout competition carries no handicap until then.
@@ -62,9 +62,20 @@ The re-eval is **idempotent**: re-running it with the same fixture states produc
 
 - **Skip leading universal-loss ranks.** If rank 1 was a loss for *every* player it's discarded and the streak count restarts from rank 2; if rank 2 was also universally lost, from rank 3; and so on — the rebased start is the lowest rank any player got right. Each player's streak is then the consecutive run of surviving picks from that start, so a player who lost rank 1 alongside everyone else can still win on ranks 2+.
 - **Total wipeout → full refund.** If *no* rank has a single correct pick anywhere (every player got every pick wrong), there is no winner: the game completes with `reason: 'cup-total-wipeout'`, every stake is refunded (`payment.status = 'refunded'`), and no payout is written.
-- **No lives carry into the rebased start.** Discarded leading ranks are all losses, and lives are *earned* only by winning underdogs — so a player enters the rebased start with only their `startingLives`. The rebase changes where the streak is counted, not the lives tally; `cupTiebreaker` still breaks ties on final lives → goals.
+- **No lives carry into the rebased start.** Discarded leading ranks are all losses, and lives are *earned* only by winning underdogs — so a player enters the rebased start with only their `startingLives`. The rebase changes where the streak is counted, not the lives tally.
 
 This is a cross-player, winner-determination concern, **distinct** from the per-player confirmed-prefix rule above: the confirmed-prefix rule bounds *which* picks are settled (stop at the first pending pick); the wipeout rule rebases *where* the streak begins (skip leading ranks everyone lost). It resolves the `d8360e69` incident, where the old tiebreaker counted every scattered win — including wins logged after a streak had already broken — and mis-crowned an eliminated player.
+
+### Tiebreaker order
+
+Once the streak is rebased, `cupTiebreaker` ranks players by, in order:
+
+1. **Streak** — longest consecutive run of surviving picks (win / draw_success / saved_by_life) from the rebased start.
+2. **Lives — frozen at elimination.** Lives gained *after* the pick that breaks the streak don't count (the player is already out; those lives can never be spent). Only lives earned while the streak was alive count. See `evaluateCupPicks`.
+3. **Counted goals in the streak** — tier-adjusted goals from the streak picks only. Favourite-win goals are suppressed (tier table above) and goals from picks after the break / from losing picks don't count.
+4. **Raw goals in the streak (backstop)** — the picked teams' *actual* goals over the streak picks, ignoring favourite suppression. Used only when 1–3 all tie, to crown a clear winner rather than split. (`d8360e69`: two players tied on streak 1, lives 0 and counted goals 0 because both streak picks were 1-tier-favourite wins; raw goals — France 3 vs Scotland 1 — separated them.)
+
+If even raw goals tie, the pot is split.
 
 Persisted bookkeeping (new columns introduced with this design):
 
@@ -94,7 +105,7 @@ stateDiagram-v2
     }
 ```
 
-Once `streakBroken=true`, no later pick can be saved by a life — subsequent draws and losses persist as `'loss'`. A subsequent genuine **win** still persists as `'win'` (and still earns underdog lives); it just can't extend the already-broken streak. Lives spent earlier remain spent. Those later win rows are what let the wipeout rule rebase a streak onto ranks after a universal loss.
+Once `streakBroken=true`, no later pick can be saved by a life — subsequent draws and losses persist as `'loss'`. A subsequent genuine **win** still persists as `'win'` (so its raw goals stay visible to the tiebreaker and the wipeout rebase), but it **earns no lives** — life accrual is frozen at the eliminating pick, since lives won after you're out can never be spent. Lives spent earlier remain spent.
 
 ## Player state machine
 
@@ -158,6 +169,7 @@ See [`docs/superpowers/specs/2026-05-12-fixture-cancellation-handling-design.md`
 
 - Leading universal-loss rank skipped: everyone loses rank 1, fixtures settle in rank order, and the player who wins rank 2 is crowned (not refunded) — proving eliminated players' later picks settle.
 - Total wipeout: every player gets every pick wrong → game completes, no winner, no payout, every `payment` refunded.
+- Raw-goals backstop (`group_knockout`, the `d8360e69` case): two players tie on streak 1, lives 0 and counted goals 0 (both streak picks 1-tier-favourite wins) → the raw goals of the streak pick (France 3 vs Scotland 1) crown a solo winner rather than splitting.
 
 Not yet covered:
 - 1-tier and 2-tier underdog wins.

--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -655,6 +655,88 @@ describe('lifecycle: cup wipeout rule', () => {
 		const payments = await db.query.payment.findMany({ where: eq(payment.gameId, gameId) })
 		expect(payments.every((p) => p.status === 'refunded')).toBe(true)
 	})
+
+	it('breaks a streak+lives+counted-goals tie on raw streak goals — no split (d8360e69)', async () => {
+		// WC handicap competition so 1-tier-favourite wins suppress counted goals.
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		// pot1 favourites vs pot2 opponents (tierDiffFromPicked = +1 → goals suppressed).
+		const fra = await makeTeam({ name: 'France', shortName: 'FRA', fifaPot: 1 })
+		const sen = await makeTeam({ name: 'Senegal', shortName: 'SEN', fifaPot: 2 })
+		const sco = await makeTeam({ name: 'Scotland', shortName: 'SCO', fifaPot: 1 })
+		const hai = await makeTeam({ name: 'Haiti', shortName: 'HAI', fifaPot: 2 })
+		// rank-2 underdogs (pot2 home vs pot1 away) that LOSE → break each streak at 1.
+		const uda = await makeTeam({ name: 'UdogA', shortName: 'UDA', fifaPot: 2 })
+		const fava = await makeTeam({ name: 'FavA', shortName: 'FVA', fifaPot: 1 })
+		const udb = await makeTeam({ name: 'UdogB', shortName: 'UDB', fifaPot: 2 })
+		const favb = await makeTeam({ name: 'FavB', shortName: 'FVB', fifaPot: 1 })
+		const r1 = await makeRound(compId, { number: 1, status: 'open' })
+		const fxA1 = await makeFixture({ roundId: r1, homeTeamId: fra, awayTeamId: sen })
+		const fxA2 = await makeFixture({ roundId: r1, homeTeamId: uda, awayTeamId: fava })
+		const fxB1 = await makeFixture({ roundId: r1, homeTeamId: sco, awayTeamId: hai })
+		const fxB2 = await makeFixture({ roundId: r1, homeTeamId: udb, awayTeamId: favb })
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'cup',
+			currentRoundId: r1,
+			modeConfig: { numberOfPicks: 2, startingLives: 0 },
+		})
+		const gpSean = await makePlayer({ gameId, userId: 'u-sean', livesRemaining: 0 })
+		const gpMark = await makePlayer({ gameId, userId: 'u-mark', livesRemaining: 0 })
+		await makePayment({ gameId, userId: 'u-sean' })
+		await makePayment({ gameId, userId: 'u-mark' })
+		// Sean: rank1 France (pot1 favourite) wins, rank2 underdog loses.
+		await makePick({
+			gameId,
+			gamePlayerId: gpSean,
+			roundId: r1,
+			teamId: fra,
+			fixtureId: fxA1,
+			confidenceRank: 1,
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpSean,
+			roundId: r1,
+			teamId: uda,
+			fixtureId: fxA2,
+			confidenceRank: 2,
+		})
+		// Mark: rank1 Scotland (pot1 favourite) wins, rank2 underdog loses.
+		await makePick({
+			gameId,
+			gamePlayerId: gpMark,
+			roundId: r1,
+			teamId: sco,
+			fixtureId: fxB1,
+			confidenceRank: 1,
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpMark,
+			roundId: r1,
+			teamId: udb,
+			fixtureId: fxB2,
+			confidenceRank: 2,
+		})
+
+		await finishFixture(fxA1, 3, 0) // France win 3-0 → counted 0 (favourite), raw 3
+		await finishFixture(fxB1, 1, 0) // Scotland win 1-0 → counted 0 (favourite), raw 1
+		await finishFixture(fxA2, 0, 2) // Sean's rank-2 underdog loses → streak breaks at 1
+		await finishFixture(fxB2, 0, 2) // Mark's rank-2 underdog loses → streak breaks at 1
+		for (const fx of [fxA1, fxB1, fxA2, fxB2]) await settleFixture(fx)
+
+		const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+		expect(g?.status).toBe('completed')
+
+		// Both tie on streak (1), lives (0) and counted goals (0). Raw streak goals
+		// separate them: France 3 > Scotland 1 → Sean wins SOLO, not a split.
+		const players = await db.query.gamePlayer.findMany({ where: eq(gamePlayer.gameId, gameId) })
+		expect(players.find((p) => p.id === gpSean)?.status).toBe('winner')
+		expect(players.find((p) => p.id === gpMark)?.status).not.toBe('winner')
+		const payouts = await db.query.payout.findMany({ where: eq(payout.gameId, gameId) })
+		expect(payouts.map((p) => p.userId)).toEqual(['u-sean'])
+		expect(payouts[0]?.isSplit).toBe(false)
+	})
 })
 
 /* ────────────────────────────────────────────────────────────────────── */

--- a/src/lib/game-logic/auto-complete-tiebreakers.test.ts
+++ b/src/lib/game-logic/auto-complete-tiebreakers.test.ts
@@ -103,25 +103,89 @@ describe('cupTiebreaker', () => {
 		).toEqual(['b'])
 	})
 
-	it('splits when all three metrics tie', () => {
+	it('falls through to raw streak goals when streak, lives and counted goals all tie', () => {
+		// d8360e69: both streak 1, lives 0, counted goals 0 (favourite wins
+		// suppressed) — the raw goals of the streak pick separate them.
 		expect(
 			cupTiebreaker([
-				{ gamePlayerId: 'a', cumulativeStreak: 10, livesRemaining: 2, cumulativeGoals: 18 },
-				{ gamePlayerId: 'b', cumulativeStreak: 10, livesRemaining: 2, cumulativeGoals: 18 },
+				{
+					gamePlayerId: 'a',
+					cumulativeStreak: 1,
+					livesRemaining: 0,
+					cumulativeGoals: 0,
+					rawStreakGoals: 3,
+				},
+				{
+					gamePlayerId: 'b',
+					cumulativeStreak: 1,
+					livesRemaining: 0,
+					cumulativeGoals: 0,
+					rawStreakGoals: 1,
+				},
+			]),
+		).toEqual(['a'])
+	})
+
+	it('splits only when raw streak goals also tie', () => {
+		expect(
+			cupTiebreaker([
+				{
+					gamePlayerId: 'a',
+					cumulativeStreak: 1,
+					livesRemaining: 0,
+					cumulativeGoals: 0,
+					rawStreakGoals: 2,
+				},
+				{
+					gamePlayerId: 'b',
+					cumulativeStreak: 1,
+					livesRemaining: 0,
+					cumulativeGoals: 0,
+					rawStreakGoals: 2,
+				},
 			]),
 		).toEqual(['a', 'b'])
+	})
+
+	it('does not consult raw goals when counted goals already separate players', () => {
+		// counted goals decide first; raw goals (which would favour b) are ignored.
+		expect(
+			cupTiebreaker([
+				{
+					gamePlayerId: 'a',
+					cumulativeStreak: 1,
+					livesRemaining: 0,
+					cumulativeGoals: 2,
+					rawStreakGoals: 2,
+				},
+				{
+					gamePlayerId: 'b',
+					cumulativeStreak: 1,
+					livesRemaining: 0,
+					cumulativeGoals: 1,
+					rawStreakGoals: 9,
+				},
+			]),
+		).toEqual(['a'])
 	})
 })
 
 describe('resolveWipeout', () => {
+	// Tuple: [rank, correct, goals(counted), rawGoals]. rawGoals defaults to the
+	// counted goals (they only differ for cup favourite-win suppression).
 	const p = (
 		gamePlayerId: string,
-		picks: Array<[rank: number, correct: boolean, goals?: number]>,
+		picks: Array<[rank: number, correct: boolean, goals?: number, rawGoals?: number]>,
 		livesRemaining = 0,
 	): WipeoutPlayerInput => ({
 		gamePlayerId,
 		livesRemaining,
-		picks: picks.map(([rank, correct, goals = 0]) => ({ rank, correct, goals })),
+		picks: picks.map(([rank, correct, goals = 0, rawGoals]) => ({
+			rank,
+			correct,
+			goals,
+			rawGoals: rawGoals ?? goals,
+		})),
 	})
 
 	it('computes a consecutive streak from rank 1 when rank 1 has a winner', () => {
@@ -140,8 +204,8 @@ describe('resolveWipeout', () => {
 		expect(out.totalWipeout).toBe(false)
 		expect(out.startingRank).toBe(1)
 		expect(out.scores).toEqual([
-			{ gamePlayerId: 'a', streak: 3, goalsInStreak: 0, livesRemaining: 0 },
-			{ gamePlayerId: 'b', streak: 1, goalsInStreak: 0, livesRemaining: 0 },
+			{ gamePlayerId: 'a', streak: 3, goalsInStreak: 0, rawGoalsInStreak: 0, livesRemaining: 0 },
+			{ gamePlayerId: 'b', streak: 1, goalsInStreak: 0, rawGoalsInStreak: 0, livesRemaining: 0 },
 		])
 	})
 
@@ -161,8 +225,8 @@ describe('resolveWipeout', () => {
 			]),
 		])
 		expect(out.scores).toEqual([
-			{ gamePlayerId: 'a', streak: 2, goalsInStreak: 0, livesRemaining: 0 },
-			{ gamePlayerId: 'b', streak: 1, goalsInStreak: 0, livesRemaining: 0 },
+			{ gamePlayerId: 'a', streak: 2, goalsInStreak: 0, rawGoalsInStreak: 0, livesRemaining: 0 },
+			{ gamePlayerId: 'b', streak: 1, goalsInStreak: 0, rawGoalsInStreak: 0, livesRemaining: 0 },
 		])
 	})
 
@@ -183,8 +247,8 @@ describe('resolveWipeout', () => {
 		expect(out.totalWipeout).toBe(false)
 		expect(out.startingRank).toBe(2)
 		expect(out.scores).toEqual([
-			{ gamePlayerId: 'a', streak: 2, goalsInStreak: 0, livesRemaining: 0 },
-			{ gamePlayerId: 'b', streak: 0, goalsInStreak: 0, livesRemaining: 0 },
+			{ gamePlayerId: 'a', streak: 2, goalsInStreak: 0, rawGoalsInStreak: 0, livesRemaining: 0 },
+			{ gamePlayerId: 'b', streak: 0, goalsInStreak: 0, rawGoalsInStreak: 0, livesRemaining: 0 },
 		])
 	})
 
@@ -206,8 +270,8 @@ describe('resolveWipeout', () => {
 		])
 		expect(out.startingRank).toBe(3)
 		expect(out.scores).toEqual([
-			{ gamePlayerId: 'a', streak: 2, goalsInStreak: 0, livesRemaining: 0 },
-			{ gamePlayerId: 'b', streak: 0, goalsInStreak: 0, livesRemaining: 0 },
+			{ gamePlayerId: 'a', streak: 2, goalsInStreak: 0, rawGoalsInStreak: 0, livesRemaining: 0 },
+			{ gamePlayerId: 'b', streak: 0, goalsInStreak: 0, rawGoalsInStreak: 0, livesRemaining: 0 },
 		])
 	})
 
@@ -238,7 +302,23 @@ describe('resolveWipeout', () => {
 			]),
 		])
 		expect(out.scores).toEqual([
-			{ gamePlayerId: 'a', streak: 2, goalsInStreak: 5, livesRemaining: 0 },
+			{ gamePlayerId: 'a', streak: 2, goalsInStreak: 5, rawGoalsInStreak: 5, livesRemaining: 0 },
+		])
+	})
+
+	it('tracks raw streak goals separately from counted goals (favourite suppression)', () => {
+		// rank 1 is a favourite win: counted 0, raw 3. rank 2 underdog win: counted
+		// + raw 1. Post-break rank 3 win (raw 9) must not count for either.
+		const out = resolveWipeout([
+			p('a', [
+				[1, true, 0, 3],
+				[2, true, 1, 1],
+				[3, false, 0, 0],
+				[4, true, 0, 9],
+			]),
+		])
+		expect(out.scores).toEqual([
+			{ gamePlayerId: 'a', streak: 2, goalsInStreak: 1, rawGoalsInStreak: 4, livesRemaining: 0 },
 		])
 	})
 
@@ -252,7 +332,7 @@ describe('resolveWipeout', () => {
 			]),
 		])
 		expect(out.scores).toEqual([
-			{ gamePlayerId: 'a', streak: 2, goalsInStreak: 3, livesRemaining: 0 },
+			{ gamePlayerId: 'a', streak: 2, goalsInStreak: 3, rawGoalsInStreak: 3, livesRemaining: 0 },
 		])
 	})
 

--- a/src/lib/game-logic/auto-complete-tiebreakers.ts
+++ b/src/lib/game-logic/auto-complete-tiebreakers.ts
@@ -17,6 +17,13 @@ export interface CupTiebreakerInput {
 	cumulativeStreak: number
 	livesRemaining: number
 	cumulativeGoals: number
+	/**
+	 * Raw goals scored by the streak picks, ignoring the favourite-win goal
+	 * suppression. Last-resort tiebreak when streak, lives and counted goals all
+	 * tie — separates two players whose streaks were all 1-tier-favourite wins
+	 * (counted 0) rather than splitting the pot. Optional; treated as 0 when absent.
+	 */
+	rawStreakGoals?: number
 }
 
 function maxBy<T>(items: T[], key: (t: T) => number): T[] {
@@ -43,7 +50,11 @@ export function cupTiebreaker(players: CupTiebreakerInput[]): string[] {
 	const topLives = maxBy(topStreak, (p) => p.livesRemaining)
 	if (topLives.length <= 1) return topLives.map((p) => p.gamePlayerId)
 	const topGoals = maxBy(topLives, (p) => p.cumulativeGoals)
-	return topGoals.map((p) => p.gamePlayerId)
+	if (topGoals.length <= 1) return topGoals.map((p) => p.gamePlayerId)
+	// Last-resort separator: raw goals of the streak picks (favourite suppression
+	// ignored). Prefers a clear winner over a split whenever any goals separate them.
+	const topRaw = maxBy(topGoals, (p) => p.rawStreakGoals ?? 0)
+	return topRaw.map((p) => p.gamePlayerId)
 }
 
 // -- Wipeout rule (single-round modes: turbo + cup) --
@@ -65,8 +76,14 @@ export interface WipeoutPickOutcome {
 	rank: number
 	/** did this pick keep the streak alive (turbo: predicted right; cup: win / draw_success / saved_by_life). */
 	correct: boolean
-	/** goals to add to the goals tiebreak if this pick is inside the streak (0 otherwise). */
+	/** counted (tier-adjusted) goals — feeds the primary goals tiebreak if this pick is inside the streak. */
 	goals: number
+	/**
+	 * Raw goals the picked team actually scored, ignoring cup favourite-win
+	 * suppression — feeds the raw-goals backstop. Optional; defaults to `goals`
+	 * (turbo has no suppression, so raw === counted there).
+	 */
+	rawGoals?: number
 }
 
 export interface WipeoutPlayerInput {
@@ -81,6 +98,8 @@ export interface WipeoutScore {
 	gamePlayerId: string
 	streak: number
 	goalsInStreak: number
+	/** raw goals over the streak picks (favourite suppression ignored) — for the cup raw-goals backstop. */
+	rawGoalsInStreak: number
 	livesRemaining: number
 }
 
@@ -114,15 +133,18 @@ export function resolveWipeout(players: WipeoutPlayerInput[]): WipeoutOutcome {
 		const ordered = player.picks.filter((pk) => pk.rank >= start).sort((a, b) => a.rank - b.rank)
 		let streak = 0
 		let goalsInStreak = 0
+		let rawGoalsInStreak = 0
 		for (const pk of ordered) {
 			if (!pk.correct) break
 			streak++
 			goalsInStreak += pk.goals
+			rawGoalsInStreak += pk.rawGoals ?? pk.goals
 		}
 		return {
 			gamePlayerId: player.gamePlayerId,
 			streak,
 			goalsInStreak,
+			rawGoalsInStreak,
 			livesRemaining: player.livesRemaining,
 		}
 	})

--- a/src/lib/game-logic/cup.test.ts
+++ b/src/lib/game-logic/cup.test.ts
@@ -135,6 +135,20 @@ describe('evaluateCupPicks', () => {
 			expect(result.pickResults[1].result).toBe('loss')
 		})
 
+		it('does NOT earn lives from a win after the streak has already broken', () => {
+			// rank 1 loses (no lives) → eliminated. rank 2 is an underdog win that
+			// would normally grant 3 lives — but the streak is already broken, so
+			// lives are frozen at the eliminating pick. Goals still count (it IS a
+			// win), only the life accrual is suppressed.
+			const picks = [makePick(1, 'home', 0, 2, 0), makePick(2, 'away', 0, 2, 3)]
+			const result = evaluateCupPicks(picks, 0)
+			expect(result.pickResults[0].result).toBe('loss')
+			expect(result.pickResults[1].result).toBe('win')
+			expect(result.pickResults[1].goalsCounted).toBe(2)
+			expect(result.pickResults[1].livesGained).toBe(0)
+			expect(result.finalLives).toBe(0)
+		})
+
 		it('can spend multiple lives before streak breaks', () => {
 			const picks = [
 				makePick(1, 'away', 0, 2, 3),

--- a/src/lib/game-logic/cup.ts
+++ b/src/lib/game-logic/cup.ts
@@ -55,7 +55,12 @@ export function evaluateCupPicks(picks: CupPickInput[], startingLives: number): 
 			if (tierDiffFromPicked !== 1) {
 				goalsCounted = pickedTeamGoals
 			}
-			if (tierDiffFromPicked < 0) {
+			// Lives are earned only while the streak is alive. A win after the
+			// streak has broken (the player is already eliminated) earns nothing
+			// usable — counting it would inflate the lives tiebreaker with lives
+			// the player can never spend. Goals still count; only life accrual is
+			// frozen at the eliminating pick.
+			if (tierDiffFromPicked < 0 && !streakBroken) {
 				livesGained = Math.abs(tierDiffFromPicked)
 				currentLives += livesGained
 			}
@@ -63,7 +68,7 @@ export function evaluateCupPicks(picks: CupPickInput[], startingLives: number): 
 			if (tierDiffFromPicked <= -1) {
 				result = 'draw_success'
 				// Goals NOT counted on draw_success (matches old app stored procedure)
-				if (tierDiffFromPicked <= -2) {
+				if (tierDiffFromPicked <= -2 && !streakBroken) {
 					livesGained = 1
 					currentLives += 1
 				}

--- a/src/lib/game/auto-complete.test.ts
+++ b/src/lib/game/auto-complete.test.ts
@@ -217,12 +217,24 @@ describe('checkCupCompletion (single gameweek — longest streak)', () => {
 	beforeEach(() => vi.clearAllMocks())
 
 	// Cup pick rows carry a confidenceRank; the streak is now rank-ordered.
+	// `rawGoals` (the picked team's actual goals, pre-suppression) defaults to the
+	// counted goalsScored; it only differs for 1-tier-favourite wins. The pick is
+	// modelled as the home side so checkCupCompletion can read raw goals off the
+	// joined fixture.
 	const cupPick = (
 		gamePlayerId: string,
 		confidenceRank: number,
 		result: string,
 		goalsScored = 0,
-	) => ({ gamePlayerId, confidenceRank, result, goalsScored })
+		rawGoals = goalsScored,
+	) => ({
+		gamePlayerId,
+		confidenceRank,
+		result,
+		goalsScored,
+		teamId: 'home-team',
+		fixture: { homeTeamId: 'home-team', homeScore: rawGoals, awayScore: 0 },
+	})
 
 	it('crowns the longest streak across all players (tiebreak streak→lives→goals)', async () => {
 		dbMock.query.gamePlayer.findMany.mockResolvedValue([
@@ -328,6 +340,26 @@ describe('checkCupCompletion (single gameweek — longest streak)', () => {
 		expect(result.reason).toBe('cup-total-wipeout')
 		expect(result.refund).toBe(true)
 		expect(result.winnerPlayerIds).toEqual([])
+	})
+
+	it('breaks a streak+lives+counted-goals tie on raw streak goals (no split) — the d8360e69 case', async () => {
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([
+			{ id: 'sean', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+			{ id: 'mark', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+		] as never)
+		// Both: rank-1 favourite WIN (counted goals suppressed to 0), then a rank-2
+		// loss → streak 1, lives 0, counted goals 0. Raw goals separate them:
+		// Sean's France scored 3, Mark's Scotland scored 1 → Sean wins, no split.
+		dbMock.query.pick.findMany.mockResolvedValue([
+			cupPick('sean', 1, 'win', 0, 3),
+			cupPick('sean', 2, 'loss', 0, 0),
+			cupPick('mark', 1, 'win', 0, 1),
+			cupPick('mark', 2, 'loss', 0, 0),
+		] as never)
+
+		const result = await checkCupCompletion('g1')
+		expect(result.reason).toBe('cup-longest-streak')
+		expect(result.winnerPlayerIds).toEqual(['sean'])
 	})
 
 	it('tiebreaks equal streaks by lives', async () => {

--- a/src/lib/game/auto-complete.ts
+++ b/src/lib/game/auto-complete.ts
@@ -147,8 +147,12 @@ export async function checkCupCompletion(gameId: string): Promise<CompletionChec
 	})
 	if (allPlayers.length === 0) return { completed: false, winnerPlayerIds: [] }
 
+	// Picks are joined to their fixture so we can read the picked team's *raw*
+	// goals (the actual score) — the counted `goalsScored` suppresses 1-tier-
+	// favourite-win goals, but the raw-goals backstop needs the unsuppressed value.
 	const allPicks = await db.query.pick.findMany({
 		where: eq(pick.gameId, gameId),
+		with: { fixture: true },
 	})
 	const players: WipeoutPlayerInput[] = allPlayers.map((p) => ({
 		gamePlayerId: p.id,
@@ -159,11 +163,16 @@ export async function checkCupCompletion(gameId: string): Promise<CompletionChec
 			// picks contribute nothing — the streak walks past a void gap and stops
 			// at any pending pick (there should be none once the gameweek is done).
 			.filter((pk) => pk.result != null && pk.result !== 'void' && pk.result !== 'pending')
-			.map((pk) => ({
-				rank: pk.confidenceRank ?? 0,
-				correct: pk.result === 'win' || pk.result === 'draw' || pk.result === 'saved_by_life',
-				goals: pk.goalsScored ?? 0,
-			})),
+			.map((pk) => {
+				const pickedHome = pk.teamId === pk.fixture?.homeTeamId
+				const rawGoals = pickedHome ? (pk.fixture?.homeScore ?? 0) : (pk.fixture?.awayScore ?? 0)
+				return {
+					rank: pk.confidenceRank ?? 0,
+					correct: pk.result === 'win' || pk.result === 'draw' || pk.result === 'saved_by_life',
+					goals: pk.goalsScored ?? 0,
+					rawGoals,
+				}
+			}),
 	}))
 
 	const outcome = resolveWipeout(players)
@@ -181,6 +190,7 @@ export async function checkCupCompletion(gameId: string): Promise<CompletionChec
 			cumulativeStreak: s.streak,
 			livesRemaining: s.livesRemaining,
 			cumulativeGoals: s.goalsInStreak,
+			rawStreakGoals: s.rawGoalsInStreak,
 		})),
 	)
 	return { completed: true, winnerPlayerIds: winners, reason: 'cup-longest-streak' }


### PR DESCRIPTION
## What & why

Two cup tiebreaker corrections surfaced while re-settling the live World Cup
incident on cup game `d8360e69` (which #80 already partly addressed). Both are
cup-only; turbo is unaffected (no lives, no favourite-goal suppression).

### 1. Lives frozen at the eliminating pick
`evaluateCupPicks` kept granting lives for underdog wins logged **after** the
streak broke — lives an already-eliminated player can never spend, which
inflated the lives tiebreaker. #80's `reevaluateCupGame` guard-removal (needed
so post-break picks settle for the wipeout rebase) exposed this latent
behaviour. Life accrual now stops once `streakBroken`; goals and result labels
are unchanged, so the rebase still sees post-break wins.

### 2. Raw-goals tiebreak backstop
`cupTiebreaker` gains a 4th rung: when streak, lives **and** counted
(tier-adjusted) goals all tie, fall back to the **raw** goals scored by the
streak picks — favourite-win suppression ignored — to crown a clear winner
rather than splitting. Only splits if raw goals also tie.

**Full cup tiebreaker:** streak → lives (frozen at elimination) → counted goals → raw goals → split.

### The d8360e69 case
Two players tie on streak 1, lives 0 and counted goals 0 — both their streak
picks were 1-tier-favourite wins (goals suppressed). The raw goals of those
streak picks (France 3 vs Scotland 1) separate them → solo winner, not a split.

## Changes
- `evaluateCupPicks`: freeze life accrual (win + underdog-draw branches) once `streakBroken`.
- `resolveWipeout`: track `rawGoalsInStreak` alongside `goalsInStreak` (`WipeoutPickOutcome.rawGoals`, optional, defaults to counted).
- `cupTiebreaker`: 4th rung on `rawStreakGoals` (optional input).
- `checkCupCompletion`: join the fixture to read each picked team's raw goals; pass `rawStreakGoals`.
- Docs: `cup.md` tiebreaker order + lives-frozen + raw-goals backstop; corrected the stale "post-break wins still earn lives" note.

## Tests
- **Unit:** post-break win earns no life (`evaluateCupPicks`); `resolveWipeout` raw vs counted; `cupTiebreaker` rung-4 (and that counted goals decide first); `checkCupCompletion` d8360e69 case → solo winner not split.
- **Smoke:** `group_knockout` backstop scenario — two favourite-win streaks tie on everything countable, raw goals crown a solo winner.

## Verification
typecheck ✓ · unit 454 ✓ · smoke 28 ✓ · build ✓ (local, against migrated DB).

## Follow-up
After merge + deploy, the `d8360e69` data correction re-settles to: **Sean Lennon solo, £50** (all 5 pickers marked paid → pot £50), un-crowning the previously-mis-crowned eliminated player.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
