### PR TITLE
fix(classic): keep advance picks hidden from others until the round's deadline

### DIFF
--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -1103,6 +1103,51 @@ describe('post-deadline + post-completion visibility', () => {
 		expect(otherRow?.cellsByRoundId[r2]?.result).toBe('locked')
 	})
 
+	it('classic: progress grid hides other players ADVANCE picks for a FUTURE round before its deadline', async () => {
+		// Advance picks (PR #81) let a player commit a real pick for a future round
+		// while it's still 'upcoming'. Those must stay 'locked' to other viewers
+		// until THAT round's deadline — not leak the team the moment they're made.
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const a = await makeTeam({ name: 'A', shortName: 'A' })
+		const b = await makeTeam({ name: 'B', shortName: 'B' })
+		const c = await makeTeam({ name: 'C', shortName: 'C' })
+		const d = await makeTeam({ name: 'D', shortName: 'D' })
+		const r2 = await makeRound(compId, {
+			number: 2,
+			status: 'open',
+			deadline: new Date(Date.now() + 86_400_000),
+		})
+		// Future round, still 'upcoming' for this game (currentRound is r2), deadline ahead.
+		const r3 = await makeRound(compId, {
+			number: 3,
+			status: 'upcoming',
+			deadline: new Date(Date.now() + 172_800_000),
+		})
+		const fx2 = await makeFixture({ roundId: r2, homeTeamId: a, awayTeamId: b })
+		const fx3 = await makeFixture({ roundId: r3, homeTeamId: c, awayTeamId: d })
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r2,
+			modeConfig: { allowRebuys: false },
+		})
+		const gpMe = await makePlayer({ gameId, userId: 'u-me' })
+		const gpOther = await makePlayer({ gameId, userId: 'u-other' })
+		// Both pick the current round AND lock an advance pick for the future round.
+		await makePick({ gameId, gamePlayerId: gpMe, roundId: r2, teamId: a, fixtureId: fx2 })
+		await makePick({ gameId, gamePlayerId: gpOther, roundId: r2, teamId: b, fixtureId: fx2 })
+		await makePick({ gameId, gamePlayerId: gpMe, roundId: r3, teamId: c, fixtureId: fx3 })
+		await makePick({ gameId, gamePlayerId: gpOther, roundId: r3, teamId: d, fixtureId: fx3 })
+
+		const grid = await getProgressGridData(gameId, 'u-me')
+		const myRow = grid?.players.find((p) => p.id === gpMe)
+		const otherRow = grid?.players.find((p) => p.id === gpOther)
+		// My own advance pick is visible to me; the other player's advance pick must
+		// be locked (deadline for r3 hasn't passed).
+		expect(myRow?.cellsByRoundId[r3]?.result).not.toBe('locked')
+		expect(otherRow?.cellsByRoundId[r3]?.result).toBe('locked')
+	})
+
 	it('turbo: standings hide other players picks BEFORE the deadline', async () => {
 		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
 		const teams: string[] = []

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -848,15 +848,22 @@ export async function getProgressGridData(
 	const currentRoundNumber =
 		gameData.competition.rounds.find((r) => r.id === gameData.currentRoundId)?.number ?? null
 	const derivedRoundStatus = new Map<string, 'upcoming' | 'open' | 'active' | 'completed'>()
+	// Whether a round's picks are locked-and-revealable to everyone. Picks stay
+	// hidden from other viewers until the round's OWN deadline passes (or it's
+	// processed) — this must hold for FUTURE rounds too, since advance picks
+	// (PR #81) commit real picks for a round that's still 'upcoming'. Keying the
+	// reveal on `=== 'open'` only covered the current round and leaked advance
+	// picks the moment they were made.
+	const picksLockedByRoundId = new Map<string, boolean>()
 	for (const r of gameData.competition.rounds) {
-		derivedRoundStatus.set(
-			r.id,
-			deriveGameRoundStatus({
-				round: { id: r.id, number: r.number, status: r.status, deadline: r.deadline },
-				game: { currentRoundId: gameData.currentRoundId, currentRoundNumber },
-				now,
-			}),
-		)
+		const status = deriveGameRoundStatus({
+			round: { id: r.id, number: r.number, status: r.status, deadline: r.deadline },
+			game: { currentRoundId: gameData.currentRoundId, currentRoundNumber },
+			now,
+		})
+		derivedRoundStatus.set(r.id, status)
+		const deadlinePassed = r.deadline != null && now >= r.deadline
+		picksLockedByRoundId.set(r.id, status === 'completed' || deadlinePassed)
 	}
 
 	// Get user names for players
@@ -891,12 +898,13 @@ export async function getProgressGridData(
 					continue
 				}
 			}
-			const isRoundOpen = derivedRoundStatus.get(r.id) === 'open'
+			const picksLocked = picksLockedByRoundId.get(r.id) ?? false
 			const isOwnPick = viewerGamePlayerId && thePick?.gamePlayerId === viewerGamePlayerId
-			// If the round is open (deadline hasn't passed yet) and either the viewer
-			// isn't the picker or the caller has requested a shared-view (hide
-			// everything current) — hide the team info.
-			const hideTeam = isRoundOpen && (options?.hideAllCurrentPicks || !isOwnPick)
+			// Hide the team while this round's picks aren't locked yet (its deadline
+			// hasn't passed) and either the viewer isn't the picker or the caller
+			// requested a shared-view (hide everything not-yet-locked). Covers the
+			// current open round AND future advance-pick rounds.
+			const hideTeam = !picksLocked && (options?.hideAllCurrentPicks || !isOwnPick)
 
 			if (!thePick) {
 				// Always show "?" for players who haven't picked yet — acts as a nudge.


### PR DESCRIPTION
## The bug

PR #81 (lockable advance picks) lets a player commit a **real** pick for a
**future** round. That round is still `'upcoming'` for the game, but having a
pick on it makes it a "touched" column in the classic progress grid. The grid
hid other players' picks only when a round's derived status was `'open'` — and
`'open'` only ever applies to the **current** round — so a future advance pick
**leaked the picked team to every other player the moment it was locked in**,
well before that round's deadline. A pick-secrecy / fairness break.

## Root cause

`getProgressGridData` (`detail-queries.ts`) gated reveal on
`derivedRoundStatus === 'open'`. `deriveGameRoundStatus` returns `'upcoming'`
(not `'open'`) for a future round the game hasn't advanced to — so the hide
condition was `false` for future rounds → team shown.

## Fix

Reveal a round's picks to *other* viewers based on whether that round's picks
are **locked** — its own `deadline` has passed, or it's been processed
(`completed`) — instead of the `'open'` status. This naturally covers the
current open round **and** future advance-pick rounds: their picks render
`'locked'` to others until the deadline, then reveal.

- Single fix site: `getProgressGridData`. The share-image path
  (`hideAllCurrentPicks`) reuses it and inherits the fix.
- Turbo/cup are single-round (no future rounds), so they can't leak advance
  picks — unaffected.

## Tests
- **Smoke (new regression):** two players lock advance picks for a future round
  (`r3`, deadline ahead); the viewer sees their own `r3` cell but the other
  player's stays `'locked'`. Fails before the fix, passes after.
- The existing "hides other players' picks BEFORE the deadline" (current round)
  and "reveal after the deadline" scenarios still pass.

## Verification
typecheck ✓ · unit 463 ✓ · smoke 29 ✓ · build ✓ (local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
