### PR TITLE
feat(classic): sortable progress grid (status / goals / name)

### DIFF
--- a/src/components/standings/grid-sort-control.tsx
+++ b/src/components/standings/grid-sort-control.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+import type { GridSortKey } from './grid-sort'
+
+interface GridSortControlProps {
+	value: GridSortKey
+	onChange: (value: GridSortKey) => void
+}
+
+const OPTIONS: Array<{ value: GridSortKey; label: string }> = [
+	{ value: 'status', label: 'Status' },
+	{ value: 'goals', label: 'Goals' },
+	{ value: 'name', label: 'Name' },
+]
+
+export function GridSortControl({ value, onChange }: GridSortControlProps) {
+	return (
+		<div className="flex items-center gap-1">
+			<span className="text-xs text-muted-foreground mr-0.5">Sort</span>
+			{OPTIONS.map((opt) => (
+				<button
+					key={opt.value}
+					type="button"
+					aria-pressed={value === opt.value}
+					onClick={() => onChange(opt.value)}
+					className={cn(
+						'text-xs px-2 py-1 rounded-md border border-border font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+						value === opt.value
+							? 'bg-foreground text-background border-foreground'
+							: 'bg-card text-muted-foreground hover:bg-muted',
+					)}
+				>
+					{opt.label}
+				</button>
+			))}
+		</div>
+	)
+}

--- a/src/components/standings/grid-sort.test.ts
+++ b/src/components/standings/grid-sort.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { type GridSortKey, sortGridPlayers } from './grid-sort'
+
+interface P {
+	name: string
+	status: 'alive' | 'eliminated' | 'winner'
+	eliminatedRoundNumber?: number
+	goals: number
+}
+const p = (over: Partial<P> & { name: string }): P => ({
+	status: 'alive',
+	goals: 0,
+	...over,
+})
+
+const sortNames = (players: P[], key: GridSortKey) =>
+	sortGridPlayers(players, key).map((x) => x.name)
+
+describe('sortGridPlayers', () => {
+	it("'status': alive before eliminated, later-eliminated above earlier, then name A–Z", () => {
+		const players = [
+			p({ name: 'Zoe', status: 'eliminated', eliminatedRoundNumber: 1 }),
+			p({ name: 'Bob', status: 'alive' }),
+			p({ name: 'Amy', status: 'alive' }),
+			p({ name: 'Max', status: 'eliminated', eliminatedRoundNumber: 3 }),
+		]
+		expect(sortNames(players, 'status')).toEqual(['Amy', 'Bob', 'Max', 'Zoe'])
+	})
+
+	it("'goals': highest first, ties broken by name", () => {
+		const players = [
+			p({ name: 'Amy', goals: 4 }),
+			p({ name: 'Bob', goals: 9 }),
+			p({ name: 'Cas', goals: 4 }),
+		]
+		expect(sortNames(players, 'goals')).toEqual(['Bob', 'Amy', 'Cas'])
+	})
+
+	it("'name': alphabetical regardless of status/goals", () => {
+		const players = [
+			p({ name: 'Cas', status: 'eliminated', eliminatedRoundNumber: 2, goals: 9 }),
+			p({ name: 'Amy', goals: 0 }),
+			p({ name: 'Bob', goals: 3 }),
+		]
+		expect(sortNames(players, 'name')).toEqual(['Amy', 'Bob', 'Cas'])
+	})
+
+	it('does not mutate the input array', () => {
+		const players = [p({ name: 'Bob' }), p({ name: 'Amy' })]
+		const before = players.map((x) => x.name)
+		sortGridPlayers(players, 'name')
+		expect(players.map((x) => x.name)).toEqual(before)
+	})
+})

