### PR TITLE
fix(admin): consistent make-picks / remove / mark-paid across all game modes

### DIFF
--- a/src/app/api/games/[id]/admin/mark-entry-paid/[userId]/route.test.ts
+++ b/src/app/api/games/[id]/admin/mark-entry-paid/[userId]/route.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/auth-helpers', () => ({
+	requireSession: vi.fn().mockResolvedValue({ user: { id: 'admin' } }),
+}))
+
+const { dbMock } = vi.hoisted(() => ({
+	dbMock: {
+		query: {
+			game: { findFirst: vi.fn() },
+			gamePlayer: { findFirst: vi.fn() },
+			payment: { findFirst: vi.fn() },
+		},
+		insert: vi.fn(() => ({
+			values: vi.fn(() => ({
+				returning: vi.fn().mockResolvedValue([{ id: 'pay-new' }]),
+			})),
+		})),
+	},
+}))
+
+vi.mock('@/lib/db', () => ({ db: dbMock }))
+
+import { POST } from './route'
+
+const ctx = (gameId = 'g1', userId = 'u-target') => ({
+	params: Promise.resolve({ id: gameId, userId }),
+})
+const req = () => new Request('http://localhost/mark-entry-paid', { method: 'POST' })
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	dbMock.query.game.findFirst.mockResolvedValue({
+		id: 'g1',
+		createdBy: 'admin',
+		entryFee: '10.00',
+	})
+	dbMock.query.gamePlayer.findFirst.mockResolvedValue({ id: 'gp1', userId: 'u-target' })
+	dbMock.query.payment.findFirst.mockResolvedValue(undefined)
+})
+
+describe('POST mark-entry-paid', () => {
+	it('rejects a non-admin with 403', async () => {
+		dbMock.query.game.findFirst.mockResolvedValue({ id: 'g1', createdBy: 'someone-else' })
+		expect((await POST(req(), ctx())).status).toBe(403)
+	})
+
+	it('404s when the game does not exist', async () => {
+		dbMock.query.game.findFirst.mockResolvedValue(undefined)
+		expect((await POST(req(), ctx())).status).toBe(404)
+	})
+
+	it('404s when the player is not in the game', async () => {
+		dbMock.query.gamePlayer.findFirst.mockResolvedValue(undefined)
+		const res = await POST(req(), ctx())
+		expect(res.status).toBe(404)
+		expect((await res.json()).error).toBe('not-in-game')
+	})
+
+	it('refuses when the player already has a non-refunded payment row', async () => {
+		// Such a player isn't a synthetic "unpaid" row — the admin should use the
+		// existing row's Mark paid / Dispute controls instead of creating a dup.
+		dbMock.query.payment.findFirst.mockResolvedValue({ id: 'p1', status: 'pending' })
+		const res = await POST(req(), ctx())
+		expect(res.status).toBe(400)
+		expect((await res.json()).error).toBe('entry-exists')
+	})
+
+	it('creates a paid entry for a player with no payment row', async () => {
+		const res = await POST(req(), ctx())
+		expect(res.status).toBe(200)
+		const body = await res.json()
+		expect(body.status).toBe('paid')
+		expect(body.paymentId).toBe('pay-new')
+		expect(dbMock.insert).toHaveBeenCalledOnce()
+	})
+})

