### PR TITLE
fix(share): stop the classic standings image clipping ~half the players

### DIFF
--- a/src/lib/share/layouts/classic-standings.test.tsx
+++ b/src/lib/share/layouts/classic-standings.test.tsx
@@ -53,6 +53,37 @@ describe('classicStandingsLayout', () => {
 		expect(height).toBeGreaterThanOrEqual(600)
 	})
 
+	it('canvas height fits every visible row (regression: rows were clipping ~half the field)', () => {
+		// 16 alive players, no cap/overflow. @vercel/og clips to this fixed height,
+		// so it must leave room for all 16 rows. The old `260 + n*52` gave 1092 and
+		// clipped past ~row 11; the corrected `340 + n*70` gives 1460.
+		const players = Array.from({ length: 16 }).map((_, i) => ({
+			id: `p${i}`,
+			name: `Player ${i + 1}`,
+			status: 'alive' as const,
+			eliminatedRoundNumber: null,
+			cellsByRoundId: {
+				r1: { result: 'win' as const, teamShortName: 'ARS' },
+			},
+		}))
+		const data: Extract<import('../data').StandingsShareData, { mode: 'classic' }> = {
+			mode: 'classic',
+			flat: false,
+			header: fixture.header,
+			classicGrid: {
+				aliveCount: 16,
+				eliminatedCount: 0,
+				pot: '100.00',
+				rounds: [{ id: 'r1', number: 1, name: 'GW1' }],
+				players,
+			} as never,
+		}
+		const { height } = classicStandingsLayout(data)
+		// Enough vertical room for all 16 rows (≥ 70px each) plus header chrome.
+		expect(height).toBeGreaterThanOrEqual(16 * 70)
+		expect(height).toBe(1460)
+	})
+
 	it('caps at 30 visible (20 alive + 10 eliminated) and emits an overflow tail when needed', () => {
 		const bigPlayers = Array.from({ length: 35 }).map((_, i) => ({
 			id: `p${i}`,

--- a/src/lib/share/layouts/classic-standings.tsx
+++ b/src/lib/share/layouts/classic-standings.tsx
@@ -16,6 +16,19 @@ const STANDINGS_ALIVE_CAP = 20
 const STANDINGS_ELIMINATED_CAP = 10
 const FLAT_CAP = 30
 
+// @vercel/og renders to a FIXED-height canvas and CLIPS overflow — it does not
+// grow to fit. So the height must be computed to match the real rendered
+// content, and each row is given a FIXED height so a row can never grow past
+// the per-row budget (e.g. when many gameweeks make cells narrow). Previously a
+// hand-tuned `260 + n*52` under-counted both the chrome and the true row height,
+// clipping ~half the players once a few gameweeks were populated.
+const ROW_HEIGHT = 70
+const OVERFLOW_ROW_HEIGHT = 44
+// Everything above the first player row (outer 48px padding ×2, header block,
+// alive/eliminated legend, card padding, column-header row) plus the card +
+// outer bottom padding.
+const CHROME_HEIGHT = 340
+
 export interface ClassicStandingsRender {
 	jsx: ReactElement
 	width: number
@@ -39,7 +52,10 @@ export function classicStandingsLayout(
 	const overflow = players.length - visible.length
 
 	const visibleRounds = grid.rounds.slice(-6)
-	const height = Math.max(600, 260 + visible.length * 52 + (overflow > 0 ? 40 : 0))
+	const height = Math.max(
+		600,
+		CHROME_HEIGHT + visible.length * ROW_HEIGHT + (overflow > 0 ? OVERFLOW_ROW_HEIGHT : 0),
+	)
 
 	const jsx = (
 		<div
@@ -121,7 +137,7 @@ export function classicStandingsLayout(
 						style={{
 							display: 'flex',
 							alignItems: 'center',
-							padding: '10px 0',
+							height: `${ROW_HEIGHT}px`,
 							borderBottom: '1px solid #f0eee9',
 							opacity: player.status === 'eliminated' ? 0.5 : 1,
 						}}


### PR DESCRIPTION
## The bug (C7)

The classic **Share-grid image** only displayed ~8 of N players once a few gameweeks were populated — confirmed by rendering it.

## Root cause

`@vercel/og` renders to a **fixed-height canvas and clips overflow** (it doesn't grow to fit). The height was a hand-tuned `260 + n*52` that under-counted:
- **Chrome:** the outer 48px padding (×2), header, alive/eliminated legend, card padding, and column-header row exceed 260.
- **Row height:** a populated row is ~70px (team + opponent line + padding), not 52.

So the canvas was too short and the bottom rows fell off the edge. With ~12+ players the shortfall is ~4–5 rows → ~8 show.

## Fix

- Each player row gets a **fixed height** (`ROW_HEIGHT=70`) so a row can't grow past its budget (e.g. when many gameweeks make cells narrow and text wraps).
- Canvas height computed from real constants: `CHROME_HEIGHT(340) + visible*ROW_HEIGHT + overflow row`.

## Verification (rendered the actual PNG and inspected it)

- **Before:** 16 players / 3 GW → height 1092, clipped at ~row 11 (rows 12–16 gone).
- **After:** 16p/3GW → height 1460, **all 16 rows + footer render**. Also checked the max case **30p / 6 GW** (28 rows + overflow tail + footer) — no clipping.
- Regression test pins the height so it can't silently shrink again.

typecheck ✓ · unit 484 ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)