--- a/src/components/standings/grid-sort.ts
+++ b/src/components/standings/grid-sort.ts
@@ -1,0 +1,30 @@
+export type GridSortKey = 'status' | 'goals' | 'name'
+
+interface SortablePlayer {
+	name: string
+	status: 'alive' | 'eliminated' | 'winner'
+	eliminatedRoundNumber?: number
+	goals: number
+}
+
+/**
+ * Order players for the progress grid. Pure + non-mutating.
+ *  - 'status' (default): alive first; among eliminated, the later-eliminated
+ *    (survived longer) rank higher; ties by name A–Z.
+ *  - 'goals': most goals first; ties by name A–Z.
+ *  - 'name': alphabetical.
+ */
+export function sortGridPlayers<T extends SortablePlayer>(players: T[], key: GridSortKey): T[] {
+	const byName = (a: T, b: T) => a.name.localeCompare(b.name)
+	return [...players].sort((a, b) => {
+		if (key === 'name') return byName(a, b)
+		if (key === 'goals') return b.goals - a.goals || byName(a, b)
+		// 'status'
+		if (a.status === 'alive' && b.status !== 'alive') return -1
+		if (a.status !== 'alive' && b.status === 'alive') return 1
+		if (a.status === 'eliminated' && b.status === 'eliminated') {
+			return (b.eliminatedRoundNumber ?? 0) - (a.eliminatedRoundNumber ?? 0) || byName(a, b)
+		}
+		return byName(a, b)
+	})
+}

--- a/src/components/standings/progress-grid.tsx
+++ b/src/components/standings/progress-grid.tsx
@@ -7,6 +7,8 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { GridFilter } from './grid-filter'
+import { type GridSortKey, sortGridPlayers } from './grid-sort'
+import { GridSortControl } from './grid-sort-control'
 
 const LIVE_RECENT_MS = 1500
 
@@ -89,6 +91,7 @@ export function ProgressGrid({
 	showAdminActions,
 }: ProgressGridProps) {
 	const [filter, setFilter] = useState<'all' | 'last5' | 'last3'>(defaultFilter)
+	const [sort, setSort] = useState<GridSortKey>('status')
 	const [showOpponents, setShowOpponents] = useState(false)
 	const [hideEliminated, setHideEliminated] = useState(false)
 	const liveCtx = useLiveGame()
@@ -150,14 +153,7 @@ export function ProgressGrid({
 
 	const currentRoundId = rounds.at(-1)?.id
 
-	const sortedPlayers = [...players].sort((a, b) => {
-		if (a.status === 'alive' && b.status !== 'alive') return -1
-		if (a.status !== 'alive' && b.status === 'alive') return 1
-		if (a.status === 'eliminated' && b.status === 'eliminated') {
-			return (b.eliminatedRoundNumber ?? 0) - (a.eliminatedRoundNumber ?? 0)
-		}
-		return a.name.localeCompare(b.name)
-	})
+	const sortedPlayers = sortGridPlayers(players, sort)
 
 	const visiblePlayers = hideEliminated
 		? sortedPlayers.filter((p) => p.status !== 'eliminated')
@@ -204,6 +200,7 @@ export function ProgressGrid({
 							Share grid
 						</Button>
 					)}
+					<GridSortControl value={sort} onChange={setSort} />
 					<GridFilter value={filter} onChange={setFilter} />
 				</div>
 			</div>


### PR DESCRIPTION
## What & why

C3 from the classic backlog. The classic progress grid had a **fixed** player order (alive-first → elimination round → name) with no way to re-sort. Now there's a **"Sort"** segmented control (mirrors the existing round filter) with:

- **Status** — default; same ordering as before, so no regression
- **Goals** — highest first (surfaces the Gls column added in #83)
- **Name** — A–Z

## Notes
- The comparator is a pure, **unit-tested** function (`sortGridPlayers`, 4 cases incl. non-mutation) — ordering logic is covered without a DOM or DB.
- Scope is the **classic progress grid**. Turbo and cup standings are already performance-ranked ladders (streak → goals → lives), so they're not in scope here.

## Verification
- ✅ typecheck · Biome · unit **467** (+4) · smoke **29** · `next build`
- ✅ dev-server render: the Sort control renders next to the round filter, buttons carry `aria-pressed`, default order unchanged, no errors.