--- a/src/app/api/games/[id]/admin/mark-entry-paid/[userId]/route.ts
+++ b/src/app/api/games/[id]/admin/mark-entry-paid/[userId]/route.ts
@@ -1,0 +1,66 @@
+import { and, eq, ne } from 'drizzle-orm'
+import { NextResponse } from 'next/server'
+import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { game, gamePlayer } from '@/lib/schema/game'
+import { payment } from '@/lib/schema/payment'
+
+type Ctx = { params: Promise<{ id: string; userId: string }> }
+
+/**
+ * Admin-only: mark a player's entry fee paid when they have NO payment row at
+ * all. This is the case for players added to the game after the deadline (the
+ * add-player flow doesn't create a pending payment), which surface in the admin
+ * payments panel as synthetic "unpaid" rows with no payment id — so the normal
+ * "Mark paid" override (which needs a payment id) isn't reachable for them.
+ *
+ * Creates a `paid` payment row (entry fee, method 'manual'); the pot is derived
+ * from paid payments, so this grows it exactly like confirming any other entry.
+ *
+ * Guarded so it can't duplicate an entry: if the player already has a
+ * non-refunded payment they're not a synthetic row, and the admin should use
+ * that row's existing Mark paid / Dispute controls instead.
+ */
+export async function POST(_request: Request, ctx: Ctx): Promise<Response> {
+	const session = await requireSession()
+	const { id: gameId, userId: targetUserId } = await ctx.params
+
+	const gameRow = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+	if (!gameRow) return NextResponse.json({ error: 'not-found' }, { status: 404 })
+	if (gameRow.createdBy !== session.user.id) {
+		return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+	}
+
+	const playerRow = await db.query.gamePlayer.findFirst({
+		where: and(eq(gamePlayer.gameId, gameId), eq(gamePlayer.userId, targetUserId)),
+	})
+	if (!playerRow) return NextResponse.json({ error: 'not-in-game' }, { status: 404 })
+
+	// Only for players with no live payment row. A refunded row (e.g. an
+	// admin-removed player) doesn't count — re-adding them can take a fresh
+	// paid entry.
+	const existing = await db.query.payment.findFirst({
+		where: and(
+			eq(payment.gameId, gameId),
+			eq(payment.userId, targetUserId),
+			ne(payment.status, 'refunded'),
+		),
+	})
+	if (existing) {
+		return NextResponse.json({ error: 'entry-exists' }, { status: 400 })
+	}
+
+	const [inserted] = await db
+		.insert(payment)
+		.values({
+			gameId,
+			userId: targetUserId,
+			amount: gameRow.entryFee ?? '0.00',
+			status: 'paid',
+			method: 'manual',
+			paidAt: new Date(),
+		})
+		.returning()
+
+	return NextResponse.json({ paymentId: inserted.id, status: 'paid' })
+}

--- a/src/components/game/payments-panel.test.tsx
+++ b/src/components/game/payments-panel.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('sonner', () => ({
+	toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+import { type AdminPayment, PaymentsPanel } from './payments-panel'
+
+const baseProps = {
+	gameId: 'g1',
+	gameName: 'Cup Tuesday',
+	inviteCode: 'ABC123',
+	totals: { confirmed: '30.00', pending: '0.00', total: '30.00' },
+}
+
+function row(overrides: Partial<AdminPayment>): AdminPayment {
+	return {
+		id: 'p1',
+		userId: 'u1',
+		userName: 'Alice',
+		amount: '10.00',
+		status: 'paid',
+		isRebuy: false,
+		isRebuyEligible: false,
+		claimedAt: null,
+		paidAt: null,
+		...overrides,
+	}
+}
+
+describe('PaymentsPanel synthetic (no-payment) rows', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks()
+	})
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('shows a Mark paid button for a late-added player with no payment row', () => {
+		render(
+			<PaymentsPanel
+				{...baseProps}
+				payments={[row({ id: null, status: 'unpaid', userName: 'Philip' })]}
+			/>,
+		)
+		expect(screen.getByRole('button', { name: 'Mark paid' })).toBeTruthy()
+	})
+
+	it('marks a no-payment player paid via the mark-entry-paid endpoint', async () => {
+		const fetchMock = vi
+			.spyOn(globalThis, 'fetch')
+			.mockResolvedValue(new Response(JSON.stringify({ status: 'paid' }), { status: 200 }))
+		render(
+			<PaymentsPanel
+				{...baseProps}
+				payments={[row({ id: null, status: 'unpaid', userId: 'u-philip', userName: 'Philip' })]}
+			/>,
+		)
+		fireEvent.click(screen.getByRole('button', { name: 'Mark paid' }))
+		await waitFor(() =>
+			expect(fetchMock).toHaveBeenCalledWith('/api/games/g1/admin/mark-entry-paid/u-philip', {
+				method: 'POST',
+			}),
+		)
+	})
+
+	it('does not offer the synthetic Mark paid for a real paid row (uses Dispute instead)', () => {
+		render(<PaymentsPanel {...baseProps} payments={[row({ id: 'p1', status: 'paid' })]} />)
+		expect(screen.queryByRole('button', { name: 'Mark paid' })).toBeNull()
+		expect(screen.getByRole('button', { name: 'Dispute' })).toBeTruthy()
+	})
+})

