### PR TITLE
feat(admin): pick-after-deadline, mark-paid, remove no-pick player

### DIFF
--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -242,10 +242,12 @@ export default async function GameDetailPage({
 				existingPickFixtureId={classicPickData.existingPickFixtureId}
 				chain={classicPlannerData?.chain}
 				futureRounds={classicPlannerData?.futureRounds}
-				currentRoundClosed={roundDeadlinePassed}
+				// An admin acting-as a player can fix a pick after the deadline, so the
+				// current round stays interactive for them; for everyone else it locks.
+				currentRoundClosed={roundDeadlinePassed && !actingAsTarget}
 				actingAs={actingAsForPickUI}
 			/>
-		) : game.currentRound && isAlive && !roundDeadlinePassed ? (
+		) : game.currentRound && isAlive && (!roundDeadlinePassed || !!actingAsTarget) ? (
 			game.gameMode === 'turbo' && turboPickData ? (
 				<TurboPick
 					gameId={game.id}

--- a/src/app/api/games/[id]/admin/remove-player/[userId]/route.test.ts
+++ b/src/app/api/games/[id]/admin/remove-player/[userId]/route.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/auth-helpers', () => ({
+	requireSession: vi.fn().mockResolvedValue({ user: { id: 'admin' } }),
+}))
+
+const { dbMock } = vi.hoisted(() => {
+	const setWhere = { set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })) }
+	return {
+		dbMock: {
+			query: {
+				game: { findFirst: vi.fn() },
+				gamePlayer: { findFirst: vi.fn() },
+				pick: { findFirst: vi.fn() },
+			},
+			update: vi.fn(() => setWhere),
+			transaction: vi.fn(async (cb: (tx: unknown) => unknown) =>
+				cb({ update: vi.fn(() => setWhere) }),
+			),
+		},
+	}
+})
+
+vi.mock('@/lib/db', () => ({ db: dbMock }))
+
+import { POST } from './route'
+
+const ctx = (gameId = 'g1', userId = 'u-target') => ({
+	params: Promise.resolve({ id: gameId, userId }),
+})
+const req = () => new Request('http://localhost/remove', { method: 'POST' })
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	dbMock.query.game.findFirst.mockResolvedValue({ id: 'g1', createdBy: 'admin' })
+	dbMock.query.gamePlayer.findFirst.mockResolvedValue({ id: 'gp1', userId: 'u-target' })
+	dbMock.query.pick.findFirst.mockResolvedValue(undefined)
+})
+
+describe('POST remove-player', () => {
+	it('rejects a non-admin with 403', async () => {
+		dbMock.query.game.findFirst.mockResolvedValue({ id: 'g1', createdBy: 'someone-else' })
+		const res = await POST(req(), ctx())
+		expect(res.status).toBe(403)
+	})
+
+	it('404s when the player is not in the game', async () => {
+		dbMock.query.gamePlayer.findFirst.mockResolvedValue(undefined)
+		const res = await POST(req(), ctx())
+		expect(res.status).toBe(404)
+	})
+
+	it('refuses to remove a player who has already picked', async () => {
+		dbMock.query.pick.findFirst.mockResolvedValue({ id: 'pick1' })
+		const res = await POST(req(), ctx())
+		expect(res.status).toBe(400)
+		expect((await res.json()).error).toBe('player-has-picks')
+	})
+
+	it('removes a no-pick player (status flip + transaction)', async () => {
+		const res = await POST(req(), ctx())
+		expect(res.status).toBe(200)
+		expect((await res.json()).status).toBe('removed')
+		expect(dbMock.transaction).toHaveBeenCalledOnce()
+	})
+})

