### PR TITLE
fix(wc): capture ET/penalty winner so knockout ties score correctly

### DIFF
--- a/drizzle/0007_fast_gunslinger.sql
+++ b/drizzle/0007_fast_gunslinger.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "fixture" ADD COLUMN "winner" text;

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1678 @@
+{
+  "id": "59fce0f3-bff9-4e07-9366-2586d1f0e1d8",
+  "prevId": "e5cf3bd1-ea9a-40b2-9c29-174ece5c6a9a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition": {
+      "name": "competition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "competition_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_source": {
+          "name": "data_source",
+          "type": "competition_data_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "season": {
+          "name": "season",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fixture": {
+      "name": "fixture",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_team_id": {
+          "name": "home_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "away_team_id": {
+          "name": "away_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kickoff": {
+          "name": "kickoff",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_score": {
+          "name": "home_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "away_score": {
+          "name": "away_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "fixture_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ids": {
+          "name": "external_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fixture_round_id_round_id_fk": {
+          "name": "fixture_round_id_round_id_fk",
+          "tableFrom": "fixture",
+          "tableTo": "round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fixture_home_team_id_team_id_fk": {
+          "name": "fixture_home_team_id_team_id_fk",
+          "tableFrom": "fixture",
+          "tableTo": "team",
+          "columnsFrom": [
+            "home_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fixture_away_team_id_team_id_fk": {
+          "name": "fixture_away_team_id_team_id_fk",
+          "tableFrom": "fixture",
+          "tableTo": "team",
+          "columnsFrom": [
+            "away_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.round": {
+      "name": "round",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "round_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upcoming'"
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "round_competition_id_competition_id_fk": {
+          "name": "round_competition_id_competition_id_fk",
+          "tableFrom": "round",
+          "tableTo": "competition",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team": {
+      "name": "team",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_url": {
+          "name": "badge_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_color": {
+          "name": "primary_color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ids": {
+          "name": "external_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "league_position": {
+          "name": "league_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_form": {
+      "name": "team_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recent_results": {
+          "name": "recent_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "home_form": {
+          "name": "home_form",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "away_form": {
+          "name": "away_form",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "league_position": {
+          "name": "league_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_form_team_comp_idx": {
+          "name": "team_form_team_comp_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_form_team_id_team_id_fk": {
+          "name": "team_form_team_id_team_id_fk",
+          "tableFrom": "team_form",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_form_competition_id_competition_id_fk": {
+          "name": "team_form_competition_id_competition_id_fk",
+          "tableFrom": "team_form",
+          "tableTo": "competition",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game": {
+      "name": "game",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "game_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'setup'"
+        },
+        "game_mode": {
+          "name": "game_mode",
+          "type": "game_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode_config": {
+          "name": "mode_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_players": {
+          "name": "max_players",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_round_id": {
+          "name": "current_round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_competition_id_competition_id_fk": {
+          "name": "game_competition_id_competition_id_fk",
+          "tableFrom": "game",
+          "tableTo": "competition",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_current_round_id_round_id_fk": {
+          "name": "game_current_round_id_round_id_fk",
+          "tableFrom": "game",
+          "tableTo": "round",
+          "columnsFrom": [
+            "current_round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "game_invite_code_unique": {
+          "name": "game_invite_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_player": {
+      "name": "game_player",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "player_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'alive'"
+        },
+        "eliminated_round_id": {
+          "name": "eliminated_round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eliminated_reason": {
+          "name": "eliminated_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lives_remaining": {
+          "name": "lives_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_player_unique_idx": {
+          "name": "game_player_unique_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_player_game_id_game_id_fk": {
+          "name": "game_player_game_id_game_id_fk",
+          "tableFrom": "game_player",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_player_eliminated_round_id_round_id_fk": {
+          "name": "game_player_eliminated_round_id_round_id_fk",
+          "tableFrom": "game_player",
+          "tableTo": "round",
+          "columnsFrom": [
+            "eliminated_round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pick": {
+      "name": "pick",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_player_id": {
+          "name": "game_player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fixture_id": {
+          "name": "fixture_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_rank": {
+          "name": "confidence_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "predicted_result": {
+          "name": "predicted_result",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "pick_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "goals_scored": {
+          "name": "goals_scored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "life_gained": {
+          "name": "life_gained",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "life_spent": {
+          "name": "life_spent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_submitted": {
+          "name": "auto_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_auto": {
+          "name": "is_auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pick_player_round_idx": {
+          "name": "pick_player_round_idx",
+          "columns": [
+            {
+              "expression": "game_player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "round_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "confidence_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pick_game_id_game_id_fk": {
+          "name": "pick_game_id_game_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_game_player_id_game_player_id_fk": {
+          "name": "pick_game_player_id_game_player_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "game_player",
+          "columnsFrom": [
+            "game_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_round_id_round_id_fk": {
+          "name": "pick_round_id_round_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_team_id_team_id_fk": {
+          "name": "pick_team_id_team_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_fixture_id_fixture_id_fk": {
+          "name": "pick_fixture_id_fixture_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "fixture",
+          "columnsFrom": [
+            "fixture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planned_pick": {
+      "name": "planned_pick",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_player_id": {
+          "name": "game_player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_submit": {
+          "name": "auto_submit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "planned_pick_unique_idx": {
+          "name": "planned_pick_unique_idx",
+          "columns": [
+            {
+              "expression": "game_player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "round_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "planned_pick_game_player_id_game_player_id_fk": {
+          "name": "planned_pick_game_player_id_game_player_id_fk",
+          "tableFrom": "planned_pick",
+          "tableTo": "game_player",
+          "columnsFrom": [
+            "game_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "planned_pick_round_id_round_id_fk": {
+          "name": "planned_pick_round_id_round_id_fk",
+          "tableFrom": "planned_pick",
+          "tableTo": "round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "planned_pick_team_id_team_id_fk": {
+          "name": "planned_pick_team_id_team_id_fk",
+          "tableFrom": "planned_pick",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_run": {
+      "name": "cron_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "route": {
+          "name": "route",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment": {
+      "name": "payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payment_game_id_game_id_fk": {
+          "name": "payment_game_id_game_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payout": {
+      "name": "payout",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_split": {
+          "name": "is_split",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "payout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payout_game_id_game_id_fk": {
+          "name": "payout_game_id_game_id_fk",
+          "tableFrom": "payout",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.competition_data_source": {
+      "name": "competition_data_source",
+      "schema": "public",
+      "values": [
+        "fpl",
+        "football_data",
+        "manual"
+      ]
+    },
+    "public.competition_type": {
+      "name": "competition_type",
+      "schema": "public",
+      "values": [
+        "league",
+        "knockout",
+        "group_knockout"
+      ]
+    },
+    "public.fixture_status": {
+      "name": "fixture_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "live",
+        "finished",
+        "postponed",
+        "cancelled"
+      ]
+    },
+    "public.round_status": {
+      "name": "round_status",
+      "schema": "public",
+      "values": [
+        "upcoming",
+        "open",
+        "active",
+        "completed"
+      ]
+    },
+    "public.game_mode": {
+      "name": "game_mode",
+      "schema": "public",
+      "values": [
+        "classic",
+        "turbo",
+        "cup"
+      ]
+    },
+    "public.game_status": {
+      "name": "game_status",
+      "schema": "public",
+      "values": [
+        "setup",
+        "open",
+        "active",
+        "completed"
+      ]
+    },
+    "public.pick_result": {
+      "name": "pick_result",
+      "schema": "public",
+      "values": [
+        "pending",
+        "win",
+        "loss",
+        "draw",
+        "saved_by_life",
+        "void"
+      ]
+    },
+    "public.player_status": {
+      "name": "player_status",
+      "schema": "public",
+      "values": [
+        "alive",
+        "eliminated",
+        "winner"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "manual",
+        "mangopay"
+      ]
+    },
+    "public.payment_status": {
+      "name": "payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "claimed",
+        "paid",
+        "refunded"
+      ]
+    },
+    "public.payout_status": {
+      "name": "payout_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1779462870708,
       "tag": "0006_add_cron_run",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1782250018684,
+      "tag": "0007_fast_gunslinger",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/smoke/helpers.ts
+++ b/scripts/smoke/helpers.ts
@@ -213,10 +213,11 @@ export async function finishFixture(
 	fixtureId: string,
 	homeScore: number,
 	awayScore: number,
+	winner?: 'home' | 'away' | null,
 ): Promise<void> {
 	await db
 		.update(fixture)
-		.set({ status: 'finished', homeScore, awayScore })
+		.set({ status: 'finished', homeScore, awayScore, winner: winner ?? null })
 		.where(sql`${fixture.id} = ${fixtureId}`)
 }
 

--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -231,6 +231,83 @@ describe('lifecycle: classic-PL', () => {
 		expect(g?.status).toBe('active')
 	})
 
+	it('knockout ET/penalty winner: a level full-time score scores by winner, not as a draw', async () => {
+		// group_knockout, knockout round (number > 3). Fixture ends 1-1 full time;
+		// home advanced on penalties (winner: 'home'). A second fixture stays
+		// pending so the round doesn't complete (keeps the test about scoring).
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		const home = await makeTeam({ name: 'Home', shortName: 'HOM' })
+		const away = await makeTeam({ name: 'Away', shortName: 'AWY' })
+		const r4 = await makeRound(compId, { number: 4, status: 'open' })
+		const fx = await makeFixture({ roundId: r4, homeTeamId: home, awayTeamId: away })
+		await makeFixture({ roundId: r4, homeTeamId: home, awayTeamId: away }) // pending — keeps round open
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r4,
+			modeConfig: { allowRebuys: false },
+		})
+		const gpHome = await makePlayer({ gameId, userId: 'u-home' })
+		const gpAway = await makePlayer({ gameId, userId: 'u-away' })
+		await makePick({ gameId, gamePlayerId: gpHome, roundId: r4, teamId: home, fixtureId: fx })
+		await makePick({ gameId, gamePlayerId: gpAway, roundId: r4, teamId: away, fixtureId: fx })
+
+		await finishFixture(fx, 1, 1, 'home')
+		await settleFixture(fx)
+
+		const picks = await db.query.pick.findMany({ where: eq(pick.gameId, gameId) })
+		// The home backer's team advanced on penalties → win, not a draw. The bug
+		// scored this level-full-time fixture as a draw and eliminated the team
+		// that actually went through.
+		expect(picks.find((p) => p.gamePlayerId === gpHome)?.result).toBe('win')
+		expect(picks.find((p) => p.gamePlayerId === gpAway)?.result).toBe('loss')
+		const players = await db.query.gamePlayer.findMany({ where: eq(gamePlayer.gameId, gameId) })
+		expect(players.find((p) => p.id === gpHome)?.status).not.toBe('eliminated')
+		expect(players.find((p) => p.id === gpAway)?.status).toBe('eliminated')
+	})
+
+	it('last player alive is crowned winner without their own pick winning', async () => {
+		// The doomed player's pick loses → eliminated → one alive. The survivor's
+		// pick is on a still-pending fixture, so the crown comes purely from being
+		// the last alive (rule: a loss/no-pick elimination can hand the win).
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const a = await makeTeam({ name: 'A', shortName: 'A' })
+		const b = await makeTeam({ name: 'B', shortName: 'B' })
+		const r2 = await makeRound(compId, { number: 2, status: 'open' })
+		const fxPending = await makeFixture({ roundId: r2, homeTeamId: a, awayTeamId: b })
+		const fxLose = await makeFixture({ roundId: r2, homeTeamId: a, awayTeamId: b })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r2,
+			modeConfig: { allowRebuys: false },
+		})
+		const gpSurvivor = await makePlayer({ gameId, userId: 'u-survivor' })
+		const gpDoomed = await makePlayer({ gameId, userId: 'u-doomed' })
+		await makePick({
+			gameId,
+			gamePlayerId: gpSurvivor,
+			roundId: r2,
+			teamId: a,
+			fixtureId: fxPending,
+		})
+		await makePick({ gameId, gamePlayerId: gpDoomed, roundId: r2, teamId: a, fixtureId: fxLose })
+
+		await finishFixture(fxLose, 0, 2) // away wins → doomed (picked A=home) loses → eliminated
+		await settleFixture(fxLose)
+
+		const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+		expect(g?.status).toBe('completed')
+		const players = await db.query.gamePlayer.findMany({ where: eq(gamePlayer.gameId, gameId) })
+		expect(players.find((p) => p.id === gpSurvivor)?.status).toBe('winner')
+		expect(players.find((p) => p.id === gpDoomed)?.status).toBe('eliminated')
+		// Survivor's own pick never settled to a win — the crown came from being last alive.
+		const picks = await db.query.pick.findMany({ where: eq(pick.gameId, gameId) })
+		expect(picks.find((p) => p.gamePlayerId === gpSurvivor)?.result).toBe('pending')
+	})
+
 	it('progress grid exposes each player total goals scored (sum of winning picks)', async () => {
 		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
 		const a = await makeTeam({ name: 'A', shortName: 'A' })

--- a/src/app/api/cron/poll-scores/route.ts
+++ b/src/app/api/cron/poll-scores/route.ts
@@ -102,6 +102,7 @@ async function pollScores(apiKey: string): Promise<NextResponse> {
 						homeScore: score.homeScore,
 						awayScore: score.awayScore,
 						status: score.status,
+						winner: score.winner ?? null,
 					})
 					.where(eq(fixture.id, existing.id))
 

--- a/src/app/api/picks/[gameId]/[roundId]/route.ts
+++ b/src/app/api/picks/[gameId]/[roundId]/route.ts
@@ -169,6 +169,7 @@ export async function POST(request: Request, { params }: { params: Params }) {
 					awayScore: f.awayScore,
 					status: f.status,
 					stage: wcRoundStage(r.number),
+					winner: f.winner,
 				})),
 			)
 			const wcResult = validateWcClassicPick({
@@ -182,6 +183,7 @@ export async function POST(request: Request, { params }: { params: Params }) {
 					awayScore: f.awayScore,
 					status: f.status,
 					stage: wcRoundStage(roundData.number),
+					winner: f.winner,
 				})),
 				finishedKnockoutFixtures,
 			})

--- a/src/lib/data/football-data.test.ts
+++ b/src/lib/data/football-data.test.ts
@@ -129,7 +129,44 @@ describe('FootballDataAdapter', () => {
 	it('fetches live scores', async () => {
 		const scores = await adapter.fetchLiveScores(1)
 		expect(scores).toHaveLength(2)
-		expect(scores[0]).toEqual({ externalId: '501', homeScore: 2, awayScore: 0, status: 'finished' })
+		expect(scores[0]).toEqual({
+			externalId: '501',
+			homeScore: 2,
+			awayScore: 0,
+			status: 'finished',
+			winner: null,
+		})
+	})
+
+	it('captures the authoritative winner for ET/penalty knockout results', async () => {
+		// 1-1 full time, home advanced on penalties → score.winner = 'HOME_TEAM'.
+		const penaltyMatch = {
+			matches: [
+				{
+					id: 777,
+					matchday: 5,
+					homeTeam: { id: 57, name: 'Arsenal', tla: 'ARS', crest: '' },
+					awayTeam: { id: 61, name: 'Chelsea', tla: 'CHE', crest: '' },
+					utcDate: '2026-07-10T19:00:00Z',
+					status: 'FINISHED',
+					score: { winner: 'HOME_TEAM', fullTime: { home: 1, away: 1 } },
+				},
+			],
+		}
+		vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+			Promise.resolve(new Response(JSON.stringify(penaltyMatch))),
+		)
+		const rounds = await adapter.fetchRounds()
+		expect(rounds[0].fixtures[0].winner).toBe('home')
+		const scores = await adapter.fetchLiveScores(5)
+		expect(scores[0].winner).toBe('home')
+	})
+
+	it('records no winner for a genuine draw (no score.winner)', async () => {
+		// mockMatches #502 is a 1-1 with no winner field → null.
+		const rounds = await adapter.fetchRounds()
+		const drawn = rounds[0].fixtures.find((x) => x.externalId === '502')
+		expect(drawn?.winner).toBeNull()
 	})
 
 	it('sends API key in headers', async () => {

--- a/src/lib/data/football-data.ts
+++ b/src/lib/data/football-data.ts
@@ -40,7 +40,17 @@ interface FdMatch {
 	awayTeam: FdTeam
 	utcDate: string
 	status: string
-	score: { fullTime: { home: number | null; away: number | null } }
+	// `winner` is the authoritative outcome ('HOME_TEAM' | 'AWAY_TEAM' | 'DRAW' |
+	// null). For knockout ties decided in ET/penalties, fullTime stays level but
+	// winner names the side that advanced.
+	score: { winner?: string | null; fullTime: { home: number | null; away: number | null } }
+}
+
+/** Map football-data `score.winner` to our home/away marker (DRAW/null → null). */
+function mapWinner(winner: string | null | undefined): 'home' | 'away' | null {
+	if (winner === 'HOME_TEAM') return 'home'
+	if (winner === 'AWAY_TEAM') return 'away'
+	return null
 }
 
 interface FdStandingEntry {
@@ -137,6 +147,7 @@ export class FootballDataAdapter implements CompetitionAdapter {
 							status: this.mapStatus(m.status),
 							homeScore: m.score.fullTime.home,
 							awayScore: m.score.fullTime.away,
+							winner: mapWinner(m.score.winner),
 						}),
 					),
 				}
@@ -154,6 +165,7 @@ export class FootballDataAdapter implements CompetitionAdapter {
 				homeScore: m.score.fullTime.home as number,
 				awayScore: m.score.fullTime.away as number,
 				status: m.status === 'FINISHED' ? ('finished' as const) : ('live' as const),
+				winner: mapWinner(m.score.winner),
 			}))
 	}
 

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -39,6 +39,8 @@ export interface AdapterFixture {
 	status: 'scheduled' | 'live' | 'finished' | 'postponed' | 'cancelled'
 	homeScore: number | null
 	awayScore: number | null
+	/** Authoritative winner for ET/penalty results (level full-time score); null otherwise. */
+	winner?: 'home' | 'away' | null
 }
 
 export interface AdapterFixtureScore {
@@ -46,4 +48,6 @@ export interface AdapterFixtureScore {
 	homeScore: number
 	awayScore: number
 	status: 'live' | 'finished' | 'cancelled'
+	/** Authoritative winner for ET/penalty results (level full-time score); null otherwise. */
+	winner?: 'home' | 'away' | null
 }

--- a/src/lib/game-logic/common.test.ts
+++ b/src/lib/game-logic/common.test.ts
@@ -72,4 +72,44 @@ describe('determinePickResult', () => {
 			}),
 		).toBe('draw')
 	})
+
+	// Knockout fixtures decided in ET/penalties arrive level on full-time but
+	// carry an authoritative `winner` (football-data score.winner). When present
+	// it overrides the score — there is no draw.
+	it('uses winner over a level score: picked winner (home) = win', () => {
+		expect(
+			determinePickResult({
+				pickedTeamId: 'a',
+				homeTeamId: 'a',
+				awayTeamId: 'b',
+				homeScore: 1,
+				awayScore: 1,
+				winner: 'home',
+			}),
+		).toBe('win')
+	})
+	it('uses winner over a level score: picked loser (away) = loss', () => {
+		expect(
+			determinePickResult({
+				pickedTeamId: 'b',
+				homeTeamId: 'a',
+				awayTeamId: 'b',
+				homeScore: 1,
+				awayScore: 1,
+				winner: 'home',
+			}),
+		).toBe('loss')
+	})
+	it('ignores a null winner — group-stage draw stays a draw', () => {
+		expect(
+			determinePickResult({
+				pickedTeamId: 'a',
+				homeTeamId: 'a',
+				awayTeamId: 'b',
+				homeScore: 1,
+				awayScore: 1,
+				winner: null,
+			}),
+		).toBe('draw')
+	})
 })

--- a/src/lib/game-logic/common.ts
+++ b/src/lib/game-logic/common.ts
@@ -13,11 +13,21 @@ export interface PickResultInput {
 	awayTeamId: string
 	homeScore: number
 	awayScore: number
+	/**
+	 * Authoritative match winner for a fixture decided after a level full-time
+	 * score (extra time / penalties — football-data `score.winner`). When set it
+	 * overrides the score, so there's no draw. Null/undefined → use the score
+	 * (the normal case, incl. legitimate group-stage draws).
+	 */
+	winner?: 'home' | 'away' | null
 }
 
 export function determinePickResult(input: PickResultInput): PickResult {
-	const outcome = determineFixtureOutcome(input.homeScore, input.awayScore)
 	const pickedHome = input.pickedTeamId === input.homeTeamId
+	if (input.winner != null) {
+		return (pickedHome ? 'home' : 'away') === input.winner ? 'win' : 'loss'
+	}
+	const outcome = determineFixtureOutcome(input.homeScore, input.awayScore)
 	if (outcome === 'draw') return 'draw'
 	if (pickedHome && outcome === 'home_win') return 'win'
 	if (!pickedHome && outcome === 'away_win') return 'win'

--- a/src/lib/game-logic/cup.test.ts
+++ b/src/lib/game-logic/cup.test.ts
@@ -13,6 +13,43 @@ function makePick(
 }
 
 describe('evaluateCupPicks', () => {
+	describe('penalty/extra-time winner (knockout)', () => {
+		it('treats a level score with winner = picked team as a win, not a draw', () => {
+			const res = evaluateCupPicks(
+				[
+					{
+						confidenceRank: 1,
+						pickedTeam: 'home',
+						homeScore: 1,
+						awayScore: 1,
+						tierDifference: 0,
+						winner: 'home',
+					},
+				],
+				0,
+			)
+			expect(res.pickResults[0].result).toBe('win')
+			expect(res.eliminated).toBe(false)
+		})
+		it('treats a level score with winner = opponent as a loss (streak breaks)', () => {
+			const res = evaluateCupPicks(
+				[
+					{
+						confidenceRank: 1,
+						pickedTeam: 'away',
+						homeScore: 1,
+						awayScore: 1,
+						tierDifference: 0,
+						winner: 'home',
+					},
+				],
+				0,
+			)
+			expect(res.pickResults[0].result).toBe('loss')
+			expect(res.eliminated).toBe(true)
+		})
+	})
+
 	describe('pick restrictions', () => {
 		it('rejects picks where picked team is >1 tier above opponent', () => {
 			const result = evaluateCupPicks([makePick(1, 'home', 3, 0, 2)], 0)

--- a/src/lib/game-logic/cup.ts
+++ b/src/lib/game-logic/cup.ts
@@ -4,6 +4,12 @@ export interface CupPickInput {
 	homeScore: number
 	awayScore: number
 	tierDifference: number // from HOME team perspective: positive = home higher tier
+	/**
+	 * Authoritative winner for a knockout fixture decided on ET/penalties (level
+	 * full-time score). When set it overrides the score: the match is a win for
+	 * that side, never a draw. Null/undefined → use the score.
+	 */
+	winner?: 'home' | 'away' | null
 }
 
 export interface CupPickResult {
@@ -43,8 +49,11 @@ export function evaluateCupPicks(picks: CupPickInput[], startingLives: number): 
 
 		const pickedTeamGoals = pick.pickedTeam === 'home' ? pick.homeScore : pick.awayScore
 		const opponentGoals = pick.pickedTeam === 'home' ? pick.awayScore : pick.homeScore
-		const pickedTeamWon = pickedTeamGoals > opponentGoals
-		const isDraw = pickedTeamGoals === opponentGoals
+		// A recorded winner (ET/penalties) is authoritative — the match is a win
+		// for that side and never a draw, regardless of the level full-time score.
+		const pickedTeamWon =
+			pick.winner != null ? pick.winner === pick.pickedTeam : pickedTeamGoals > opponentGoals
+		const isDraw = pick.winner != null ? false : pickedTeamGoals === opponentGoals
 
 		let result: CupPickResult['result'] = 'loss'
 		let livesGained = 0

--- a/src/lib/game-logic/wc-classic.test.ts
+++ b/src/lib/game-logic/wc-classic.test.ts
@@ -14,6 +14,7 @@ interface F {
 	awayScore: number | null
 	status: 'scheduled' | 'live' | 'finished' | 'postponed' | 'cancelled'
 	stage: 'group' | 'knockout'
+	winner: 'home' | 'away' | null
 }
 
 const r1 = 'round-group-1'
@@ -25,6 +26,7 @@ function f(partial: Partial<F> & Pick<F, 'id' | 'homeTeamId' | 'awayTeamId' | 's
 		homeScore: null,
 		awayScore: null,
 		status: 'scheduled',
+		winner: null,
 		...partial,
 	}
 }
@@ -48,10 +50,9 @@ describe('isTeamTournamentEliminated', () => {
 		expect(isTeamTournamentEliminated('t1', [knockout])).toBe(true)
 	})
 
-	it('returns false when a knockout fixture finished in a draw (penalties go on)', () => {
-		// For the purposes of the LPS rule, a draw doesn't eliminate;
-		// only a decisive loss does. Our fixture status does not carry penalties,
-		// so we conservatively treat draw as not-eliminated.
+	it('returns false when a level knockout score has no recorded winner (undecided)', () => {
+		// A level score with no `winner` recorded is treated as undecided →
+		// nobody eliminated (the winner field, when present, is authoritative).
 		const knockout = f({
 			id: 'k1',
 			homeTeamId: 't1',
@@ -62,6 +63,23 @@ describe('isTeamTournamentEliminated', () => {
 			stage: 'knockout',
 			roundId: r2,
 		})
+		expect(isTeamTournamentEliminated('t1', [knockout])).toBe(false)
+	})
+
+	it('eliminates the ET/penalty loser via winner on a level full-time score', () => {
+		// 1-1 full time, home advanced on penalties (winner: 'home').
+		const knockout = f({
+			id: 'k1',
+			homeTeamId: 't1',
+			awayTeamId: 't2',
+			homeScore: 1,
+			awayScore: 1,
+			status: 'finished',
+			stage: 'knockout',
+			roundId: r2,
+			winner: 'home',
+		})
+		expect(isTeamTournamentEliminated('t2', [knockout])).toBe(true)
 		expect(isTeamTournamentEliminated('t1', [knockout])).toBe(false)
 	})
 })

--- a/src/lib/game-logic/wc-classic.ts
+++ b/src/lib/game-logic/wc-classic.ts
@@ -11,6 +11,8 @@ export interface WcFixture {
 	awayScore: number | null
 	status: 'scheduled' | 'live' | 'finished' | 'postponed' | 'cancelled'
 	stage: 'group' | 'knockout'
+	/** Authoritative winner for ET/penalty results (level full-time score). */
+	winner: 'home' | 'away' | null
 }
 
 export interface AlivePlayer {
@@ -40,9 +42,15 @@ export function isTeamTournamentEliminated(
 	for (const f of finishedKnockoutFixtures) {
 		if (f.stage !== 'knockout') continue
 		if (f.status !== 'finished') continue
-		if (f.homeScore == null || f.awayScore == null) continue
-		if (f.homeScore === f.awayScore) continue // draws treated as not-eliminated
-		const loserId = f.homeScore > f.awayScore ? f.awayTeamId : f.homeTeamId
+		// Prefer the authoritative winner (covers ET/penalty results that are
+		// level on score). Otherwise fall back to a decisive score. A level score
+		// with no recorded winner is undecided → nobody eliminated.
+		let loserId: string | null = null
+		if (f.winner != null) {
+			loserId = f.winner === 'home' ? f.awayTeamId : f.homeTeamId
+		} else if (f.homeScore != null && f.awayScore != null && f.homeScore !== f.awayScore) {
+			loserId = f.homeScore > f.awayScore ? f.awayTeamId : f.homeTeamId
+		}
 		if (loserId === teamId) return true
 	}
 	return false

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -391,6 +391,7 @@ export async function syncCompetition(
 						status: af.status,
 						homeScore: af.homeScore,
 						awayScore: af.awayScore,
+						winner: af.winner ?? null,
 						externalIds: {
 							...((existingFixture.externalIds as Record<string, string | number>) ?? {}),
 							[key]: af.externalId,
@@ -417,6 +418,7 @@ export async function syncCompetition(
 					status: af.status,
 					homeScore: af.homeScore,
 					awayScore: af.awayScore,
+					winner: af.winner ?? null,
 					externalId: af.externalId,
 					externalIds: { [key]: af.externalId },
 				})

--- a/src/lib/game/settle.ts
+++ b/src/lib/game/settle.ts
@@ -181,6 +181,7 @@ async function settleClassicPickRow(
 		awayTeamId: fx.awayTeam.id,
 		homeScore,
 		awayScore,
+		winner: fx.winner,
 	})
 	const pickedHome = p.teamId === fx.homeTeam.id
 	const goalsScored = result === 'win' ? (pickedHome ? homeScore : awayScore) : 0
@@ -325,6 +326,7 @@ export async function reevaluateCupGame(gameId: string): Promise<boolean> {
 				homeScore: fx.homeScore ?? 0,
 				awayScore: fx.awayScore ?? 0,
 				tierDifference: tierDiff,
+				winner: fx.winner,
 			}
 		})
 
@@ -513,6 +515,7 @@ async function runWcClassicAutoElims(gameId: string, currentRoundId: string): Pr
 			awayScore: f.awayScore,
 			status: f.status,
 			stage: wcRoundStage(r.number),
+			winner: f.winner,
 		})),
 	)
 	const remainingRounds = allRounds
@@ -528,6 +531,7 @@ async function runWcClassicAutoElims(gameId: string, currentRoundId: string): Pr
 				awayScore: f.awayScore,
 				status: f.status,
 				stage: wcRoundStage(r.number),
+				winner: f.winner,
 			})),
 		}))
 	const alivePlayers = await db.query.gamePlayer.findMany({

--- a/src/lib/schema/competition.ts
+++ b/src/lib/schema/competition.ts
@@ -94,6 +94,9 @@ export const fixture = pgTable('fixture', {
 	kickoff: timestamp('kickoff'),
 	homeScore: integer('home_score'),
 	awayScore: integer('away_score'),
+	// Authoritative winner for knockout ties decided in ET/penalties (full-time
+	// score stays level). Null for draws / regulation results / non-knockout.
+	winner: text('winner').$type<'home' | 'away'>(),
 	status: fixtureStatusEnum('status').notNull().default('scheduled'),
 	// Source-specific id from the adapter that originally inserted the fixture.
 	// Kept for backwards-compatibility; new code should prefer external_ids.


### PR DESCRIPTION
## What & why

Issue #66. Knockout fixtures decided in extra time / on penalties arrive **level on full-time**, but the football-data API names the real outcome in `score.winner`. The adapter only read `score.fullTime`, so a 1-1 (won on penalties) was scored as a **draw** — in classic that **eliminated the team that actually advanced**, and cup mis-scored streak/lives. The `isTeamTournamentEliminated` "draws treated as not-eliminated" line was a documented workaround for this.

## Change
- **Adapter**: `football-data` parses `score.winner` → `'home' | 'away' | null`, carried on `AdapterFixture`/`AdapterFixtureScore`. FPL has no winner → null, so league play is unchanged.
- **Schema**: new nullable `fixture.winner` column (migration `0007`); `syncCompetition` + the live poll persist it.
- **Scoring**: `determinePickResult` (classic) and `evaluateCupPicks` (cup) gain an optional `winner` — when present it's authoritative (a win for that side, never a draw). Threaded through `settleClassicPickRow`, `reevaluateCupGame`, and the WC auto-elim / pick-validation `WcFixture` builders. **Turbo is PL-only (no knockouts) → untouched.**
- `isTeamTournamentEliminated` now uses the winner (penalty loser correctly out for future picks), replacing the draw workaround.

Only bites at the knockout stage (WC is still in groups), so no live impact yet.

## Related rule check (your ask)
Added a smoke test for the **already-correct** classic rule that the **last player alive is crowned without their own pick needing to win** (`checkClassicCompletion` → `last-alive`). Confirmed it holds; no code change needed (you asked for the test only).

## Verification
- ✅ typecheck · Biome · unit **476** (+8: winner override in determinePickResult / evaluateCupPicks / isTeamTournamentEliminated + adapter parsing) · smoke **32** (+2: knockout-winner scoring, last-alive auto-win) · `next build`
- Rebased onto latest `main` (incl. #86); no migration/route conflict.