--- a/src/components/game/payments-panel.tsx
+++ b/src/components/game/payments-panel.tsx
@@ -31,8 +31,28 @@ export function PaymentsPanel(props: PaymentsPanelProps) {
 
 	async function callAction(
 		p: AdminPayment,
-		action: 'dispute' | 'admin-rebuy' | 'mark-paid' | 'add-rebuy',
+		action: 'dispute' | 'admin-rebuy' | 'mark-paid' | 'add-rebuy' | 'mark-entry-paid',
 	) {
+		if (action === 'mark-entry-paid') {
+			// A late-added player has no payment row at all (synthetic "unpaid"
+			// row, id === null) so the id-based override can't reach them. Create a
+			// paid entry directly — same effect on the pot as confirming any entry.
+			const res = await fetch(`/api/games/${props.gameId}/admin/mark-entry-paid/${p.userId}`, {
+				method: 'POST',
+			})
+			if (res.ok) {
+				toast.success(`Marked ${p.userName} as paid`)
+				props.onChange?.()
+			} else {
+				const body = await res.json().catch(() => ({ error: 'failed' }))
+				toast.error(
+					body.error === 'entry-exists'
+						? `${p.userName} already has an entry`
+						: 'Failed to mark paid',
+				)
+			}
+			return
+		}
 		if (action === 'add-rebuy') {
 			// Record a rebuy (extra entry) at any stage — even after the rebuy
 			// window. Creates a pending entry; mark it paid (here or by the player)
@@ -169,6 +189,16 @@ export function PaymentsPanel(props: PaymentsPanelProps) {
 											/>
 										)}
 									</>
+								) : p.id === null && p.status === 'unpaid' ? (
+									// Late-added player with no payment row — let the admin record
+									// the entry fee as paid (mirrors pre-deadline entrants' Mark paid).
+									<button
+										type="button"
+										onClick={() => callAction(p, 'mark-entry-paid')}
+										className="rounded border border-[var(--alive)] px-3 py-1.5 text-xs font-semibold text-[var(--alive)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+									>
+										Mark paid
+									</button>
 								) : null}
 							</div>
 						}

--- a/src/components/standings/admin-player-actions.test.tsx
+++ b/src/components/standings/admin-player-actions.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const refresh = vi.fn()
+const toastSuccess = vi.fn()
+const toastError = vi.fn()
+
+vi.mock('next/navigation', () => ({
+	useRouter: () => ({ push: vi.fn(), refresh }),
+}))
+vi.mock('sonner', () => ({
+	toast: { success: (m: string) => toastSuccess(m), error: (m: string) => toastError(m) },
+}))
+
+import { AdminPlayerActions } from './admin-player-actions'
+
+describe('AdminPlayerActions', () => {
+	beforeEach(() => {
+		refresh.mockClear()
+		toastSuccess.mockClear()
+		toastError.mockClear()
+	})
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('links the ✎ action to the acting-as pick flow', () => {
+		render(<AdminPlayerActions gameId="g1" playerId="gp1" userId="u1" playerName="Alice" />)
+		const link = screen.getByTitle('Pick for Alice') as HTMLAnchorElement
+		expect(link.getAttribute('href')).toBe('/game/g1?actingAs=gp1')
+	})
+
+	it('hides the ✕ remove action when there is no userId', () => {
+		render(<AdminPlayerActions gameId="g1" playerId="gp1" playerName="Alice" />)
+		expect(screen.queryByTitle('Remove Alice')).toBeNull()
+	})
+
+	it('removes the player via the endpoint and refreshes on success', async () => {
+		vi.spyOn(window, 'confirm').mockReturnValue(true)
+		const fetchMock = vi
+			.spyOn(globalThis, 'fetch')
+			.mockResolvedValue(new Response(null, { status: 200 }))
+		render(<AdminPlayerActions gameId="g1" playerId="gp1" userId="u1" playerName="Alice" />)
+		fireEvent.click(screen.getByTitle('Remove Alice'))
+		await waitFor(() => expect(refresh).toHaveBeenCalled())
+		expect(fetchMock).toHaveBeenCalledWith('/api/games/g1/admin/remove-player/u1', {
+			method: 'POST',
+		})
+		expect(toastSuccess).toHaveBeenCalledWith('Removed Alice')
+	})
+
+	it('does not call the endpoint when the confirm is dismissed', () => {
+		vi.spyOn(window, 'confirm').mockReturnValue(false)
+		const fetchMock = vi.spyOn(globalThis, 'fetch')
+		render(<AdminPlayerActions gameId="g1" playerId="gp1" userId="u1" playerName="Alice" />)
+		fireEvent.click(screen.getByTitle('Remove Alice'))
+		expect(fetchMock).not.toHaveBeenCalled()
+	})
+
+	it('surfaces the player-has-picks error without refreshing', async () => {
+		vi.spyOn(window, 'confirm').mockReturnValue(true)
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response(JSON.stringify({ error: 'player-has-picks' }), { status: 409 }),
+		)
+		render(<AdminPlayerActions gameId="g1" playerId="gp1" userId="u1" playerName="Alice" />)
+		fireEvent.click(screen.getByTitle('Remove Alice'))
+		await waitFor(() =>
+			expect(toastError).toHaveBeenCalledWith("Can't remove Alice — they've already made a pick"),
+		)
+		expect(refresh).not.toHaveBeenCalled()
+	})
+})

