### PR TITLE
fix(classic): stop WC games auto-completing at the group→knockout boundary

### DIFF
--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -376,6 +376,113 @@ describe('lifecycle: classic-WC', () => {
 		const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
 		expect(g?.currentRoundId).toBe(r2)
 	})
+
+	it('does NOT complete mid-round when the terminal seeded round is only partially finished — the dc857c5f MD3 mis-crowning', async () => {
+		// MD3 is the LAST seeded round (knockout rounds not yet created). Settling
+		// just ONE of its fixtures must not end the game: "rounds exhausted" cannot
+		// be concluded while the round is still in progress. This is the exact
+		// shape that wrongly crowned a winner mid-MD3.
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		const ger = await makeTeam({ name: 'Germany', shortName: 'GER', fifaPot: 1 })
+		const kor = await makeTeam({ name: 'South Korea', shortName: 'KOR', fifaPot: 3 })
+		const mar = await makeTeam({ name: 'Morocco', shortName: 'MAR', fifaPot: 2 })
+		const civ = await makeTeam({ name: 'Ivory Coast', shortName: 'CIV', fifaPot: 3 })
+		const md3 = await makeRound(compId, { number: 3, status: 'open' })
+		const fxFinished = await makeFixture({ roundId: md3, homeTeamId: ger, awayTeamId: kor })
+		const fxPending = await makeFixture({ roundId: md3, homeTeamId: mar, awayTeamId: civ })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: md3,
+			modeConfig: { allowRebuys: false },
+		})
+		const winner = await makePlayer({ gameId, userId: 'u-win' })
+		const loser = await makePlayer({ gameId, userId: 'u-lose' })
+		const waiting = await makePlayer({ gameId, userId: 'u-wait' })
+		await makePick({
+			gameId,
+			gamePlayerId: winner,
+			roundId: md3,
+			teamId: ger,
+			fixtureId: fxFinished,
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: loser,
+			roundId: md3,
+			teamId: kor,
+			fixtureId: fxFinished,
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: waiting,
+			roundId: md3,
+			teamId: mar,
+			fixtureId: fxPending,
+		})
+
+		// Germany beat South Korea; Morocco's fixture is still to play.
+		await finishFixture(fxFinished, 2, 0)
+		await settleFixture(fxFinished)
+
+		const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+		expect(g?.status).toBe('active') // NOT completed mid-round
+		expect(g?.currentRoundId).toBe(md3) // still on MD3
+		const payouts = await db.query.payout.findMany({ where: eq(payout.gameId, gameId) })
+		expect(payouts).toHaveLength(0) // nobody crowned
+
+		const players = await db.query.gamePlayer.findMany({ where: eq(gamePlayer.gameId, gameId) })
+		const byId = Object.fromEntries(players.map((p) => [p.id, p]))
+		expect(byId[loser].status).toBe('eliminated') // the loss still eliminates
+		expect(byId[winner].status).toBe('alive')
+		expect(byId[waiting].status).toBe('alive')
+	})
+
+	it('waits at the group→knockout boundary: MD3 fully settles with a TBD knockout round seeded → no completion, no auto-elim', async () => {
+		// With the knockout round seeded (a round row exists, fixtures TBD), the
+		// fully-finished group stage must NOT auto-complete (nextRoundExists is
+		// true) and must NOT auto-eliminate everyone (the bracket is unpublished).
+		// The game waits, pointed at the just-completed MD3, until the draw lands.
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		const ger = await makeTeam({ name: 'Germany', shortName: 'GER', fifaPot: 1 })
+		const kor = await makeTeam({ name: 'South Korea', shortName: 'KOR', fifaPot: 3 })
+		const mar = await makeTeam({ name: 'Morocco', shortName: 'MAR', fifaPot: 2 })
+		const civ = await makeTeam({ name: 'Ivory Coast', shortName: 'CIV', fifaPot: 3 })
+		const md3 = await makeRound(compId, { number: 3, status: 'open' })
+		// Round of 32 seeded but TBD — exists as a round row, no fixtures yet.
+		await makeRound(compId, { number: 4, status: 'upcoming' })
+		const fxA = await makeFixture({ roundId: md3, homeTeamId: ger, awayTeamId: kor })
+		const fxB = await makeFixture({ roundId: md3, homeTeamId: mar, awayTeamId: civ })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: md3,
+			modeConfig: { allowRebuys: false },
+		})
+		const p1 = await makePlayer({ gameId, userId: 'u-1' })
+		const p2 = await makePlayer({ gameId, userId: 'u-2' })
+		await makePick({ gameId, gamePlayerId: p1, roundId: md3, teamId: ger, fixtureId: fxA })
+		await makePick({ gameId, gamePlayerId: p2, roundId: md3, teamId: mar, fixtureId: fxB })
+
+		await finishFixture(fxA, 2, 0)
+		await finishFixture(fxB, 1, 0)
+		await settleFixture(fxA)
+		await settleFixture(fxB) // MD3 now fully finished
+
+		const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+		expect(g?.status).toBe('active') // did NOT wrongly complete via rounds-exhausted
+		expect(g?.currentRoundId).toBe(md3) // stays put awaiting the bracket
+		const payouts = await db.query.payout.findMany({ where: eq(payout.gameId, gameId) })
+		expect(payouts).toHaveLength(0)
+
+		const players = await db.query.gamePlayer.findMany({ where: eq(gamePlayer.gameId, gameId) })
+		expect(players.every((p) => p.status === 'alive')).toBe(true) // no wrongful auto-elim
+
+		const md3row = await db.query.round.findFirst({ where: eq(roundTable.id, md3) })
+		expect(md3row?.status).toBe('completed') // round itself is done
+	})
 })
 
 /* ────────────────────────────────────────────────────────────────────── */

