### PR TITLE
fix(pot): count rebuys in the target so pot sizing stays consistent

### DIFF
--- a/src/app/(app)/game/[id]/page.tsx
+++ b/src/app/(app)/game/[id]/page.tsx
@@ -156,11 +156,13 @@ export default async function GameDetailPage({
 	// players so admins can rebuy-via-pick (see maybeUnEliminate in the POST route).
 	const aliveCount = game.players.filter((p) => p.status === 'alive').length
 
-	// Target = entryFee × playerCount (what the pot would be if everyone paid).
-	// Unpaid = headline sum of outstanding (not yet claimed) entries, computed
-	// directly from target − pot.total since pot includes both paid and claimed.
+	// Target = entryFee × expected entries (what the pot would be if everyone
+	// paid). expectedEntries counts each player's rebuys as additional owed
+	// entries, so a rebuy isn't missed (was players.length, which under-counted).
+	// Unpaid = headline sum of outstanding entries, computed directly from
+	// target − pot.total.
 	const entryFeeNum = game.entryFee ? Number.parseFloat(game.entryFee) : 0
-	const targetNum = entryFeeNum * game.players.length
+	const targetNum = entryFeeNum * game.expectedEntries
 	const unpaidNum = Math.max(0, targetNum - Number.parseFloat(game.pot.total))
 	const target = targetNum.toFixed(2)
 	const unpaid = unpaidNum.toFixed(2)

--- a/src/lib/game-logic/prizes.test.ts
+++ b/src/lib/game-logic/prizes.test.ts
@@ -1,5 +1,43 @@
 import { describe, expect, it } from 'vitest'
-import { calculatePayouts, calculatePot } from './prizes'
+import { calculatePayouts, calculatePot, expectedEntryCount } from './prizes'
+
+describe('expectedEntryCount', () => {
+	it('counts one entry per player when there are no rebuys', () => {
+		// c has no payment row yet but still owes the original entry.
+		expect(
+			expectedEntryCount(
+				['a', 'b', 'c'],
+				[
+					{ userId: 'a', status: 'paid' },
+					{ userId: 'b', status: 'pending' },
+				],
+			),
+		).toBe(3)
+	})
+	it('counts a rebuy as a second entry for that player', () => {
+		expect(
+			expectedEntryCount(
+				['a', 'b'],
+				[
+					{ userId: 'a', status: 'paid' },
+					{ userId: 'a', status: 'pending' }, // rebuy
+					{ userId: 'b', status: 'paid' },
+				],
+			),
+		).toBe(3)
+	})
+	it('excludes refunded rows', () => {
+		expect(
+			expectedEntryCount(
+				['a'],
+				[
+					{ userId: 'a', status: 'paid' },
+					{ userId: 'a', status: 'refunded' },
+				],
+			),
+		).toBe(1)
+	})
+})
 
 describe('calculatePot', () => {
 	it('returns all zeros on empty input', () => {

--- a/src/lib/game-logic/prizes.ts
+++ b/src/lib/game-logic/prizes.ts
@@ -9,6 +9,26 @@ export interface PotBreakdown {
 	total: string
 }
 
+/**
+ * How many entries the pot would hold if everyone paid everything they owe —
+ * i.e. the multiplier for the target pot (target = entryFee × entryCount).
+ *
+ * Each player owes their original entry, plus one more per rebuy. A rebuy is an
+ * extra non-refunded payment row, so a player's owed entries = max(1, their
+ * non-refunded rows) — `max(1, …)` covers players with no payment row yet (they
+ * still owe the original). Refunded rows (e.g. admin-removed players) don't
+ * count. Using distinct player count instead would undercount rebuys.
+ */
+export function expectedEntryCount(
+	playerUserIds: string[],
+	payments: { userId: string; status: string }[],
+): number {
+	return playerUserIds.reduce((sum, uid) => {
+		const owed = payments.filter((p) => p.userId === uid && p.status !== 'refunded').length
+		return sum + Math.max(1, owed)
+	}, 0)
+}
+
 export function calculatePot(payments: PaymentLike[]): PotBreakdown {
 	let paid = 0
 	let claimed = 0

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -16,7 +16,7 @@ import { roundLabel, roundLabelLong } from '@/lib/game/round-label'
 import { deriveGameRoundStatus } from '@/lib/game/round-status'
 import { evaluateCupPicks } from '@/lib/game-logic/cup'
 import { computeTierDifference } from '@/lib/game-logic/cup-tier'
-import { calculatePot } from '@/lib/game-logic/prizes'
+import { calculatePot, expectedEntryCount } from '@/lib/game-logic/prizes'
 import { fixture, round, team } from '@/lib/schema/competition'
 import { game, type gamePlayer, pick } from '@/lib/schema/game'
 import { payment } from '@/lib/schema/payment'
@@ -86,6 +86,12 @@ export async function getGameDetail(gameId: string, userId: string) {
 		})
 	).filter((p) => !removedUserIds.has(p.userId))
 	const pot = calculatePot(payments)
+	// Target multiplier: counts each player's rebuys as extra owed entries, so the
+	// "if everyone paid" target isn't undercounted when players have rebought.
+	const expectedEntries = expectedEntryCount(
+		gameData.players.map((p) => p.userId),
+		payments,
+	)
 
 	// Resolve user names for every player + the admin so payment UI can show names.
 	const { user } = await import('@/lib/schema/auth')
@@ -290,6 +296,7 @@ export async function getGameDetail(gameId: string, userId: string) {
 		entryFee: gameData.entryFee,
 		inviteCode: gameData.inviteCode,
 		pot,
+		expectedEntries,
 		players: gameData.players,
 		picks: gameData.picks,
 		myMembership,


### PR DESCRIPTION
C6 (rebuy pot). Per the agreed rule: **an entry only increments the pot when it's `paid`** (pending never counts), and **both the user and the admin can mark any entry — regular or rebuy — paid, at any stage.**

That part already held in the code:
- user claim sets `paid` directly (RebuyBanner uses the same `claim` endpoint for rebuys);
- the admin "Mark paid" button (shipped in #90) works on any pending/claimed row, including rebuys;
- `calculatePot` counts `paid` (and `'claimed'`, which is no longer written by any flow), so pending/refunded are excluded.

## The one inconsistency fixed
The **target** ("what the pot would be if everyone paid", shown on the game header) was `entryFee × players.length` — it counts a rebuying player once, so it under-states the target by one entry per rebuy.

- New pure, unit-tested **`expectedEntryCount(playerUserIds, payments)`**: each player owes `max(1, their non-refunded payment rows)` — original entry plus one per rebuy; refunded rows (e.g. admin-removed players) don't count.
- `getGameDetail` returns `expectedEntries`; the game page multiplies it by `entryFee` for the target. With no rebuys it equals the player count, so existing games are unchanged.

## Verification
- ✅ typecheck · Biome · unit **493** (+3 `expectedEntryCount`) · smoke **34** · `next build`