--- a/src/components/standings/admin-player-actions.tsx
+++ b/src/components/standings/admin-player-actions.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+
+interface AdminPlayerActionsProps {
+	gameId: string
+	/** gamePlayer id — the acting-as target for the "make picks" link. */
+	playerId: string
+	/** auth user id — required by the remove-player endpoint. Omit to hide ✕. */
+	userId?: string | null
+	playerName: string
+}
+
+/**
+ * Row-level admin controls shared by every game mode's standings:
+ *   ✎ — make picks for the player (acting-as), persists past the deadline
+ *   ✕ — remove the player from the game (refund + drop from pot)
+ *
+ * Both only make sense for an alive player who hasn't picked the current
+ * round; that gating lives at the call site (and the remove endpoint also
+ * guards "player-has-picks"). Keeping the markup + remove flow in one place
+ * means classic / turbo / cup can't drift out of sync.
+ */
+export function AdminPlayerActions({
+	gameId,
+	playerId,
+	userId,
+	playerName,
+}: AdminPlayerActionsProps) {
+	const router = useRouter()
+
+	async function removePlayer() {
+		if (
+			!window.confirm(
+				`Remove ${playerName} from the game? They haven't picked, so they'll be taken out of the standings and the pot.`,
+			)
+		)
+			return
+		const res = await fetch(`/api/games/${gameId}/admin/remove-player/${userId}`, {
+			method: 'POST',
+		})
+		if (res.ok) {
+			toast.success(`Removed ${playerName}`)
+			router.refresh()
+		} else {
+			const body = (await res.json().catch(() => ({}))) as { error?: string }
+			toast.error(
+				body.error === 'player-has-picks'
+					? `Can't remove ${playerName} — they've already made a pick`
+					: 'Failed to remove player',
+			)
+		}
+	}
+
+	return (
+		<>
+			<a
+				href={`/game/${gameId}?actingAs=${playerId}`}
+				title={`Pick for ${playerName}`}
+				className="ml-2 inline-flex h-6 w-6 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:border-border hover:bg-muted"
+			>
+				✎
+			</a>
+			{userId && (
+				<button
+					type="button"
+					onClick={removePlayer}
+					title={`Remove ${playerName}`}
+					className="ml-1 inline-flex h-6 w-6 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:border-[var(--eliminated)] hover:text-[var(--eliminated)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+				>
+					✕
+				</button>
+			)}
+		</>
+	)
+}

--- a/src/components/standings/cup-grid.tsx
+++ b/src/components/standings/cup-grid.tsx
@@ -3,6 +3,7 @@
 import { useLiveGame } from '@/components/live/use-live-game'
 import type { CupStandingsData } from '@/lib/game/cup-standings-queries'
 import { cn } from '@/lib/utils'