--- a/src/app/api/games/[id]/admin/remove-player/[userId]/route.ts
+++ b/src/app/api/games/[id]/admin/remove-player/[userId]/route.ts
@@ -1,0 +1,59 @@
+import { and, eq } from 'drizzle-orm'
+import { NextResponse } from 'next/server'
+import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { game, gamePlayer, pick } from '@/lib/schema/game'
+import { payment } from '@/lib/schema/payment'
+
+type Ctx = { params: Promise<{ id: string; userId: string }> }
+
+/**
+ * Admin-only: remove a player who never engaged (no picks) — e.g. someone added
+ * or who joined but never played and shouldn't sit in the pot/standings.
+ *
+ * Preserves history (no row deletes): the gamePlayer is flipped to
+ * `eliminated` with reason `admin_removed`, and any of their payments are
+ * refunded so they drop out of the pot. `admin_removed` players are excluded
+ * from standings, counts and the pot target (see getGameDetail /
+ * getProgressGridData). Guarded to no-pick players so a real participant's
+ * history can never be wiped this way.
+ */
+export async function POST(_request: Request, ctx: Ctx): Promise<Response> {
+	const session = await requireSession()
+	const { id: gameId, userId: targetUserId } = await ctx.params
+
+	const gameRow = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+	if (!gameRow) return NextResponse.json({ error: 'not-found' }, { status: 404 })
+	if (gameRow.createdBy !== session.user.id) {
+		return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+	}
+
+	const playerRow = await db.query.gamePlayer.findFirst({
+		where: and(eq(gamePlayer.gameId, gameId), eq(gamePlayer.userId, targetUserId)),
+	})
+	if (!playerRow) return NextResponse.json({ error: 'not-in-game' }, { status: 404 })
+
+	// Only removable if they've never picked — protects a real participant's
+	// history. If they've engaged, the admin should eliminate, not remove.
+	const existingPick = await db.query.pick.findFirst({
+		where: eq(pick.gamePlayerId, playerRow.id),
+	})
+	if (existingPick) {
+		return NextResponse.json({ error: 'player-has-picks' }, { status: 400 })
+	}
+
+	await db.transaction(async (tx) => {
+		await tx
+			.update(gamePlayer)
+			.set({ status: 'eliminated', eliminatedReason: 'admin_removed', eliminatedRoundId: null })
+			.where(eq(gamePlayer.id, playerRow.id))
+		// Refund any of their payments so they drop out of the pot (calculatePot
+		// ignores refunded). Idempotent.
+		await tx
+			.update(payment)
+			.set({ status: 'refunded', refundedAt: new Date() })
+			.where(and(eq(payment.gameId, gameId), eq(payment.userId, targetUserId)))
+	})
+
+	return NextResponse.json({ status: 'removed' })
+}

--- a/src/app/api/picks/[gameId]/[roundId]/route.ts
+++ b/src/app/api/picks/[gameId]/[roundId]/route.ts
@@ -142,7 +142,9 @@ export async function POST(request: Request, { params }: { params: Params }) {
 				usedTeamIds,
 				fixtureTeamIds,
 			},
-			{ allowEliminatedRebuy },
+			// Admin acting-as (verified above) may submit a pick after the round's
+			// deadline — fixing a missed/wrong pick. isPastRound stays enforced.
+			{ allowEliminatedRebuy, allowAdminLateSubmission: !!body.actingAs },
 		)
 
 		if (!validation.valid) {
@@ -268,7 +270,10 @@ export async function POST(request: Request, { params }: { params: Params }) {
 					pickedTeam: p.predictedResult === 'away_win' ? 'away' : 'home',
 				})),
 			},
