### PR TITLE
fix(settlement): QStash callbacks pinned to stale deployment + cup/turbo crown guard

### DIFF
--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -17,7 +17,7 @@
  * Adding a new competition? Add a scenario for each supported mode here.
  * See `docs/superpowers/specs/2026-05-12-per-fixture-settlement-and-live-projection-design.md`.
  */
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 import { db } from '@/lib/db'
 import { getCupLadderData, getCupStandingsData } from '@/lib/game/cup-standings-queries'
@@ -664,6 +664,75 @@ describe('lifecycle: cup-WC', () => {
 		const hero = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gpHero) })
 		expect(hero?.livesRemaining).toBe(3)
 		expect(hero?.status).toBe('alive')
+	})
+
+	it('does NOT crown while a higher-confidence pick is unplayed — the 1f0d292d mis-crowning', async () => {
+		// Mirrors the incident: rank-1 pick on an UNPLAYED fixture, rank-2 on a
+		// played one. The gameweek is incomplete → no winner, no payout, game stays
+		// active. Guards against premature cup completion (e.g. stale code).
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		const a = await makeTeam({ name: 'Aaa', shortName: 'AAA', fifaPot: 2 })
+		const b = await makeTeam({ name: 'Bbb', shortName: 'BBB', fifaPot: 2 })
+		const c = await makeTeam({ name: 'Ccc', shortName: 'CCC', fifaPot: 2 })
+		const d = await makeTeam({ name: 'Ddd', shortName: 'DDD', fifaPot: 2 })
+		const r1 = await makeRound(compId, { number: 1, status: 'open' })
+		const fxPlayed = await makeFixture({ roundId: r1, homeTeamId: a, awayTeamId: b })
+		const fxUnplayed = await makeFixture({ roundId: r1, homeTeamId: c, awayTeamId: d })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'cup',
+			currentRoundId: r1,
+			modeConfig: { numberOfPicks: 2, startingLives: 0 },
+		})
+		const gp1 = await makePlayer({ gameId, userId: 'u-1', livesRemaining: 0 })
+		const gp2 = await makePlayer({ gameId, userId: 'u-2', livesRemaining: 0 })
+		// rank-1 on the UNPLAYED fixture for both; rank-2 on the played one.
+		await makePick({
+			gameId,
+			gamePlayerId: gp1,
+			roundId: r1,
+			teamId: c,
+			fixtureId: fxUnplayed,
+			confidenceRank: 1,
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gp1,
+			roundId: r1,
+			teamId: a,
+			fixtureId: fxPlayed,
+			confidenceRank: 2,
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gp2,
+			roundId: r1,
+			teamId: d,
+			fixtureId: fxUnplayed,
+			confidenceRank: 1,
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gp2,
+			roundId: r1,
+			teamId: b,
+			fixtureId: fxPlayed,
+			confidenceRank: 2,
+		})
+
+		await finishFixture(fxPlayed, 1, 0)
+		await settleFixture(fxPlayed)
+
+		const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+		expect(g?.status).toBe('active') // gameweek incomplete → not crowned
+		const payouts = await db.query.payout.findMany({ where: eq(payout.gameId, gameId) })
+		expect(payouts).toHaveLength(0)
+		// the rank-2 (played) pick stays pending behind the unplayed rank-1.
+		const r2 = await db.query.pick.findFirst({
+			where: and(eq(pick.gamePlayerId, gp1), eq(pick.confidenceRank, 2)),
+		})
+		expect(r2?.result).toBe('pending')
 	})
 
 	it('cup re-eval is idempotent — re-settling the same fixture changes nothing', async () => {

--- a/src/lib/data/qstash.test.ts
+++ b/src/lib/data/qstash.test.ts
@@ -20,7 +20,25 @@ describe('qstash helpers', () => {
 	beforeEach(() => {
 		publishJSONMock.mockClear()
 		process.env.QSTASH_TOKEN = 'qs-token'
+		// Existing cases exercise the VERCEL_URL fallback (stable origin unset).
+		process.env.NEXT_PUBLIC_APP_URL = ''
 		process.env.VERCEL_URL = 'https://example.com'
+	})
+
+	it('prefers the stable NEXT_PUBLIC_APP_URL over the per-deployment VERCEL_URL', async () => {
+		// The fix: jobs must target the stable production origin so a job queued
+		// by an old deployment still runs CURRENT code (not the old deployment's).
+		process.env.NEXT_PUBLIC_APP_URL = 'https://last-person-standing.app'
+		process.env.VERCEL_URL = 'https://last-person-standing-oldhash.vercel.app'
+		process.env.CRON_SECRET = 'shh'
+		await enqueuePollScoresAt(new Date('2026-06-26T18:50:00Z'), 'dedup-1')
+		await enqueueProcessRound('g', 'r')
+		expect(publishJSONMock.mock.calls[0][0].url).toBe(
+			'https://last-person-standing.app/api/cron/poll-scores',
+		)
+		expect(publishJSONMock.mock.calls[1][0].url).toBe(
+			'https://last-person-standing.app/api/cron/qstash-handler',
+		)
 	})
 
 	it('enqueues a process-round message with a 2-minute delay', async () => {

--- a/src/lib/data/qstash.ts
+++ b/src/lib/data/qstash.ts
@@ -5,11 +5,34 @@ export type QStashJob =
 	| { type: 'deadline_reminder'; gameId: string; roundId: string; window: '24h' | '2h' }
 	| { type: 'auto_submit'; gamePlayerId: string; roundId: string; teamId: string }
 
+/**
+ * Stable callback origin for QStash jobs.
+ *
+ * MUST prefer the stable production domain (`NEXT_PUBLIC_APP_URL`) over
+ * `VERCEL_URL`. `VERCEL_URL` is the *per-deployment* immutable URL
+ * (`…-<hash>.vercel.app`); pinning callbacks to it means a job scheduled by an
+ * old deployment fires against THAT deployment's code when it runs. Because
+ * fixture-kickoff polls are pre-scheduled up to 7 days ahead (see
+ * `scheduleUpcomingFixturePolls`) and the poll chain self-perpetuates, a fix
+ * deployed today can be silently undone for up to a week by stale jobs still
+ * hitting the old deployment. This caused a cup game to be crowned mid-gameweek
+ * by week-old buggy code even though current production was correct.
+ *
+ * `NEXT_PUBLIC_APP_URL` is the custom production domain (last-person-standing.app)
+ * and always resolves to the current production deployment, so every job — no
+ * matter which deployment queued it — runs current code. Falls back to
+ * `VERCEL_URL` only when the stable origin isn't configured (local/dev).
+ */
+function callbackBase(): string {
+	const base = process.env.NEXT_PUBLIC_APP_URL || process.env.VERCEL_URL || ''
+	if (!base) {
+		throw new Error('NEXT_PUBLIC_APP_URL (or VERCEL_URL) must be set to enqueue QStash messages')
+	}
+	return base.startsWith('http') ? base : `https://${base}`
+}
+
 function handlerUrl(): string {
-	const base = process.env.VERCEL_URL ?? ''
-	if (!base) throw new Error('VERCEL_URL must be set to enqueue QStash messages')
-	const withScheme = base.startsWith('http') ? base : `https://${base}`
-	return `${withScheme}/api/cron/qstash-handler`
+	return `${callbackBase()}/api/cron/qstash-handler`
 }
 
 function client(): Client {
@@ -62,13 +85,10 @@ export async function enqueueAutoSubmit(
  * security envelope as a GH Actions secret).
  */
 export async function enqueuePollScores(delaySeconds = 60): Promise<void> {
-	const base = process.env.VERCEL_URL ?? ''
-	if (!base) throw new Error('VERCEL_URL must be set to enqueue poll-scores')
 	const cronSecret = process.env.CRON_SECRET
 	if (!cronSecret) throw new Error('CRON_SECRET must be set to enqueue poll-scores')
-	const withScheme = base.startsWith('http') ? base : `https://${base}`
 	await client().publishJSON({
-		url: `${withScheme}/api/cron/poll-scores`,
+		url: `${callbackBase()}/api/cron/poll-scores`,
 		body: { source: 'qstash-loop' },
 		headers: { Authorization: `Bearer ${cronSecret}` },
 		delay: delaySeconds,
@@ -88,13 +108,10 @@ export async function enqueuePollScores(delaySeconds = 60): Promise<void> {
  * default, so two bootstrap runs within that window won't double up.
  */
 export async function enqueuePollScoresAt(notBefore: Date, dedupId?: string): Promise<void> {
-	const base = process.env.VERCEL_URL ?? ''
-	if (!base) throw new Error('VERCEL_URL must be set to enqueue poll-scores')
 	const cronSecret = process.env.CRON_SECRET
 	if (!cronSecret) throw new Error('CRON_SECRET must be set to enqueue poll-scores')
-	const withScheme = base.startsWith('http') ? base : `https://${base}`
 	await client().publishJSON({
-		url: `${withScheme}/api/cron/poll-scores`,
+		url: `${callbackBase()}/api/cron/poll-scores`,
 		body: { source: 'fixture-kickoff' },
 		headers: { Authorization: `Bearer ${cronSecret}` },
 		notBefore: Math.floor(notBefore.getTime() / 1000),

--- a/src/lib/game/auto-complete.test.ts
+++ b/src/lib/game/auto-complete.test.ts
@@ -406,4 +406,23 @@ describe('checkCupCompletion (single gameweek — longest streak)', () => {
 		const result = await checkCupCompletion('g1')
 		expect(result.completed).toBe(false)
 	})
+
+	it('refuses to complete while ANY pick is still pending — the 1f0d292d invariant guard', async () => {
+		// Even with settled picks present, a single pending pick means the
+		// gameweek is incomplete → no crown. Independent of the caller's
+		// allFinished gate (which stale code defeated in prod).
+		dbMock.query.gamePlayer.findMany.mockResolvedValue([
+			{ id: 'p1', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+			{ id: 'p2', status: 'eliminated', eliminatedRoundId: 'r1', livesRemaining: 0 },
+		] as never)
+		dbMock.query.pick.findMany.mockResolvedValue([
+			cupPick('p1', 1, 'win', 3),
+			cupPick('p2', 1, 'pending'), // a fixture hasn't been played yet
+			cupPick('p2', 2, 'win', 5),
+		] as never)
+
+		const result = await checkCupCompletion('g1')
+		expect(result.completed).toBe(false)
+		expect(result.winnerPlayerIds).toEqual([])
+	})
 })

--- a/src/lib/game/auto-complete.ts
+++ b/src/lib/game/auto-complete.ts
@@ -171,6 +171,21 @@ export async function checkCupCompletion(gameId: string): Promise<CompletionChec
 		where: eq(pick.gameId, gameId),
 		with: { fixture: true },
 	})
+
+	// Authoritative invariant guard, independent of the caller's fixture-derived
+	// `allFinished` gate: a cup game is a single gameweek and may only be crowned
+	// once EVERY pick has a final result. If any pick is still `pending`, a fixture
+	// hasn't been played/settled — crowning now would decide the game on an
+	// incomplete gameweek (the 1f0d292d incident, where stale code crowned a
+	// winner whose rank-1 pick hadn't kicked off). This holds even if `allFinished`
+	// is satisfied wrongly (e.g. stale code / transient fixture state).
+	const pendingCount = allPicks.filter((p) => p.result === 'pending').length
+	if (pendingCount > 0) {
+		console.warn(
+			`[checkCupCompletion] refusing to complete game ${gameId}: ${pendingCount} pending pick(s) — gameweek incomplete`,
+		)
+		return { completed: false, winnerPlayerIds: [] }
+	}
 	const players: WipeoutPlayerInput[] = allPlayers.map((p) => ({
 		gamePlayerId: p.id,
 		livesRemaining: p.livesRemaining,

--- a/src/lib/game/settle.ts
+++ b/src/lib/game/settle.ts
@@ -453,6 +453,20 @@ async function checkAndMaybeCompleteOrAdvance(
 		return
 	} else if (g.gameMode === 'turbo') {
 		if (!allFinished) return
+		// Authoritative invariant guard (independent of the fixture-derived
+		// `allFinished`): never crown while any pick in the round is still
+		// `pending`. Mirrors the cup guard — protects against stale code or a
+		// transient fixture state satisfying `allFinished` wrongly.
+		const roundPicks = await db.query.pick.findMany({
+			where: and(eq(pick.gameId, gameId), eq(pick.roundId, roundId)),
+		})
+		const pendingTurbo = roundPicks.filter((p) => p.result === 'pending').length
+		if (pendingTurbo > 0) {
+			console.warn(
+				`[checkAndMaybeCompleteOrAdvance] refusing to complete turbo game ${gameId}: ${pendingTurbo} pending pick(s)`,
+			)
+			return
+		}
 		const turboPlayerResults = await collectTurboPlayerResults(gameId, roundId)
 		const completion = checkTurboCompletion(turboPlayerResults)
 		await applyAutoCompletion(gameId, completion.winnerPlayerIds, { refund: completion.refund })


### PR DESCRIPTION
## Root cause of the recurring game-state failures

QStash callback URLs were built from **`VERCEL_URL`** — the **per-deployment, immutable** URL (`…-<hash>.vercel.app`). Live-score polls are **pre-scheduled per fixture-kickoff up to 7 days ahead** (`scheduleUpcomingFixturePolls`, `PRE_SCHEDULE_LOOKAHEAD_MS = 7d`), and the poll chain self-perpetuates. So a job scheduled by an **old deployment** fires against **that deployment's code** when the fixture kicks off — meaning **a deployed fix can be silently undone for up to a week** by stale jobs still running old code.

Confirmed via the QStash event log: the live chain was calling `https://last-person-standing-6hdm3j37h-…vercel.app/api/cron/poll-scores` (a deployment URL, not the production domain).

This crowned cup game `1f0d292d` mid-gameweek (winner's rank-1 pick hadn't kicked off) using **week-old pre-#80 cup logic**, even though current production was correct — which is why the data was impossible to reproduce against the deployed code.

## Fixes

1. **`qstash.ts`** — build callback URLs from the stable **`NEXT_PUBLIC_APP_URL`** (`last-person-standing.app`), falling back to `VERCEL_URL` only when unset (local/dev). Every job now hits **current** production code regardless of which deployment queued it.

2. **Defense-in-depth invariant guard** (independent of the fixture-derived `allFinished` gate): `checkCupCompletion` and the turbo completion branch **refuse to crown while any pick in the deciding round is still `pending`**, and log a warning. This holds even if `allFinished` is satisfied wrongly (stale code / transient fixture state) — so the failure class is impossible going forward, and any future near-miss is logged.

## Tests
- qstash: asserts `NEXT_PUBLIC_APP_URL` takes precedence over `VERCEL_URL`.
- `checkCupCompletion`: refuses to complete with a pending pick present.
- smoke: reproduces the `1f0d292d` shape (rank-1 unplayed → no crown, game stays active, rank-2 stays pending).
- Full: typecheck · biome · unit · smoke 37/37 · build.

## Operational follow-up (this PR doesn't do it)
Already-scheduled QStash jobs pinned to old deployments must be **flushed** after this deploys (they won't be redirected) so they don't fire old code at upcoming kickoffs. Both reactivated games (`1f0d292d`, `dc857c5f`) re-verified after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)