+import { AdminPlayerActions } from './admin-player-actions'
 
 interface CupGridProps {
 	data: CupStandingsData
@@ -215,15 +216,22 @@ function PlayerRow({
 					</Badge>
 				)}
 				{!isOut && liveEliminated && <Badge tone="danger">OUT {roundLabel}</Badge>}
-				{showAdminActions && gameId && !isOut && !player.hasSubmitted && roundStatus === 'open' && (
-					<a
-						href={`/game/${gameId}?actingAs=${player.id}`}
-						title={`Pick for ${player.name}`}
-						className="ml-2 inline-flex h-6 w-6 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:border-border hover:bg-muted"
-					>
-						✎
-					</a>
-				)}
+				{/* Admin make-picks / remove controls. Gated on the round still being
+				    in play (NOT 'open' — the grid only renders post-deadline, when the
+				    derived status is 'active'; gating on 'open' made the ✎ unreachable)
+				    and the player having no picks yet. */}
+				{showAdminActions &&
+					gameId &&
+					!isOut &&
+					!player.hasSubmitted &&
+					roundStatus !== 'completed' && (
+						<AdminPlayerActions
+							gameId={gameId}
+							playerId={player.id}
+							userId={player.userId}
+							playerName={player.name}
+						/>
+					)}
 			</div>
 			<LivesCell remaining={player.livesRemaining} max={maxLives} />
 			<div className="text-center font-bold">{player.streak || '—'}</div>

--- a/src/components/standings/cup-standings.tsx
+++ b/src/components/standings/cup-standings.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react'
 import { Disclosure } from '@/components/ui/disclosure'
 import type { CupLadderData } from '@/lib/game/cup-standings-queries'
 import { cn } from '@/lib/utils'
+import { AdminPlayerActions } from './admin-player-actions'
 import { CupGrid } from './cup-grid'
 import { CupLadder } from './cup-ladder'
 import { CupTimeline } from './cup-timeline'
@@ -19,7 +20,11 @@ interface CupStandingsProps {
 }
 
 export function CupStandings({ data, onShare, showAdminActions, gameId }: CupStandingsProps) {
-	const [view, setView] = useState<ViewMode>('ladder')
+	// Admins default to the grid — it's the only view with per-player rows, so
+	// the make-picks / remove controls live there (the ladder is fixture-centric).
+	const [view, setView] = useState<ViewMode>(showAdminActions ? 'grid' : 'ladder')
+	// `roundStatus === 'open'` is the correct pre-deadline signal: the derived
+	// status flips to 'active' the moment the deadline passes (round-status.ts).
 	const isPreDeadline = data.roundStatus === 'open'
 	const submittedCount = data.players.filter((p) => p.hasSubmitted).length
 	const totalCount = data.players.length
@@ -49,7 +54,7 @@ export function CupStandings({ data, onShare, showAdminActions, gameId }: CupSta
 			}
 		>
 			{isPreDeadline ? (
-				<PreDeadlinePicksStatus data={data} />
+				<PreDeadlinePicksStatus data={data} showAdminActions={showAdminActions} gameId={gameId} />
 			) : (
 				<>
 					<div className="px-4 md:px-5 pt-3 flex flex-wrap items-center gap-2">
@@ -100,7 +105,15 @@ export function CupStandings({ data, onShare, showAdminActions, gameId }: CupSta
  * picks are hidden anyway. Viewer can peek at the full ladder via the
  * inner "Show full standings" disclosure.
  */
-function PreDeadlinePicksStatus({ data }: { data: CupLadderData }) {
+function PreDeadlinePicksStatus({
+	data,
+	showAdminActions,
+	gameId,
+}: {
+	data: CupLadderData
+	showAdminActions?: boolean
+	gameId?: string
+}) {
 	const submitted = data.players.filter((p) => p.hasSubmitted)
 	const pending = data.players.filter((p) => !p.hasSubmitted)
 	const ordered = [...submitted, ...pending]
@@ -134,6 +147,14 @@ function PreDeadlinePicksStatus({ data }: { data: CupLadderData }) {
 							<span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
 								No picks
 							</span>
+						)}
+						{showAdminActions && gameId && !p.hasSubmitted && (
+							<AdminPlayerActions
+								gameId={gameId}
+								playerId={p.id}
+								userId={p.userId}
+								playerName={p.name}
+							/>
 						)}
 					</div>
 				))}

--- a/src/components/standings/progress-grid.tsx
+++ b/src/components/standings/progress-grid.tsx
@@ -1,13 +1,12 @@
 'use client'
 
 import { Eye, EyeOff, Share2, UsersRound } from 'lucide-react'
-import { useRouter } from 'next/navigation'
 import { useState } from 'react'
-import { toast } from 'sonner'
 import { useLiveGame } from '@/components/live/use-live-game'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { AdminPlayerActions } from './admin-player-actions'
 import { GridFilter } from './grid-filter'
 import { type GridSort, type GridSortDir, type GridSortKey, sortGridPlayers } from './grid-sort'
 
@@ -109,31 +108,6 @@ export function ProgressGrid({
 	const [showOpponents, setShowOpponents] = useState(false)
 	const [hideEliminated, setHideEliminated] = useState(false)
 	const liveCtx = useLiveGame()
-	const router = useRouter()
-
-	async function removePlayer(userId: string, name: string) {
-		if (!gameId) return
-		if (
-			!window.confirm(
-				`Remove ${name} from the game? They haven't picked, so they'll be taken out of the standings and the pot.`,
-			)
-		)
-			return
-		const res = await fetch(`/api/games/${gameId}/admin/remove-player/${userId}`, {
-			method: 'POST',
-		})
-		if (res.ok) {
-			toast.success(`Removed ${name}`)
-			router.refresh()
-		} else {
-			const body = (await res.json().catch(() => ({}))) as { error?: string }
-			toast.error(
-				body.error === 'player-has-picks'
-					? `Can't remove ${name} — they've already made a pick`
-					: 'Failed to remove player',
-			)
-		}
-	}
 
 	// Click a column header to sort by it; click the active one again to flip
 	// direction. Round columns sort by the team picked that gameweek.
@@ -392,25 +366,12 @@ export function ProgressGrid({
 												currentRoundId &&
 												player.status === 'alive' &&
 												player.cellsByRoundId[currentRoundId]?.result === 'no_pick' && (
-													<>
-														<a
-															href={`/game/${gameId}?actingAs=${player.id}`}
-															title={`Pick for ${player.name}`}
-															className="ml-2 inline-flex h-6 w-6 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:border-border hover:bg-muted"
-														>
-															✎
-														</a>
-														{player.userId && (
-															<button
-																type="button"
-																onClick={() => removePlayer(player.userId as string, player.name)}
-																title={`Remove ${player.name}`}
-																className="ml-1 inline-flex h-6 w-6 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:border-[var(--eliminated)] hover:text-[var(--eliminated)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-															>
-																✕
-															</button>
-														)}
-													</>
+													<AdminPlayerActions
+														gameId={gameId}
+														playerId={player.id}
+														userId={player.userId}
+														playerName={player.name}
+													/>
 												)}
 										</td>
 										{visibleRounds.map((r) => {

--- a/src/components/standings/turbo-standings.tsx
+++ b/src/components/standings/turbo-standings.tsx
@@ -6,6 +6,7 @@ import { useLiveGame } from '@/components/live/use-live-game'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { AdminPlayerActions } from './admin-player-actions'
 import { type LadderFixture, TurboLadder } from './turbo-ladder'
 import { TurboTimeline } from './turbo-timeline'
 
@@ -32,6 +33,12 @@ export interface TurboPickCell {
 
 export interface TurboPlayerRow {
 	id: string
+	/**
+	 * auth user id — needed by the admin remove-player control. Optional because
+	 * the share-image render path builds these rows without it (no admin UI
+	 * there); the live standings query (getTurboStandingsData) always sets it.
+	 */
+	userId?: string
 	name: string
 	picks: TurboPickCell[] // exactly numberOfPicks entries (or fewer if player hasn't submitted)
 	streak: number
@@ -70,7 +77,9 @@ export function TurboStandings({
 }: TurboStandingsProps) {
 	const initial = rounds[rounds.length - 1]?.id
 	const [roundId, setRoundId] = useState<string>(initial ?? '')
-	const [view, setView] = useState<ViewMode>('ladder')
+	// Admins default to the grid — the per-player make-picks / remove controls
+	// live in that view (the ladder is fixture-centric).
+	const [view, setView] = useState<ViewMode>(showAdminActions ? 'grid' : 'ladder')
 	const liveCtx = useLiveGame()
 	const round = rounds.find((r) => r.id === roundId) ?? rounds[rounds.length - 1]
 
@@ -347,17 +356,18 @@ function GridView({
 												no picks
 											</span>
 										)}
+										{/* Admin make-picks / remove controls — persist past the deadline
+										    (gating on 'open' hid them the moment the round went 'active'). */}
 										{showAdminActions &&
 											gameId &&
 											!player.hasSubmitted &&
-											roundStatus === 'open' && (
-												<a
-													href={`/game/${gameId}?actingAs=${player.id}`}
-													title={`Pick for ${player.name}`}
-													className="ml-2 inline-flex h-6 w-6 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:border-border hover:bg-muted"
-												>
-													✎
-												</a>
+											roundStatus !== 'completed' && (
+												<AdminPlayerActions
+													gameId={gameId}
+													playerId={player.id}
+													userId={player.userId}
+													playerName={player.name}
+												/>
 											)}
 									</td>
 									<td className="text-center px-2 py-2 font-display font-semibold text-lg">

--- a/src/lib/game/cup-standings-queries.test.ts
+++ b/src/lib/game/cup-standings-queries.test.ts
@@ -49,6 +49,47 @@ describe('getCupStandingsData', () => {
 		expect(await getCupStandingsData('g1', 'u1')).toBeNull()
 	})
 
+	it('excludes admin_removed players from the standings', async () => {
+		// An admin who removes a late/no-pick player must not see them linger in
+		// the cup ladder/grid — mirrors the classic + turbo standings filters.
+		const round = {
+			id: 'r1',
+			number: 1,
+			status: 'open' as const,
+			deadline: new Date('2026-05-01T12:00:00Z'),
+			fixtures: [],
+		}
+		findFirstMock.mockResolvedValue({
+			id: 'g',
+			currentRoundId: 'r1',
+			currentRound: round,
+			players: [
+				{ id: 'gp1', userId: 'u1', status: 'alive', livesRemaining: 3, eliminatedReason: null },
+				{
+					id: 'gp2',
+					userId: 'u2',
+					status: 'eliminated',
+					livesRemaining: 0,
+					eliminatedReason: 'admin_removed',
+				},
+			],
+			competition: { type: 'group_knockout', rounds: [round] },
+			modeConfig: { startingLives: 3, numberOfPicks: 6 },
+		})
+		findManyMock.mockResolvedValue([])
+		selectMock.mockReturnValue({
+			from: () => ({
+				where: () =>
+					Promise.resolve([
+						{ id: 'u1', name: 'Alice' },
+						{ id: 'u2', name: 'Bob' },
+					]),
+			}),
+		})
+		const result = await getCupStandingsData('g', 'u1')
+		expect(result?.players.map((p) => p.id)).toEqual(['gp1'])
+	})
+
 	it('falls back to the latest round with picks when game has completed (currentRound is null)', async () => {
 		// Game completed: applyAutoCompletion has set currentRoundId=null. The ladder
 		// should still render, showing the round where the trophy was decided.

--- a/src/lib/game/cup-standings-queries.ts
+++ b/src/lib/game/cup-standings-queries.ts
@@ -151,71 +151,73 @@ export async function getCupStandingsData(
 	const hideOpenPicks =
 		displayRound.status !== 'completed' && (!displayRound.deadline || now < displayRound.deadline)
 
-	const players: CupStandingsPlayer[] = g.players.map((p) => {
-		const isViewer = p.userId === viewerUserId
-		const myPicks = allPicks.filter((pk) => pk.gamePlayerId === p.id)
-		const picks: CupStandingsPick[] = myPicks.map((pk) => {
-			const fx = displayRound.fixtures.find((f) => f.id === pk.fixtureId)
-			if (!fx) {
-				// Shouldn't happen — pick referencing a fixture not in the round — but
-				// be defensive rather than throwing at the query layer.
+	const players: CupStandingsPlayer[] = g.players
+		.filter((p) => p.eliminatedReason !== 'admin_removed')
+		.map((p) => {
+			const isViewer = p.userId === viewerUserId
+			const myPicks = allPicks.filter((pk) => pk.gamePlayerId === p.id)
+			const picks: CupStandingsPick[] = myPicks.map((pk) => {
+				const fx = displayRound.fixtures.find((f) => f.id === pk.fixtureId)
+				if (!fx) {
+					// Shouldn't happen — pick referencing a fixture not in the round — but
+					// be defensive rather than throwing at the query layer.
+					return {
+						gamePlayerId: p.id,
+						confidenceRank: pk.confidenceRank ?? 0,
+						fixtureId: pk.fixtureId ?? '',
+						homeShort: '?',
+						awayShort: '?',
+						pickedTeamId: pk.teamId,
+						pickedSide: 'home' as const,
+						tierDifference: 0,
+						result: 'pending' as const,
+						livesGained: 0,
+						livesSpent: 0,
+						goalsCounted: pk.goalsScored ?? 0,
+					}
+				}
+				const pickedSide: 'home' | 'away' = pk.teamId === fx.homeTeamId ? 'home' : 'away'
+				const tierFromHome = computeTierDifference(fx.homeTeam, fx.awayTeam, g.competition.type)
+				const tierFromPicked = pickedSide === 'home' ? tierFromHome : -tierFromHome
+				const hidden = hideOpenPicks && !isViewer
+				// Pending picks on in-progress fixtures project as winning / losing
+				// based on current score — same visual as a settled pick. Cup-
+				// specific outcomes (draw_success, saved_by_life) only appear post-
+				// settlement when the streak/lives state is known.
+				const mapped =
+					pk.result === 'pending'
+						? projectCupCellFromFixture(pickedSide, fx)
+						: mapPickResult(pk.result)
 				return {
 					gamePlayerId: p.id,
 					confidenceRank: pk.confidenceRank ?? 0,
-					fixtureId: pk.fixtureId ?? '',
-					homeShort: '?',
-					awayShort: '?',
+					fixtureId: fx.id,
+					homeShort: fx.homeTeam.shortName,
+					awayShort: fx.awayTeam.shortName,
 					pickedTeamId: pk.teamId,
-					pickedSide: 'home' as const,
-					tierDifference: 0,
-					result: 'pending' as const,
-					livesGained: 0,
-					livesSpent: 0,
+					pickedSide,
+					tierDifference: tierFromPicked,
+					result: hidden ? 'hidden' : mapped,
+					livesGained: hidden ? 0 : computeLivesGained(pk),
+					livesSpent: hidden ? 0 : computeLivesSpent(pk),
 					goalsCounted: pk.goalsScored ?? 0,
 				}
-			}
-			const pickedSide: 'home' | 'away' = pk.teamId === fx.homeTeamId ? 'home' : 'away'
-			const tierFromHome = computeTierDifference(fx.homeTeam, fx.awayTeam, g.competition.type)
-			const tierFromPicked = pickedSide === 'home' ? tierFromHome : -tierFromHome
-			const hidden = hideOpenPicks && !isViewer
-			// Pending picks on in-progress fixtures project as winning / losing
-			// based on current score — same visual as a settled pick. Cup-
-			// specific outcomes (draw_success, saved_by_life) only appear post-
-			// settlement when the streak/lives state is known.
-			const mapped =
-				pk.result === 'pending'
-					? projectCupCellFromFixture(pickedSide, fx)
-					: mapPickResult(pk.result)
+			})
+			const streak = computeStreak(picks)
 			return {
-				gamePlayerId: p.id,
-				confidenceRank: pk.confidenceRank ?? 0,
-				fixtureId: fx.id,
-				homeShort: fx.homeTeam.shortName,
-				awayShort: fx.awayTeam.shortName,
-				pickedTeamId: pk.teamId,
-				pickedSide,
-				tierDifference: tierFromPicked,
-				result: hidden ? 'hidden' : mapped,
-				livesGained: hidden ? 0 : computeLivesGained(pk),
-				livesSpent: hidden ? 0 : computeLivesSpent(pk),
-				goalsCounted: pk.goalsScored ?? 0,
+				id: p.id,
+				userId: p.userId,
+				name: userNames.get(p.userId) ?? 'Player',
+				status: p.status,
+				livesRemaining: p.livesRemaining,
+				streak,
+				goals: picks.reduce((sum, pk) => sum + pk.goalsCounted, 0),
+				hasSubmitted: myPicks.length > 0,
+				eliminatedRoundNumber: null,
+				eliminatedRoundLabel: null,
+				picks,
 			}
 		})
-		const streak = computeStreak(picks)
-		return {
-			id: p.id,
-			userId: p.userId,
-			name: userNames.get(p.userId) ?? 'Player',
-			status: p.status,
-			livesRemaining: p.livesRemaining,
-			streak,
-			goals: picks.reduce((sum, pk) => sum + pk.goalsCounted, 0),
-			hasSubmitted: myPicks.length > 0,
-			eliminatedRoundNumber: null,
-			eliminatedRoundLabel: null,
-			picks,
-		}
-	})
 
 	const competitionType = g.competition.type as 'league' | 'knockout' | 'group_knockout'
 

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -688,6 +688,7 @@ export async function getTurboStandingsData(
 
 				return {
 					id: p.id,
+					userId: p.userId,
 					name: userNames.get(p.userId) ?? 'Player',
 					picks: cells,
 					streak,


### PR DESCRIPTION
## Why

Auditing admin functionality across the three modes surfaced real inconsistencies — and a live bug in a cup game (a late-added player whose picks the admin could only set transiently right after adding them).

| Capability | classic | turbo | cup |
|---|---|---|---|
| Make picks (✎) | ✅ persistent | ⚠️ vanished post-deadline | ❌ unreachable |
| Remove player (✕) | ✅ | ❌ | ❌ |
| `admin_removed` hidden from standings | ✅ | ✅ | ❌ data bug |
| Mark a *late/no-payment* player paid | ❌ | ❌ | ❌ (shared gap) |

**Root cause (cup/turbo make-picks):** the ✎ was gated on `roundStatus === 'open'`, but the derived round status flips to `'active'` the moment the deadline passes (`round-status.ts`). In cup the grid only renders post-deadline, so the ✎ was *never* reachable; the ladder (the admin's default view) had no controls at all.

**Payments gap (all modes):** a player added after the deadline has no payment row, so they surface as a synthetic “unpaid” row with **no action** — the existing Mark paid override needs a payment id.

## Changes

- **Shared `AdminPlayerActions`** (✎ make-picks + ✕ remove) now used by classic / turbo / cup, so the row controls can't drift again. Classic refactored onto it (behaviour unchanged).
- **cup + turbo:** controls persist past the deadline (`roundStatus !== 'completed'`); admins default to the **grid** view (the only per-player view); cup's pre-deadline status also gets ✎/✕.
- **`getCupStandingsData`:** excludes `admin_removed` players (parity with classic + turbo).
- **New `POST /api/games/[id]/admin/mark-entry-paid/[userId]`:** creates a `paid` entry for a player with no payment row (late adds). Pot is derived from paid payments, so it grows like any other entry. Panel shows a **Mark paid** button on synthetic rows.

## Testing

- Unit: cup `admin_removed` filter (RED→GREEN), `AdminPlayerActions`, the new endpoint, and the payments synthetic mark-paid branch. Full suite **511 passing**.
- typecheck ✓ · biome ✓ · build ✓
- **Authenticated SSR on the dev server:** cup / turbo / classic game pages all return 200 with the ✎/✕ controls rendering (no RSC boundary errors).

> Note: the live cup-game state (late-added player's picks reassigned to the right user, dummy removed) was tidied separately via an approved, dry-run-first prod correction. This PR is the code fix so it can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)