-			{ allowEliminatedRebuy: allowEliminatedRebuyMulti },
+			{
+				allowEliminatedRebuy: allowEliminatedRebuyMulti,
+				allowAdminLateSubmission: !!body.actingAs,
+			},
 		)
 		if (!cupValidation.valid) {
 			return NextResponse.json({ error: cupValidation.reason }, { status: 400 })
@@ -284,7 +289,10 @@ export async function POST(request: Request, { params }: { params: Params }) {
 				fixtureIds: roundData.fixtures.map((f) => f.id),
 				picks: pickEntries,
 			},
-			{ allowEliminatedRebuy: allowEliminatedRebuyMulti },
+			{
+				allowEliminatedRebuy: allowEliminatedRebuyMulti,
+				allowAdminLateSubmission: !!body.actingAs,
+			},
 		)
 		if (!validation.valid) {
 			return NextResponse.json({ error: validation.reason }, { status: 400 })

--- a/src/components/game/payments-panel.tsx
+++ b/src/components/game/payments-panel.tsx
@@ -29,7 +29,7 @@ export function PaymentsPanel(props: PaymentsPanelProps) {
 	const all = props.payments
 	const unpaidCount = all.filter((p) => p.status === 'pending' || p.status === 'unpaid').length
 
-	async function callAction(p: AdminPayment, action: 'dispute' | 'admin-rebuy') {
+	async function callAction(p: AdminPayment, action: 'dispute' | 'admin-rebuy' | 'mark-paid') {
 		if (action === 'admin-rebuy') {
 			const res = await fetch(`/api/games/${props.gameId}/admin/rebuy/${p.userId}`, {
 				method: 'POST',
@@ -39,6 +39,23 @@ export function PaymentsPanel(props: PaymentsPanelProps) {
 				props.onChange?.()
 			} else {
 				toast.error('Rebuy failed')
+			}
+			return
+		}
+		if (action === 'mark-paid') {
+			// Admin confirms the entry fee was paid (e.g. cash). Uses the existing
+			// payment override endpoint, which sets status=paid + paidAt.
+			if (!p.id) return
+			const res = await fetch(`/api/games/${props.gameId}/payments/${p.id}/override`, {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ status: 'paid' }),
+			})
+			if (res.ok) {
+				toast.success(`Marked ${p.userName} as paid`)
+				props.onChange?.()
+			} else {
+				toast.error('Failed to mark paid')
 			}
 			return
 		}
@@ -100,13 +117,24 @@ export function PaymentsPanel(props: PaymentsPanelProps) {
 									>
 										Dispute
 									</button>
-								) : p.id !== null && p.status === 'pending' ? (
-									<PaymentReminderButton
-										gameName={props.gameName}
-										amount={p.amount}
-										creatorName="you"
-										inviteCode={props.inviteCode}
-									/>
+								) : p.id !== null && (p.status === 'pending' || p.status === 'claimed') ? (
+									<>
+										<button
+											type="button"
+											onClick={() => callAction(p, 'mark-paid')}
+											className="rounded border border-[var(--alive)] px-3 py-1.5 text-xs font-semibold text-[var(--alive)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+										>
+											Mark paid
+										</button>
+										{p.status === 'pending' && (
+											<PaymentReminderButton
+												gameName={props.gameName}
+												amount={p.amount}
+												creatorName="you"
+												inviteCode={props.inviteCode}
+											/>
+										)}
+									</>
 								) : null}
 							</div>
 						}

--- a/src/components/standings/progress-grid.tsx
+++ b/src/components/standings/progress-grid.tsx
@@ -1,7 +1,9 @@
 'use client'
 
 import { Eye, EyeOff, Share2, UsersRound } from 'lucide-react'
+import { useRouter } from 'next/navigation'
 import { useState } from 'react'
+import { toast } from 'sonner'
 import { useLiveGame } from '@/components/live/use-live-game'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
@@ -67,6 +69,8 @@ export interface GridCell {
 
 export interface GridPlayer {
 	id: string
+	/** Present in the live grid (used by admin remove); omitted in the share image. */
+	userId?: string
 	name: string
 	status: 'alive' | 'eliminated' | 'winner'
 	eliminatedRoundNumber?: number
@@ -105,6 +109,31 @@ export function ProgressGrid({
 	const [showOpponents, setShowOpponents] = useState(false)
 	const [hideEliminated, setHideEliminated] = useState(false)
 	const liveCtx = useLiveGame()
+	const router = useRouter()
+
+	async function removePlayer(userId: string, name: string) {
+		if (!gameId) return
+		if (
+			!window.confirm(
+				`Remove ${name} from the game? They haven't picked, so they'll be taken out of the standings and the pot.`,
+			)
+		)
+			return
+		const res = await fetch(`/api/games/${gameId}/admin/remove-player/${userId}`, {
+			method: 'POST',
+		})
+		if (res.ok) {
+			toast.success(`Removed ${name}`)
+			router.refresh()
+		} else {
+			const body = (await res.json().catch(() => ({}))) as { error?: string }
+			toast.error(
+				body.error === 'player-has-picks'
+					? `Can't remove ${name} — they've already made a pick`
+					: 'Failed to remove player',
+			)
+		}
+	}
 
 	// Click a column header to sort by it; click the active one again to flip
 	// direction. Round columns sort by the team picked that gameweek.
@@ -363,13 +392,25 @@ export function ProgressGrid({
 												currentRoundId &&
 												player.status === 'alive' &&
 												player.cellsByRoundId[currentRoundId]?.result === 'no_pick' && (
-													<a
-														href={`/game/${gameId}?actingAs=${player.id}`}
-														title={`Pick for ${player.name}`}
-														className="ml-2 inline-flex h-6 w-6 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:border-border hover:bg-muted"
-													>
-														✎
-													</a>
+													<>
+														<a
+															href={`/game/${gameId}?actingAs=${player.id}`}
+															title={`Pick for ${player.name}`}
+															className="ml-2 inline-flex h-6 w-6 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:border-border hover:bg-muted"
+														>
+															✎
+														</a>
+														{player.userId && (
+															<button
+																type="button"
+																onClick={() => removePlayer(player.userId as string, player.name)}
+																title={`Remove ${player.name}`}
+																className="ml-1 inline-flex h-6 w-6 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:border-[var(--eliminated)] hover:text-[var(--eliminated)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+															>
+																✕
+															</button>
+														)}
+													</>
 												)}
 										</td>
 										{visibleRounds.map((r) => {

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -46,6 +46,14 @@ export async function getGameDetail(gameId: string, userId: string) {
 
 	if (!gameData) return null
 
+	// Admin-removed players are fully excluded from the game view — they drop out
+	// of standings, counts, the pot target and the payments panel. Their payments
+	// were refunded on removal, so the pot total is unaffected.
+	const removedUserIds = new Set(
+		gameData.players.filter((p) => p.eliminatedReason === 'admin_removed').map((p) => p.userId),
+	)
+	gameData.players = gameData.players.filter((p) => p.eliminatedReason !== 'admin_removed')
+
 	const myMembership = gameData.players.find((p) => p.userId === userId)
 	const isAdmin = gameData.createdBy === userId
 	const isMember = !!myMembership
@@ -72,9 +80,11 @@ export async function getGameDetail(gameId: string, userId: string) {
 		}
 	}
 
-	const payments = await db.query.payment.findMany({
-		where: eq(payment.gameId, gameId),
-	})
+	const payments = (
+		await db.query.payment.findMany({
+			where: eq(payment.gameId, gameId),
+		})
+	).filter((p) => !removedUserIds.has(p.userId))
 	const pot = calculatePot(payments)
 
 	// Resolve user names for every player + the admin so payment UI can show names.
@@ -810,6 +820,9 @@ export async function getProgressGridData(
 
 	if (!gameData) return null
 
+	// Admin-removed players don't appear in the standings grid.
+	gameData.players = gameData.players.filter((p) => p.eliminatedReason !== 'admin_removed')
+
 	// Identify the viewer's gamePlayer so we can still show them their own current pick,
 	// while hiding other players' picks for in-progress (not completed) rounds.
 	const viewerGamePlayerId = viewerUserId
@@ -979,6 +992,7 @@ export async function getProgressGridData(
 			.reduce((sum, pk) => sum + (pk.goalsScored ?? 0), 0)
 		return {
 			id: p.id,
+			userId: p.userId,
 			name: userNames.get(p.userId) ?? 'Player',
 			status: p.status,
 			eliminatedRoundNumber,

--- a/src/lib/picks/validate.test.ts
+++ b/src/lib/picks/validate.test.ts
@@ -42,6 +42,22 @@ describe('validateClassicPick', () => {
 			validateClassicPick({ ...base, teamId: 'team-a', deadline: new Date(Date.now() - 1000) }),
 		).toEqual({ valid: false, reason: 'Deadline has passed' })
 	})
+	it('allows an admin late submission past the deadline', () => {
+		expect(
+			validateClassicPick(
+				{ ...base, teamId: 'team-a', deadline: new Date(Date.now() - 1000) },
+				{ allowAdminLateSubmission: true },
+			),
+		).toEqual({ valid: true })
+	})
+	it('still rejects an admin late submission for an already-played round', () => {
+		expect(
+			validateClassicPick(
+				{ ...base, teamId: 'team-a', isPastRound: true, deadline: new Date(Date.now() - 1000) },
+				{ allowAdminLateSubmission: true },
+			),
+		).toEqual({ valid: false, reason: 'Round has already been played' })
+	})
 	it('rejects used team', () => {
 		expect(validateClassicPick({ ...base, teamId: 'used-1' })).toEqual({
 			valid: false,

--- a/src/lib/picks/validate.ts
+++ b/src/lib/picks/validate.ts
@@ -19,12 +19,12 @@ export interface ClassicPickValidation {
 
 export function validateClassicPick(
 	input: ClassicPickValidation,
-	opts: { allowEliminatedRebuy?: boolean } = {},
+	opts: { allowEliminatedRebuy?: boolean; allowAdminLateSubmission?: boolean } = {},
 ): ValidationResult {
 	if (!opts.allowEliminatedRebuy && input.playerStatus !== 'alive')
 		return { valid: false, reason: 'Player is not alive' }
 	if (input.isPastRound) return { valid: false, reason: 'Round has already been played' }
-	if (input.deadline && input.now > input.deadline)
+	if (!opts.allowAdminLateSubmission && input.deadline && input.now > input.deadline)
 		return { valid: false, reason: 'Deadline has passed' }
 	if (input.usedTeamIds.includes(input.teamId))
 		return { valid: false, reason: 'Team already used in a previous round' }
@@ -73,12 +73,12 @@ export interface CupPicksValidation {
 
 export function validateCupPicks(
 	input: CupPicksValidation,
-	opts: { allowEliminatedRebuy?: boolean } = {},
+	opts: { allowEliminatedRebuy?: boolean; allowAdminLateSubmission?: boolean } = {},
 ): ValidationResult {
 	if (!opts.allowEliminatedRebuy && input.playerStatus !== 'alive')
 		return { valid: false, reason: 'Player is not alive' }
 	if (!input.isCurrentRound) return { valid: false, reason: 'Round is not open for picks' }
-	if (input.deadline && input.now > input.deadline)
+	if (!opts.allowAdminLateSubmission && input.deadline && input.now > input.deadline)
 		return { valid: false, reason: 'Deadline has passed' }
 	// Cup mode allows partial rankings — players can submit 1..numberOfPicks
 	// picks. Matches predecessor app behaviour. Turbo still requires the full
@@ -121,12 +121,12 @@ export function validateCupPicks(
 
 export function validateTurboPicks(
 	input: TurboPicksValidation,
-	opts: { allowEliminatedRebuy?: boolean } = {},
+	opts: { allowEliminatedRebuy?: boolean; allowAdminLateSubmission?: boolean } = {},
 ): ValidationResult {
 	if (!opts.allowEliminatedRebuy && input.playerStatus !== 'alive')
 		return { valid: false, reason: 'Player is not alive' }
 	if (!input.isCurrentRound) return { valid: false, reason: 'Round is not open for picks' }
-	if (input.deadline && input.now > input.deadline)
+	if (!opts.allowAdminLateSubmission && input.deadline && input.now > input.deadline)
 		return { valid: false, reason: 'Deadline has passed' }
 	if (input.picks.length !== input.numberOfPicks)
 		return {


### PR DESCRIPTION
Three admin tools for running a live game (6a/6b/6c from the backlog).

## 6a — pick after the deadline
An admin acting-as a player (already verified as the game creator) can now set/fix a pick **after the round deadline**. The three pick validators gain an `allowAdminLateSubmission` opt that skips the deadline check — `isPastRound` stays enforced (completed rounds need re-settlement, out of scope). The game page renders the pick interface for an admin acting-as even when the deadline has passed (classic stays interactive via `currentRoundClosed={roundDeadlinePassed && !actingAsTarget}`; the turbo/cup gate is relaxed the same way).

## 6b — mark paid
A **"Mark paid"** button on pending/claimed rows in the payments panel, wired to the **existing** `POST /api/games/[id]/payments/[paymentId]/override` endpoint (`{status:'paid'}`, already tested). Pot refreshes via the existing `onChange` → `router.refresh()`.

## 6c — remove a no-pick player
New endpoint `POST /api/games/[id]/admin/remove-player/[userId]`. **Preserves history** (no row deletes): flips the player to `eliminated` / reason `admin_removed` (already a documented reason) and refunds their payments so they leave the pot. **Guarded to players who've never picked** (returns `player-has-picks` otherwise). `admin_removed` players are excluded from standings, counts and the pot target (`getGameDetail` + `getProgressGridData`). A **✕** control sits next to the ✎ pick-for-player action in the grid for no-pick players (`GridPlayer.userId` added — optional, live grid only).

## Verification
- ✅ typecheck · Biome · unit **489** (+6: admin-late validators, remove-player route) · smoke **34** · `next build`
- ✅ dev-server render (admin view): "Mark paid" buttons, ✕ remove controls, and the acting-as-**past-deadline** pick UI all render (the dead-end "Round closed" panel is gone for admins) — no errors.
- Rebased onto latest `main` (incl. #89); clean.