### PR TITLE
feat(admin): record a rebuy entry at any stage (grow the pot post-window)

### DIFF
--- a/src/app/api/games/[id]/admin/add-rebuy/[userId]/route.test.ts
+++ b/src/app/api/games/[id]/admin/add-rebuy/[userId]/route.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/auth-helpers', () => ({
+	requireSession: vi.fn().mockResolvedValue({ user: { id: 'admin' } }),
+}))
+
+const { dbMock } = vi.hoisted(() => ({
+	dbMock: {
+		query: {
+			game: { findFirst: vi.fn() },
+			gamePlayer: { findFirst: vi.fn() },
+			payment: { findFirst: vi.fn() },
+		},
+		insert: vi.fn(() => ({
+			values: vi.fn(() => ({
+				returning: vi.fn().mockResolvedValue([{ id: 'pay-new' }]),
+			})),
+		})),
+	},
+}))
+
+vi.mock('@/lib/db', () => ({ db: dbMock }))
+
+import { POST } from './route'
+
+const ctx = (gameId = 'g1', userId = 'u-target') => ({
+	params: Promise.resolve({ id: gameId, userId }),
+})
+const req = () => new Request('http://localhost/add-rebuy', { method: 'POST' })
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	dbMock.query.game.findFirst.mockResolvedValue({ id: 'g1', createdBy: 'admin', entryFee: '10.00' })
+	dbMock.query.gamePlayer.findFirst.mockResolvedValue({ id: 'gp1', userId: 'u-target' })
+	dbMock.query.payment.findFirst.mockResolvedValue(undefined)
+})
+
+describe('POST add-rebuy', () => {
+	it('rejects a non-admin with 403', async () => {
+		dbMock.query.game.findFirst.mockResolvedValue({ id: 'g1', createdBy: 'someone-else' })
+		expect((await POST(req(), ctx())).status).toBe(403)
+	})
+
+	it('404s when the player is not in the game', async () => {
+		dbMock.query.gamePlayer.findFirst.mockResolvedValue(undefined)
+		expect((await POST(req(), ctx())).status).toBe(404)
+	})
+
+	it('refuses to stack a second outstanding entry', async () => {
+		dbMock.query.payment.findFirst.mockResolvedValue({ id: 'p-pending', status: 'pending' })
+		const res = await POST(req(), ctx())
+		expect(res.status).toBe(400)
+		expect((await res.json()).error).toBe('pending-entry-exists')
+	})
+
+	it('creates a pending rebuy entry', async () => {
+		const res = await POST(req(), ctx())
+		expect(res.status).toBe(200)
+		const body = await res.json()
+		expect(body.status).toBe('pending')
+		expect(body.paymentId).toBe('pay-new')
+		expect(dbMock.insert).toHaveBeenCalledOnce()
+	})
+})

--- a/src/app/api/games/[id]/admin/add-rebuy/[userId]/route.ts
+++ b/src/app/api/games/[id]/admin/add-rebuy/[userId]/route.ts
@@ -1,0 +1,61 @@
+import { and, eq } from 'drizzle-orm'
+import { NextResponse } from 'next/server'
+import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { game, gamePlayer } from '@/lib/schema/game'
+import { payment } from '@/lib/schema/payment'
+
+type Ctx = { params: Promise<{ id: string; userId: string }> }
+
+/**
+ * Admin-only: record a rebuy (an additional entry) for a player at ANY stage —
+ * including after the round-2 rebuy window has closed, when the self-service
+ * rebuy is no longer available. Creates a second `pending` payment row; it then
+ * flows through the normal pay/mark-paid mechanics (admin "Mark paid", or the
+ * player claiming) and increments the pot once paid.
+ *
+ * Payment-only: it does NOT change the player's alive/eliminated status (that's
+ * the separate self-service rebuy). Guarded so the admin can't stack multiple
+ * outstanding entries — mark the existing one paid first.
+ */
+export async function POST(_request: Request, ctx: Ctx): Promise<Response> {
+	const session = await requireSession()
+	const { id: gameId, userId: targetUserId } = await ctx.params
+
+	const gameRow = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+	if (!gameRow) return NextResponse.json({ error: 'not-found' }, { status: 404 })
+	if (gameRow.createdBy !== session.user.id) {
+		return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+	}
+
+	const playerRow = await db.query.gamePlayer.findFirst({
+		where: and(eq(gamePlayer.gameId, gameId), eq(gamePlayer.userId, targetUserId)),
+	})
+	if (!playerRow) return NextResponse.json({ error: 'not-in-game' }, { status: 404 })
+
+	// Don't stack outstanding entries — an existing unpaid one must be settled
+	// first (keeps the pot maths and the player's pay prompt unambiguous).
+	const pending = await db.query.payment.findFirst({
+		where: and(
+			eq(payment.gameId, gameId),
+			eq(payment.userId, targetUserId),
+			eq(payment.status, 'pending'),
+		),
+	})
+	if (pending) {
+		return NextResponse.json({ error: 'pending-entry-exists' }, { status: 400 })
+	}
+
+	const [inserted] = await db
+		.insert(payment)
+		.values({
+			gameId,
+			userId: targetUserId,
+			amount: gameRow.entryFee ?? '0.00',
+			status: 'pending',
+			method: 'manual',
+		})
+		.returning()
+
+	return NextResponse.json({ paymentId: inserted.id, status: 'pending' })
+}