--- a/src/lib/data/football-data.test.ts
+++ b/src/lib/data/football-data.test.ts
@@ -202,13 +202,14 @@ describe('FootballDataAdapter', () => {
 		expect(teams.find((t) => t.externalId === 'null')).toBeUndefined()
 	})
 
-	it('skips matches with null matchday in fetchRounds', async () => {
+	it('skips null-matchday matches with no recognised stage (no "Matchday null" round)', async () => {
 		const withKnockouts = {
 			matches: [
 				...mockMatches.matches,
 				{
 					id: 998,
 					matchday: null,
+					stage: null,
 					homeTeam: { id: 64, name: 'Liverpool', tla: 'LIV', crest: '' },
 					awayTeam: { id: 66, name: 'Man United', tla: 'MUN', crest: '' },
 					utcDate: '2026-07-15T15:00:00Z',
@@ -225,6 +226,150 @@ describe('FootballDataAdapter', () => {
 		expect(rounds.find((r) => r.name === 'Matchday null')).toBeUndefined()
 		const allFixtures = rounds.flatMap((r) => r.fixtures)
 		expect(allFixtures.find((f) => f.externalId === '998')).toBeUndefined()
+	})
+
+	describe('World Cup knockout stages (matchday=null, keyed by stage)', () => {
+		// A realistic WC-shaped payload: 3 group matchdays, then knockout matches
+		// with matchday=null distinguished only by `stage`, teams still TBD.
+		const wcPayload = {
+			matches: [
+				{
+					id: 1,
+					matchday: 3,
+					stage: 'GROUP_STAGE',
+					homeTeam: { id: 760, name: 'Germany', tla: 'GER', crest: '' },
+					awayTeam: { id: 759, name: 'South Korea', tla: 'KOR', crest: '' },
+					utcDate: '2026-06-24T19:00:00Z',
+					status: 'FINISHED',
+					score: { fullTime: { home: 2, away: 0 } },
+				},
+				{
+					id: 100,
+					matchday: null,
+					stage: 'LAST_32',
+					homeTeam: { id: null, name: null, tla: null, crest: null },
+					awayTeam: { id: null, name: null, tla: null, crest: null },
+					utcDate: '2026-06-28T19:00:00Z',
+					status: 'TIMED',
+					score: { fullTime: { home: null, away: null } },
+				},
+				{
+					id: 200,
+					matchday: null,
+					stage: 'LAST_16',
+					homeTeam: { id: null, name: null, tla: null, crest: null },
+					awayTeam: { id: null, name: null, tla: null, crest: null },
+					utcDate: '2026-07-04T19:00:00Z',
+					status: 'TIMED',
+					score: { fullTime: { home: null, away: null } },
+				},
+				{
+					id: 300,
+					matchday: null,
+					stage: 'QUARTER_FINALS',
+					homeTeam: { id: null, name: null, tla: null, crest: null },
+					awayTeam: { id: null, name: null, tla: null, crest: null },
+					utcDate: '2026-07-10T19:00:00Z',
+					status: 'TIMED',
+					score: { fullTime: { home: null, away: null } },
+				},
+				{
+					id: 400,
+					matchday: null,
+					stage: 'SEMI_FINALS',
+					homeTeam: { id: null, name: null, tla: null, crest: null },
+					awayTeam: { id: null, name: null, tla: null, crest: null },
+					utcDate: '2026-07-15T19:00:00Z',
+					status: 'TIMED',
+					score: { fullTime: { home: null, away: null } },
+				},
+				{
+					id: 500,
+					matchday: null,
+					stage: 'THIRD_PLACE',
+					homeTeam: { id: null, name: null, tla: null, crest: null },
+					awayTeam: { id: null, name: null, tla: null, crest: null },
+					utcDate: '2026-07-18T19:00:00Z',
+					status: 'TIMED',
+					score: { fullTime: { home: null, away: null } },
+				},
+				{
+					id: 600,
+					matchday: null,
+					stage: 'FINAL',
+					homeTeam: { id: null, name: null, tla: null, crest: null },
+					awayTeam: { id: null, name: null, tla: null, crest: null },
+					utcDate: '2026-07-19T19:00:00Z',
+					status: 'TIMED',
+					score: { fullTime: { home: null, away: null } },
+				},
+			],
+		}
+
+		beforeEach(() => {
+			vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+				Promise.resolve(new Response(JSON.stringify(wcPayload))),
+			)
+		})
+
+		it('seeds knockout rounds (numbered after the last group matchday) even with TBD fixtures', async () => {
+			const rounds = await adapter.fetchRounds()
+			const byNumber = Object.fromEntries(rounds.map((r) => [r.number, r]))
+			// group matchday 3 stays round 3; knockout stages become 4..8.
+			expect(byNumber[3]?.name).toBe('Matchday 3')
+			expect(byNumber[4]?.name).toBe('Round of 32')
+			expect(byNumber[5]?.name).toBe('Round of 16')
+			expect(byNumber[6]?.name).toBe('Quarter-finals')
+			expect(byNumber[7]?.name).toBe('Semi-finals')
+			expect(byNumber[8]?.name).toBe('Final')
+			// TBD bracket → round rows exist but carry no fixtures / deadline yet.
+			expect(byNumber[4]?.fixtures).toHaveLength(0)
+			expect(byNumber[4]?.deadline).toBeNull()
+			expect(byNumber[8]?.fixtures).toHaveLength(0)
+		})
+
+		it('excludes the third-place playoff (not a survivor round)', async () => {
+			const rounds = await adapter.fetchRounds()
+			// Stages map to 4(R32),5(R16),6(QF),7(SF),8(Final) — no extra round for
+			// THIRD_PLACE; the highest knockout round is the Final at 8.
+			expect(Math.max(...rounds.map((r) => r.number))).toBe(8)
+			expect(rounds.some((r) => r.name === 'Final')).toBe(true)
+			expect(rounds.some((r) => /third|3rd|place/i.test(r.name))).toBe(false)
+			// 1 group matchday (#3) + 5 retained knockout rounds (R32..Final).
+			expect(rounds).toHaveLength(6)
+		})
+
+		it('live scores resolve a knockout round by stage, not matchday', async () => {
+			// A resolved + finished Round of 32 tie.
+			const resolved = {
+				matches: [
+					...wcPayload.matches.filter((m) => m.stage !== 'LAST_32'),
+					{
+						id: 100,
+						matchday: null,
+						stage: 'LAST_32',
+						homeTeam: { id: 760, name: 'Germany', tla: 'GER', crest: '' },
+						awayTeam: { id: 770, name: 'Brazil', tla: 'BRA', crest: '' },
+						utcDate: '2026-06-28T19:00:00Z',
+						status: 'FINISHED',
+						score: { winner: 'AWAY_TEAM', fullTime: { home: 1, away: 2 } },
+					},
+				],
+			}
+			vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+				Promise.resolve(new Response(JSON.stringify(resolved))),
+			)
+			// Round of 32 is round number 4 (max group matchday 3 + 1).
+			const scores = await adapter.fetchLiveScores(4)
+			expect(scores).toHaveLength(1)
+			expect(scores[0]).toEqual({
+				externalId: '100',
+				homeScore: 1,
+				awayScore: 2,
+				status: 'finished',
+				winner: 'away',
+			})
+		})
 	})
 
 	it('skips fixtures with placeholder teams in fetchRounds', async () => {

--- a/src/lib/data/football-data.ts
+++ b/src/lib/data/football-data.ts
@@ -36,6 +36,12 @@ interface FdTeam {
 interface FdMatch {
 	id: number
 	matchday: number | null
+	/**
+	 * Tournament stage. Group/league matches carry a `matchday`; knockout matches
+	 * have `matchday: null` and are distinguished only by `stage`
+	 * (LAST_32 / LAST_16 / QUARTER_FINALS / SEMI_FINALS / THIRD_PLACE / FINAL).
+	 */
+	stage?: string | null
 	homeTeam: FdTeam
 	awayTeam: FdTeam
 	utcDate: string
@@ -51,6 +57,54 @@ function mapWinner(winner: string | null | undefined): 'home' | 'away' | null {
 	if (winner === 'HOME_TEAM') return 'home'
 	if (winner === 'AWAY_TEAM') return 'away'
 	return null
+}
+
+/**
+ * Knockout stages in bracket order. The round NUMBER for a knockout stage is
+ * `maxGroupMatchday + (index in this list) + 1`, so for a competition whose
+ * group stage runs to matchday 3 (the World Cup) the knockout rounds become
+ * 4 (Round of 32) … 8 (Final). THIRD_PLACE is intentionally absent — the
+ * third-place playoff is a consolation match between two already-eliminated
+ * teams, not a survivor round, so it is excluded from the round structure.
+ */
+const KO_STAGE_ORDER = ['LAST_32', 'LAST_16', 'QUARTER_FINALS', 'SEMI_FINALS', 'FINAL'] as const
+
+const KO_STAGE_NAMES: Record<string, string> = {
+	LAST_32: 'Round of 32',
+	LAST_16: 'Round of 16',
+	QUARTER_FINALS: 'Quarter-finals',
+	SEMI_FINALS: 'Semi-finals',
+	FINAL: 'Final',
+}
+
+/** Highest matchday across the match set (0 if none carry a matchday). */
+function maxGroupMatchday(matches: FdMatch[]): number {
+	let max = 0
+	for (const m of matches) {
+		if (m.matchday != null && m.matchday > max) max = m.matchday
+	}
+	return max
+}
+
+/**
+ * Resolve a match to its round NUMBER. Group/league matches map to their
+ * `matchday`; knockout matches (matchday=null) map by `stage` to a number after
+ * the last group matchday. Returns null for matches we don't model as a survivor
+ * round (unknown stage, or THIRD_PLACE) — the caller skips them.
+ */
+function roundNumberForMatch(m: FdMatch, maxMatchday: number): number | null {
+	if (m.matchday != null) return m.matchday
+	const idx = KO_STAGE_ORDER.indexOf((m.stage ?? '') as (typeof KO_STAGE_ORDER)[number])
+	if (idx === -1) return null
+	return maxMatchday + idx + 1
+}
+
+/** Round display name from the matches grouped under it. */
+function roundNameForMatches(number: number, matches: FdMatch[]): string {
+	const first = matches[0]
+	if (first?.matchday != null) return `Matchday ${number}`
+	const stageName = first?.stage ? KO_STAGE_NAMES[first.stage] : undefined
+	return stageName ?? `Round ${number}`
 }
 
 interface FdStandingEntry {
@@ -110,32 +164,46 @@ export class FootballDataAdapter implements CompetitionAdapter {
 		const data = await this.request<{ matches: FdMatch[] }>(
 			`/competitions/${this.competitionCode}/matches`,
 		)
+		// Map every match to a round NUMBER — group/league matches by matchday,
+		// knockout matches (matchday=null) by stage (see roundNumberForMatch).
+		// Knockout rounds are seeded as round rows even before the bracket is
+		// drawn: their matches exist (with TBD teams) so the round number + name
+		// are known. This is essential for survivor-game progression — without
+		// the knockout round rows, `nextRoundExists` is false at the end of the
+		// group stage and a classic game wrongly auto-completes (the dc857c5f
+		// MD3 incident).
+		const maxMatchday = maxGroupMatchday(data.matches)
 		const roundMap = new Map<number, FdMatch[]>()
 		for (const match of data.matches) {
-			if (match.matchday == null) continue
-			const list = roundMap.get(match.matchday) ?? []
+			const number = roundNumberForMatch(match, maxMatchday)
+			if (number == null) continue
+			const list = roundMap.get(number) ?? []
 			list.push(match)
-			roundMap.set(match.matchday, list)
+			roundMap.set(number, list)
 		}
 		return Array.from(roundMap.entries())
 			.sort(([a], [b]) => a - b)
-			.map(([matchday, matches]) => {
+			.map(([number, matches]) => {
+				// Only matches with both teams resolved become fixtures. Knockout
+				// rounds with a TBD bracket yield zero fixtures (and a null deadline)
+				// until the draw is known — the round row still exists so the game
+				// can advance to it / wait at it.
 				const playable = matches.filter((m) => m.homeTeam.id != null && m.awayTeam.id != null)
 				// Round deadline = earliest kickoff − 90 minutes. Matches the FPL
 				// convention (FPL's event.deadline_time is 90 min before the first
 				// match) and aligns with public team-news release. football-data
 				// doesn't supply a separate deadline concept, so we derive from
-				// kickoffs. Knockout rounds with TBD fixtures have no kickoffs yet
-				// — deadline stays null until the bracket is published.
+				// kickoffs. Knockout rounds with TBD fixtures have no playable
+				// kickoffs yet — deadline stays null until the bracket is published.
 				const earliestKickoff = playable
 					.map((m) => new Date(m.utcDate).getTime())
 					.filter((t) => Number.isFinite(t))
 					.reduce((min, t) => (min === null || t < min ? t : min), null as number | null)
 				const deadline = earliestKickoff != null ? new Date(earliestKickoff - 90 * 60 * 1000) : null
 				return {
-					externalId: String(matchday),
-					number: matchday,
-					name: `Matchday ${matchday}`,
+					externalId: String(number),
+					number,
+					name: roundNameForMatches(number, matches),
 					deadline,
 					finished: matches.every((m) => m.status === 'FINISHED'),
 					fixtures: playable.map(
@@ -155,10 +223,19 @@ export class FootballDataAdapter implements CompetitionAdapter {
 	}
 
 	async fetchLiveScores(roundNumber: number): Promise<AdapterFixtureScore[]> {
+		// Fetch all matches and resolve each to its round number via the shared
+		// mapping, then filter to the requested round. The `?matchday=` filter
+		// can't be used because knockout matches have matchday=null and are keyed
+		// by stage — querying `?matchday=4` would return nothing for the Round of
+		// 32. (Trade-off: one all-matches request per active competition per poll
+		// rather than a single-matchday request; acceptable for the tournament
+		// sizes here.)
 		const data = await this.request<{ matches: FdMatch[] }>(
-			`/competitions/${this.competitionCode}/matches?matchday=${roundNumber}`,
+			`/competitions/${this.competitionCode}/matches`,
 		)
+		const maxMatchday = maxGroupMatchday(data.matches)
 		return data.matches
+			.filter((m) => roundNumberForMatch(m, maxMatchday) === roundNumber)
 			.filter((m) => m.score.fullTime.home != null && m.score.fullTime.away != null)
 			.map((m) => ({
 				externalId: String(m.id),

--- a/src/lib/game-logic/wc-classic.test.ts
+++ b/src/lib/game-logic/wc-classic.test.ts
@@ -180,4 +180,52 @@ describe('computeWcClassicAutoElims', () => {
 		})
 		expect(elims).toEqual([])
 	})
+
+	it('eliminates NO ONE when the remaining bracket is unpublished (TBD rounds, no fixtures) — the dc857c5f MD3 boundary', () => {
+		// At the group→knockout boundary the WC knockout rounds exist as round
+		// rows but have no fixtures yet (teams TBD). A player who has used every
+		// team so far must NOT be auto-eliminated — the bracket may still offer a
+		// valid team. Without the guard, every alive player is wrongly culled.
+		const elims = computeWcClassicAutoElims({
+			alivePlayers: [
+				{ gamePlayerId: 'p1', usedTeamIds: ['t1', 't2', 't3'] },
+				{ gamePlayerId: 'p2', usedTeamIds: ['t4', 't5', 't6'] },
+			],
+			remainingRounds: [
+				{ id: 'r-last32', fixtures: [] },
+				{ id: 'r-last16', fixtures: [] },
+			],
+			finishedKnockoutFixtures: [],
+		})
+		expect(elims).toEqual([])
+	})
+
+	it('eliminates NO ONE when there are no remaining rounds at all (true end — completion handles it)', () => {
+		const elims = computeWcClassicAutoElims({
+			alivePlayers: [{ gamePlayerId: 'p1', usedTeamIds: ['t1', 't2', 't3'] }],
+			remainingRounds: [],
+			finishedKnockoutFixtures: [],
+		})
+		expect(elims).toEqual([])
+	})
+
+	it('still prunes once EVERY remaining round is published, even alongside earlier rounds', () => {
+		// Two remaining rounds, both with fixtures; the player has used both teams
+		// in the only fixtures available → genuinely out → eliminated.
+		const elims = computeWcClassicAutoElims({
+			alivePlayers: [{ gamePlayerId: 'p1', usedTeamIds: ['t1', 't2', 't3', 't4'] }],
+			remainingRounds: [
+				{
+					id: 'r-a',
+					fixtures: [f({ id: 'a1', homeTeamId: 't1', awayTeamId: 't2', stage: 'knockout' })],
+				},
+				{
+					id: 'r-b',
+					fixtures: [f({ id: 'b1', homeTeamId: 't3', awayTeamId: 't4', stage: 'knockout' })],
+				},
+			],
+			finishedKnockoutFixtures: [],
+		})
+		expect(elims).toEqual([{ gamePlayerId: 'p1', reason: 'ran-out-of-teams' }])
+	})
 })

--- a/src/lib/game-logic/wc-classic.ts
+++ b/src/lib/game-logic/wc-classic.ts
@@ -79,6 +79,21 @@ export interface AutoElimResult {
 }
 
 export function computeWcClassicAutoElims(input: AutoElimInput): AutoElimResult[] {
+	// Defer auto-elimination while the remaining bracket is incomplete. A
+	// remaining round with no fixtures is TBD — e.g. the World Cup knockout
+	// rounds before the draw is known. Such a round may yet offer a valid team,
+	// so no player can be said to have "run out of teams" while any remaining
+	// round is unpublished. With no known remaining rounds at all (the true end
+	// of the tournament), completion — not auto-elim — crowns the winner.
+	//
+	// Without this guard, the group→knockout boundary auto-eliminates EVERY
+	// alive player ("ran-out-of-teams" against an empty fixture set) → a
+	// mass-extinction mis-completion. Players who genuinely have no valid pick
+	// are still caught by the normal no-pick elimination once the round opens.
+	const bracketFullyPublished =
+		input.remainingRounds.length > 0 && input.remainingRounds.every((r) => r.fixtures.length > 0)
+	if (!bracketFullyPublished) return []
+
 	const eliminations: AutoElimResult[] = []
 	for (const player of input.alivePlayers) {
 		const used = new Set(player.usedTeamIds)

--- a/src/lib/game/auto-complete.test.ts
+++ b/src/lib/game/auto-complete.test.ts
@@ -29,7 +29,9 @@ describe('checkClassicCompletion', () => {
 			{ id: 'p2', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
 		] as never)
 
-		const result = await checkClassicCompletion('g1', 'c1', 'r1', 5)
+		// last-alive fires mid-round too (roundFullySettled=false): no one is left
+		// to play the remaining fixtures, so the lone survivor wins immediately.
+		const result = await checkClassicCompletion('g1', 'c1', 'r1', 5, false)
 		expect(result).toEqual({
 			completed: true,
 			winnerPlayerIds: ['p1'],
@@ -51,7 +53,9 @@ describe('checkClassicCompletion', () => {
 			{ gamePlayerId: 'p3', result: 'win', goalsScored: 99 },
 		] as never)
 
-		const result = await checkClassicCompletion('g1', 'c1', 'r1', 5)
+		// mass-extinction also fires mid-round (roundFullySettled=false): with zero
+		// alive there is no one left to play on.
+		const result = await checkClassicCompletion('g1', 'c1', 'r1', 5, false)
 		expect(result).toEqual({
 			completed: true,
 			winnerPlayerIds: ['p1'],
@@ -69,7 +73,7 @@ describe('checkClassicCompletion', () => {
 			{ gamePlayerId: 'p2', result: 'win', goalsScored: 5 },
 		] as never)
 
-		const result = await checkClassicCompletion('g1', 'c1', 'r1', 5)
+		const result = await checkClassicCompletion('g1', 'c1', 'r1', 5, false)
 		expect(result.completed).toBe(true)
 		expect(result.reason).toBe('mass-extinction')
 		expect(result.winnerPlayerIds.sort()).toEqual(['p1', 'p2'])
@@ -86,12 +90,27 @@ describe('checkClassicCompletion', () => {
 			{ gamePlayerId: 'p2', result: 'win', goalsScored: 7 },
 		] as never)
 
-		const result = await checkClassicCompletion('g1', 'c1', 'r1', 38)
+		const result = await checkClassicCompletion('g1', 'c1', 'r1', 38, true)
 		expect(result).toEqual({
 			completed: true,
 			winnerPlayerIds: ['p1'],
 			reason: 'rounds-exhausted',
 		})
+	})
+
+	it('does NOT complete with rounds-exhausted MID-ROUND even when no next round exists — the dc857c5f MD3 mis-crowning', async () => {
+		// >1 alive, no next-round row (WC knockout rounds not seeded), but the
+		// current round is NOT fully settled (mid-matchday). "We've run out of
+		// rounds" can only be true once the current round finishes — never
+		// mid-round. This is the exact state that wrongly crowned Sto in MD3.
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([
+			{ id: 'p1', status: 'alive', eliminatedRoundId: null, livesRemaining: 0 },
+			{ id: 'p2', status: 'alive', eliminatedRoundId: null, livesRemaining: 0 },
+		] as never)
+		dbMock.query.round.findFirst.mockResolvedValue(null as never)
+
+		const result = await checkClassicCompletion('g1', 'c1', 'r1', 3, false)
+		expect(result.completed).toBe(false)
 	})
 
 	it('does not complete when >1 alive and a next round exists', async () => {
@@ -101,7 +120,7 @@ describe('checkClassicCompletion', () => {
 		] as never)
 		dbMock.query.round.findFirst.mockResolvedValue({ id: 'r2', number: 6 } as never)
 
-		const result = await checkClassicCompletion('g1', 'c1', 'r1', 5)
+		const result = await checkClassicCompletion('g1', 'c1', 'r1', 5, true)
 		expect(result.completed).toBe(false)
 	})
 
@@ -110,7 +129,7 @@ describe('checkClassicCompletion', () => {
 			{ id: 'p1', status: 'eliminated', eliminatedRoundId: 'r-old', livesRemaining: 0 },
 		] as never)
 
-		const result = await checkClassicCompletion('g1', 'c1', 'r1', 5)
+		const result = await checkClassicCompletion('g1', 'c1', 'r1', 5, true)
 		expect(result.completed).toBe(false)
 	})
 })

--- a/src/lib/game/auto-complete.ts
+++ b/src/lib/game/auto-complete.ts
@@ -61,6 +61,19 @@ export async function checkClassicCompletion(
 	competitionId: string,
 	completedRoundId: string,
 	completedRoundNumber: number,
+	/**
+	 * Is the current round FULLY settled (every fixture finished or cancelled)?
+	 * `rounds-exhausted` may only be evaluated once this is true — "we've run out
+	 * of rounds" cannot be concluded while the current round is still in progress.
+	 * `last-alive` / `mass-extinction` are valid mid-round (no one left to play
+	 * the remaining fixtures changes nothing) and are unaffected by this flag.
+	 *
+	 * Without this guard, the very first fixture to settle in the final seeded
+	 * round triggers a premature `rounds-exhausted` completion — the dc857c5f
+	 * MD3 mis-crowning, where the WC knockout rounds weren't seeded so
+	 * `nextRoundExists` was false from the first MD3 result onward.
+	 */
+	roundFullySettled: boolean,
 ): Promise<CompletionCheckResult> {
 	const allPlayers = await db.query.gamePlayer.findMany({
 		where: eq(gamePlayer.gameId, gameId),
@@ -82,6 +95,10 @@ export async function checkClassicCompletion(
 		)
 		return { completed: true, winnerPlayerIds: winners, reason: 'mass-extinction' }
 	}
+
+	// >1 alive: the game only ends if the tournament is genuinely out of rounds —
+	// and only once the current round has fully finished.
+	if (!roundFullySettled) return { completed: false, winnerPlayerIds: [] }
 
 	const hasNext = await nextRoundExists(competitionId, completedRoundNumber)
 	if (!hasNext) {

--- a/src/lib/game/settle.ts
+++ b/src/lib/game/settle.ts
@@ -426,7 +426,13 @@ async function checkAndMaybeCompleteOrAdvance(
 		if (allFinished && g.competition.type === 'group_knockout') {
 			await runWcClassicAutoElims(gameId, roundId)
 		}
-		const completion = await checkClassicCompletion(gameId, g.competitionId, roundId, roundNumber)
+		const completion = await checkClassicCompletion(
+			gameId,
+			g.competitionId,
+			roundId,
+			roundNumber,
+			allFinished,
+		)
 		if (completion.completed) {
 			await applyAutoCompletion(gameId, completion.winnerPlayerIds)
 			result.gamesCompleted.push(gameId)


### PR DESCRIPTION
## The incident

Live World Cup classic game `dc857c5f` ("World Cup LPS") wrongly `completed` and crowned **Sto** (£160 payout) **during matchday 3**, with 18 of 24 fixtures still unplayed — Sto's own MD3 pick (Korea) then settled as a *loss*.

## Root cause — three defects

**D1 (logic, proximate).** `checkClassicCompletion` evaluated `rounds-exhausted` after *every* pick settlement, including mid-round. The first MD3 fixture to settle triggered a premature completion. Fix: thread `roundFullySettled` (from `settleFixture`'s `allFinished`) and only allow `rounds-exhausted` when the round is fully settled. `last-alive` / `mass-extinction` still fire mid-round.

**D2 (adapter, underlying).** The football-data adapter keyed rounds off `matchday` and dropped every knockout match (`matchday == null`), so the WC knockout rounds were never seeded → `nextRoundExists` was false from the first MD3 result. Fix: map knockout matches by `stage` to round numbers after the last group matchday (R32=4 … Final=8; third-place playoff excluded), seeding the round rows even while the bracket is TBD. `fetchLiveScores` unified on the same mapping so knockout rounds also get the per-minute poll.

**D3 (auto-elim, latent).** At the group→knockout boundary `computeWcClassicAutoElims` would eliminate *every* alive player ("ran-out-of-teams" against an empty remaining-fixture set) → mass-extinction mis-completion. Fix: defer auto-elimination while any remaining round is unpublished — the game waits for the draw.

## Testing gaps closed

These slipped through because (1) a unit test encoded the buggy "no next round ⇒ complete" assumption, (2) every WC scenario hand-seeded the next round so `nextRoundExists` was never false, and (3) smoke scenarios bypass the adapter (seed fixtures directly), so the knockout-dropping bug was invisible. Added:
- adapter test over a WC-shaped payload (group matchday + knockout `stage`, TBD teams) asserting KO rounds are seeded
- smoke: terminal round partially finished → no completion
- smoke: group→knockout boundary with a TBD next round → waits, no completion, no auto-elim

## Verification
typecheck · biome · unit (working tree all green) · smoke 36/36 · production build.

## Prod follow-up (separate, approval-gated)
Interim correction already applied to `dc857c5f` (deleted the £160 payout, set Sto `eliminated`; game still frozen). After this deploys, the game is reactivated to live MD3 (+ dedup Sto's triple FRA pick) — shown before/after first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)