### PR TITLE
feat(classic): show goals-scored total in the progress grid

### DIFF
--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -229,6 +229,36 @@ describe('lifecycle: classic-PL', () => {
 		expect(g?.currentRoundId).toBe(r3)
 		expect(g?.status).toBe('active')
 	})
+
+	it('progress grid exposes each player total goals scored (sum of winning picks)', async () => {
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const a = await makeTeam({ name: 'A', shortName: 'A' })
+		const b = await makeTeam({ name: 'B', shortName: 'B' })
+		const r2 = await makeRound(compId, { number: 2, status: 'open' })
+		const fxWin = await makeFixture({ roundId: r2, homeTeamId: a, awayTeamId: b })
+		const fxLose = await makeFixture({ roundId: r2, homeTeamId: a, awayTeamId: b })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r2,
+			modeConfig: { allowRebuys: false },
+		})
+		const gpWin = await makePlayer({ gameId, userId: 'u-win' })
+		const gpLose = await makePlayer({ gameId, userId: 'u-lose' })
+		await makePick({ gameId, gamePlayerId: gpWin, roundId: r2, teamId: a, fixtureId: fxWin })
+		await makePick({ gameId, gamePlayerId: gpLose, roundId: r2, teamId: b, fixtureId: fxLose })
+
+		// A wins 3-0: gpWin (picked A) scores 3 goals; gpLose (picked B) loses, 0 goals.
+		await finishFixture(fxWin, 3, 0)
+		await settleFixture(fxWin)
+		await finishFixture(fxLose, 3, 0)
+		await settleFixture(fxLose)
+
+		const grid = await getProgressGridData(gameId, 'u-win')
+		expect(grid?.players.find((p) => p.id === gpWin)?.goals).toBe(3)
+		expect(grid?.players.find((p) => p.id === gpLose)?.goals).toBe(0)
+	})
 })
 
 /* ────────────────────────────────────────────────────────────────────── */

--- a/src/components/standings/progress-grid.tsx
+++ b/src/components/standings/progress-grid.tsx
@@ -61,6 +61,8 @@ export interface GridPlayer {
 	status: 'alive' | 'eliminated' | 'winner'
 	eliminatedRoundNumber?: number
 	eliminatedRoundLabel?: string
+	/** Total goals scored by this player's winning picks (classic tiebreaker). */
+	goals: number
 	cellsByRoundId: Record<string, GridCell>
 }
 
@@ -232,6 +234,12 @@ export function ProgressGrid({
 										</div>
 									</th>
 								))}
+								<th
+									className="font-medium text-muted-foreground text-center pb-3 px-2"
+									title="Goals scored"
+								>
+									Gls
+								</th>
 								<th className="pb-3 pl-4 min-w-[80px] text-right">Status</th>
 							</tr>
 						</thead>
@@ -314,6 +322,9 @@ export function ProgressGrid({
 												</td>
 											)
 										})}
+										<td className="px-2 text-center align-middle text-xs font-semibold tabular-nums">
+											{player.goals || '—'}
+										</td>
 										<td className="pl-4 text-right">
 											{player.status === 'alive' ? (
 												<span className="text-[0.7rem] font-semibold px-2 py-0.5 rounded bg-[var(--alive-bg)] text-[var(--alive)]">

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -962,6 +962,13 @@ export async function getProgressGridData(
 		const eliminatedRoundNumber = p.eliminatedRoundId
 			? gameData.competition.rounds.find((r) => r.id === p.eliminatedRoundId)?.number
 			: undefined
+		// Total goals scored by this player's winning picks (the classic
+		// tiebreaker). settle persists goalsScored = picked team's goals on a
+		// win, 0 otherwise — so summing across all picks is the running total.
+		// Pending/hidden current-round picks have goalsScored 0, so nothing leaks.
+		const goals = gameData.picks
+			.filter((pk) => pk.gamePlayerId === p.id)
+			.reduce((sum, pk) => sum + (pk.goalsScored ?? 0), 0)
 		return {
 			id: p.id,
 			name: userNames.get(p.userId) ?? 'Player',
@@ -971,6 +978,7 @@ export async function getProgressGridData(
 				eliminatedRoundNumber != null
 					? roundLabel(competitionType, eliminatedRoundNumber)
 					: undefined,
+			goals,
 			cellsByRoundId,
 		}
 	})


### PR DESCRIPTION
## What & why

C2 from the classic backlog. The classic **progress grid showed no goals at all**, while turbo and cup standings both surface a goals total. Goals are the classic tiebreaker and are **already persisted** — settlement writes `pick.goalsScored` (= picked team's goals on a win, 0 otherwise) — but `getProgressGridData` never summed or returned them, and the grid had no column.

## Change
- **`getProgressGridData`**: sum `goalsScored` across each player's picks → a per-player `goals` total. Pending/hidden current-round picks have `goalsScored = 0`, so nothing leaks before the deadline.
- **`GridPlayer`** gains a required `goals` field; the progress grid renders a **"Gls"** column, mirroring cup-grid (`{goals || '—'}`).

`getProgressGridData` is the only constructor of `GridPlayer`, so no other surface needed changes (typecheck confirms).

## Verification
- ✅ typecheck · Biome · unit **458** · smoke **28** (+1 new, asserting the per-player goals total on a real settled game) · `next build`
- ✅ dev-server render: the classic grid shows the new **Gls** column populated with real per-player totals (13, 12, 8, 11, 7, 3…), no errors.