### PR TITLE
fix(security): stop pick data leaking before the round deadline (3 surfaces)

### DIFF
--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -30,6 +30,7 @@ import { settleFixture } from '@/lib/game/settle'
 import { round as roundTable } from '@/lib/schema/competition'
 import { game, gamePlayer, pick } from '@/lib/schema/game'
 import { payment, payout } from '@/lib/schema/payment'
+import { getShareLiveData } from '@/lib/share/data'
 import {
 	finishFixture,
 	liveFixture,
@@ -810,6 +811,71 @@ describe('live projection', () => {
 		const loserPick = payload?.picks.find((p) => p.gamePlayerId === gpLose)
 		expect(winnerPick?.projectedOutcome).toBe('winning')
 		expect(loserPick?.projectedOutcome).toBe('losing')
+	})
+
+	it('classic: live payload hides other players current-round picks BEFORE the deadline', async () => {
+		// The /live payload feeds the 30s browser poll. Before the round deadline
+		// it must NOT carry opponents' team choices — the grid hiding them in the UI
+		// isn't enough if the raw teamId is sitting in the JSON response.
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const a = await makeTeam({ name: 'A', shortName: 'A' })
+		const b = await makeTeam({ name: 'B', shortName: 'B' })
+		const r2 = await makeRound(compId, {
+			number: 2,
+			status: 'open',
+			deadline: new Date(Date.now() + 86_400_000), // deadline still ahead
+		})
+		const fx = await makeFixture({ roundId: r2, homeTeamId: a, awayTeamId: b })
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r2,
+			modeConfig: { allowRebuys: false },
+		})
+		const gpMe = await makePlayer({ gameId, userId: 'u-me' })
+		const gpOther = await makePlayer({ gameId, userId: 'u-other' })
+		await makePick({ gameId, gamePlayerId: gpMe, roundId: r2, teamId: a, fixtureId: fx })
+		await makePick({ gameId, gamePlayerId: gpOther, roundId: r2, teamId: b, fixtureId: fx })
+
+		const payload = await getLivePayload(gameId, 'u-me')
+		const mine = payload?.picks.find((p) => p.gamePlayerId === gpMe)
+		const theirs = payload?.picks.find((p) => p.gamePlayerId === gpOther)
+		// Own pick visible; opponent's identity stripped to 'hidden'.
+		expect(mine?.teamId).toBe(a)
+		expect(theirs?.teamId).toBeNull()
+		expect(theirs?.predictedResult).toBeNull()
+		expect(theirs?.fixtureId).toBeNull()
+		expect(theirs?.result).toBe('hidden')
+	})
+
+	it('classic: live SHARE image hides every pick BEFORE the deadline', async () => {
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const a = await makeTeam({ name: 'A', shortName: 'A' })
+		const b = await makeTeam({ name: 'B', shortName: 'B' })
+		const r2 = await makeRound(compId, {
+			number: 2,
+			status: 'open',
+			deadline: new Date(Date.now() + 86_400_000), // deadline still ahead
+		})
+		const fx = await makeFixture({ roundId: r2, homeTeamId: a, awayTeamId: b })
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r2,
+			modeConfig: { allowRebuys: false },
+		})
+		const gpMe = await makePlayer({ gameId, userId: 'u-me' })
+		const gpOther = await makePlayer({ gameId, userId: 'u-other' })
+		await makePick({ gameId, gamePlayerId: gpMe, roundId: r2, teamId: a, fixtureId: fx })
+		await makePick({ gameId, gamePlayerId: gpOther, roundId: r2, teamId: b, fixtureId: fx })
+
+		const data = await getShareLiveData(gameId, 'u-me')
+		expect(data?.mode).toBe('classic')
+		// Shared image is posted to the group — before the deadline NO one's team
+		// is revealed (mirrors the standings share hiding all current picks).
+		const rows = data?.mode === 'classic' ? data.rows : []
+		expect(rows.length).toBe(2)
+		for (const row of rows) expect(row.pickedTeamShort).toBeNull()
 	})
 
 	it('turbo: projected streak counts in-progress correct picks', async () => {

--- a/src/app/api/picks/[gameId]/[roundId]/route.test.ts
+++ b/src/app/api/picks/[gameId]/[roundId]/route.test.ts
@@ -32,7 +32,14 @@ vi.mock('@/lib/db', () => ({
 
 import { requireSession } from '@/lib/auth-helpers'
 import { db } from '@/lib/db'
+import * as pickRoute from './route'
 import { POST } from './route'
+
+describe('GET /api/picks/[gameId]/[roundId]', () => {
+	it('is not exposed — a GET handler would leak opponents picks before the deadline', () => {
+		expect((pickRoute as Record<string, unknown>).GET).toBeUndefined()
+	})
+})
 
 function makeReq(body: unknown) {
 	return new Request('http://localhost/api/picks/g1/r1', {

--- a/src/app/api/picks/[gameId]/[roundId]/route.ts
+++ b/src/app/api/picks/[gameId]/[roundId]/route.ts
@@ -10,17 +10,10 @@ import { game, gamePlayer, pick } from '@/lib/schema/game'
 
 type Params = Promise<{ gameId: string; roundId: string }>
 
-export async function GET(_request: Request, { params }: { params: Params }) {
-	await requireSession()
-	const { gameId, roundId } = await params
-
-	const picks = await db.query.pick.findMany({
-		where: and(eq(pick.gameId, gameId), eq(pick.roundId, roundId)),
-		with: { team: true, gamePlayer: true },
-	})
-
-	return NextResponse.json(picks)
-}
+// NOTE: deliberately no GET handler. A GET that returned every player's picks
+// for a round leaked opponents' team choices before the deadline (and to any
+// authenticated user, members or not). Pick visibility is served only through
+// the deadline-gated read paths (progress grid / standings / live payload).
 
 export async function POST(request: Request, { params }: { params: Params }) {
 	const session = await requireSession()

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -1047,20 +1047,44 @@ export async function getLivePayload(gameId: string, viewerUserId: string) {
 		players: gameData.players,
 	})
 
+	// Hide opponents' pick identity until the round's deadline passes. The
+	// projection above is computed server-side from the full pick set, so live
+	// play is unaffected — we only strip the identifying fields (team, prediction,
+	// fixture, rank, projected outcome) from the payload sent to the browser. The
+	// viewer's own picks are always returned in full.
+	const now = new Date()
+	const deadlinePassed =
+		gameData.currentRound?.deadline != null && now >= gameData.currentRound.deadline
+	const viewerGamePlayerId = gameData.players.find((p) => p.userId === viewerUserId)?.id ?? null
+
 	return {
 		gameId: gameData.id,
 		gameMode: gameData.gameMode,
 		roundId: gameData.currentRoundId,
 		fixtures,
-		picks: picksInRound.map((p) => ({
-			gamePlayerId: p.gamePlayerId,
-			fixtureId: p.fixtureId,
-			teamId: p.teamId,
-			confidenceRank: p.confidenceRank,
-			predictedResult: p.predictedResult,
-			result: p.result,
-			projectedOutcome: proj.pickProjections.get(p.id) ?? null,
-		})),
+		picks: picksInRound.map((p) => {
+			const reveal = deadlinePassed || p.gamePlayerId === viewerGamePlayerId
+			if (!reveal) {
+				return {
+					gamePlayerId: p.gamePlayerId,
+					fixtureId: null,
+					teamId: null,
+					confidenceRank: null,
+					predictedResult: null,
+					result: 'hidden' as const,
+					projectedOutcome: null,
+				}
+			}
+			return {
+				gamePlayerId: p.gamePlayerId,
+				fixtureId: p.fixtureId,
+				teamId: p.teamId,
+				confidenceRank: p.confidenceRank,
+				predictedResult: p.predictedResult,
+				result: p.result,
+				projectedOutcome: proj.pickProjections.get(p.id) ?? null,
+			}
+		}),
 		players: gameData.players.map((p) => {
 			const projection = proj.playerProjections.get(p.id)
 			return {

--- a/src/lib/share/data.ts
+++ b/src/lib/share/data.ts
@@ -256,6 +256,11 @@ export async function getShareLiveData(
 	const currentRoundLabel = roundLabel(liveCompetitionType, currentRound.number)
 
 	if (header.gameMode === 'classic') {
+		// Don't reveal anyone's pick in the shareable image until the round's
+		// deadline has passed — the same gate the standings/grid use. A live share
+		// is normally generated mid-round (post-deadline), but nothing stops one
+		// being requested while picks are still open.
+		const liveDeadlinePassed = currentRound.deadline != null && new Date() >= currentRound.deadline
 		const allPicks = await db.query.pick.findMany({
 			where: and(eq(pick.gameId, gameId), eq(pick.roundId, currentRound.id)),
 			with: { team: true, fixture: { with: { homeTeam: true, awayTeam: true } } },
@@ -272,6 +277,21 @@ export async function getShareLiveData(
 		const rows: ClassicLiveRow[] = gameRow.players
 			.filter((p) => p.status === 'alive')
 			.map((p) => {
+				// Before the deadline, surface the player but hide their pick + fixture.
+				if (!liveDeadlinePassed) {
+					return {
+						id: p.id,
+						userId: p.userId,
+						name: userNames.get(p.userId) ?? 'Unknown',
+						pickedTeamShort: null,
+						homeShort: null,
+						awayShort: null,
+						homeScore: null,
+						awayScore: null,
+						fixtureStatus: 'scheduled' as ClassicLiveRow['fixtureStatus'],
+						liveState: 'pending' as ClassicLiveRow['liveState'],
+					}
+				}
 				const pk = allPicks.find((pp) => pp.gamePlayerId === p.id)
 				const fx = pk?.fixture
 				const homeScore = fx?.homeScore ?? null


### PR DESCRIPTION
## Why

PR #84 fixed the progress-grid **rendering**, but a belt-and-braces audit found
the underlying pick **data** still leaked to other players before the deadline
through three server surfaces. Each is the same fairness/secrecy bug at the data
layer. All three now gate reveal on the round's own deadline; the viewer's own
picks are always visible.

## The three leaks (all verified against the code)

**1. `GET /api/picks/[gameId]/[roundId]` — HIGH → deleted**
`route.ts:13-23` returned every player's picks (team names) for any round to
**any authenticated user** — no game-membership check, no deadline gate. The UI
never calls it (all 4 client calls are POST). Removed the GET handler; added a
regression test asserting no `GET` export.

**2. `getLivePayload` → `GET /api/games/[id]/live` — HIGH**
Polled by the browser every 30s (`live-provider.tsx:63`). It returned every
player's current-round `teamId` / `predictedResult` / `fixtureId` raw, no
deadline gate — so #84's grid hiding was cosmetic; the teams were in the JSON.
Now strips opponents' pick identity to `result: 'hidden'` until the deadline
passes. The live projection is computed server-side from the **full** pick set
before the strip, so in-play aggregates are unchanged.

**3. `getShareLiveData` (classic) — MED/LOW**
`share/data.ts` put every player's `pickedTeamShort` in the live share image
with no gate (cup/turbo already route through gated queries). Now hides every
pick + fixture before the deadline, matching the standings share (which hides
all current picks).

## Tests
- **Smoke (new):** live payload hides opponents' current-round picks pre-deadline (own visible, others `'hidden'`/`null`); classic live-share hides all picks pre-deadline.
- **Unit (new):** `/api/picks/...` exposes no `GET` handler.
- Existing deadline-*passed* reveal paths (live projection, standings) still pass.

## Verification
typecheck ✓ · unit 464 ✓ · smoke 32 ✓ · build ✓ (local).

## Scope note
Turbo/cup standings + cup ladder already gate correctly (audited). This closes
the data-layer side of the same bug #84 fixed in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