--- a/src/components/game/payments-panel.tsx
+++ b/src/components/game/payments-panel.tsx
@@ -29,7 +29,30 @@ export function PaymentsPanel(props: PaymentsPanelProps) {
 	const all = props.payments
 	const unpaidCount = all.filter((p) => p.status === 'pending' || p.status === 'unpaid').length
 
-	async function callAction(p: AdminPayment, action: 'dispute' | 'admin-rebuy' | 'mark-paid') {
+	async function callAction(
+		p: AdminPayment,
+		action: 'dispute' | 'admin-rebuy' | 'mark-paid' | 'add-rebuy',
+	) {
+		if (action === 'add-rebuy') {
+			// Record a rebuy (extra entry) at any stage — even after the rebuy
+			// window. Creates a pending entry; mark it paid (here or by the player)
+			// to grow the pot.
+			const res = await fetch(`/api/games/${props.gameId}/admin/add-rebuy/${p.userId}`, {
+				method: 'POST',
+			})
+			if (res.ok) {
+				toast.success(`Rebuy added for ${p.userName} — mark it paid to grow the pot`)
+				props.onChange?.()
+			} else {
+				const body = await res.json().catch(() => ({ error: 'failed' }))
+				toast.error(
+					body.error === 'pending-entry-exists'
+						? `${p.userName} already has an unpaid entry`
+						: 'Failed to add rebuy',
+				)
+			}
+			return
+		}
 		if (action === 'admin-rebuy') {
 			const res = await fetch(`/api/games/${props.gameId}/admin/rebuy/${p.userId}`, {
 				method: 'POST',
@@ -110,13 +133,24 @@ export function PaymentsPanel(props: PaymentsPanelProps) {
 									</button>
 								)}
 								{p.id !== null && p.status === 'paid' ? (
-									<button
-										type="button"
-										onClick={() => callAction(p, 'dispute')}
-										className="rounded border border-red-300 px-3 py-1.5 text-xs font-semibold text-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/50"
-									>
-										Dispute
-									</button>
+									<>
+										{!p.isRebuy && (
+											<button
+												type="button"
+												onClick={() => callAction(p, 'add-rebuy')}
+												className="rounded border border-border px-3 py-1.5 text-xs font-semibold text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+											>
+												Add rebuy
+											</button>
+										)}
+										<button
+											type="button"
+											onClick={() => callAction(p, 'dispute')}
+											className="rounded border border-red-300 px-3 py-1.5 text-xs font-semibold text-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/50"
+										>
+											Dispute
+										</button>
+									</>
 								) : p.id !== null && (p.status === 'pending' || p.status === 'claimed') ? (
 									<>
 										<button


### PR DESCRIPTION
## Problem
Once the round-2 rebuy window closes, there's **no way to record a rebuy**: the self-service rebuy is gone, and the payments panel only renders *existing* payment rows. So a player who bought back in has no entry to mark paid, and the pot can't reflect it. (Confirmed against the live WC game: 13 players, 13 paid rows, zero rebuy rows — nothing to mark.)

## Fix
- **New admin endpoint** `POST /api/games/[id]/admin/add-rebuy/[userId]`: records a rebuy by creating a second **`pending`** entry (amount = entry fee) for the player, at any stage. Payment-only — it does **not** change alive/eliminated status (that's the separate self-service rebuy, which you said you don't want here). Guarded so you can't stack a second outstanding entry.
- **Payments panel:** an **"Add rebuy"** button on each player's paid row.

Once the entry exists, the existing mechanics finish the job — no further changes needed:
- **You** mark it paid via the "Mark paid" button (#90) → pot grows (and #91 already counts the rebuy in the target).
- **An alive player** can mark it paid themselves via the rebuy banner's "Claim paid".

## Verification
- ✅ typecheck · Biome · unit **497** (+4: add-rebuy route) · smoke **34** · `next build`
- ✅ dev-server E2E (admin): "Add rebuy" renders → `POST add-rebuy` 200 creates a pending "(rebuy)" row → "Mark paid" appears → marking it paid clears the button (now `paid`, counted in the pot). No errors.