### PR TITLE
fix(live-scores): collapse parallel poll chains into one (QStash quota)

### DIFF
--- a/src/app/api/cron/poll-scores/route.ts
+++ b/src/app/api/cron/poll-scores/route.ts
@@ -128,13 +128,13 @@ async function pollScores(apiKey: string): Promise<NextResponse> {
 	}
 
 	// Self-perpetuating chain: GitHub Actions free-tier crons run every ~60-90
-	// minutes in practice (despite the `* * * * *` schedule), which is far too
-	// slow for live football scoring. To get true per-minute polling during
-	// match windows, this route enqueues the next call to itself via QStash
-	// with a 60s delay. The chain self-terminates when hasActiveFixture()
-	// returns false at the top of a future call. The hourly heartbeat from
-	// GitHub Actions restarts the chain after any breakage.
-	await enqueuePollScores(60)
+	// minutes in practice (despite the `* * * * *` schedule), too slow for live
+	// football scoring. This route enqueues the next call to itself via QStash to
+	// poll at the chain interval during match windows; it self-terminates when
+	// hasActiveFixture() returns false on a future call, and the GitHub Actions
+	// heartbeat restarts it after any breakage. enqueuePollScores grid-aligns +
+	// dedups the next link, so concurrent chains collapse into one (quota-safe).
+	await enqueuePollScores()
 
 	return NextResponse.json({ updated: totalUpdated, chained: true })
 }

--- a/src/lib/data/qstash.test.ts
+++ b/src/lib/data/qstash.test.ts
@@ -78,23 +78,41 @@ describe('qstash helpers', () => {
 		expect(call.notBefore).toBe(Math.floor(notBefore.getTime() / 1000))
 	})
 
-	it('enqueuePollScores posts to /api/cron/poll-scores with bearer auth and default 60s delay', async () => {
+	it('enqueuePollScores posts to poll-scores grid-aligned with a slot dedup id', async () => {
 		process.env.CRON_SECRET = 'shh'
-		await enqueuePollScores()
-		expect(publishJSONMock).toHaveBeenCalledWith(
-			expect.objectContaining({
-				url: 'https://example.com/api/cron/poll-scores',
-				body: { source: 'qstash-loop' },
-				headers: { Authorization: 'Bearer shh' },
-				delay: 60,
-			}),
-		)
+		const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000_000_000_000) // fixed clock
+		try {
+			await enqueuePollScores() // default 90s interval
+			const call = publishJSONMock.mock.calls[0][0]
+			expect(call.url).toBe('https://example.com/api/cron/poll-scores')
+			expect(call.body).toEqual({ source: 'qstash-loop' })
+			expect(call.headers).toEqual({ Authorization: 'Bearer shh' })
+			expect(call.delay).toBeUndefined() // grid-aligned via notBefore, not delay
+			// notBefore is on the 90s grid and at least one interval in the future.
+			expect(call.notBefore % 90).toBe(0)
+			expect(call.notBefore * 1000).toBeGreaterThan(1_000_000_000_000)
+			// dedup id is tied to the slot → concurrent enqueues collapse to one.
+			expect(call.deduplicationId).toBe(`poll-loop-${call.notBefore}`)
+		} finally {
+			nowSpy.mockRestore()
+		}
 	})
 
-	it('enqueuePollScores honours a custom delay', async () => {
+	it('enqueuePollScores collapses concurrent chains: same slot → same dedup id', async () => {
 		process.env.CRON_SECRET = 'shh'
-		await enqueuePollScores(5)
-		expect(publishJSONMock.mock.calls[0][0].delay).toBe(5)
+		// Two calls at slightly different times within the same 90s slot must
+		// produce the identical deduplicationId so QStash accepts only one.
+		const spy = vi.spyOn(Date, 'now').mockReturnValue(1_000_000_000_000)
+		try {
+			await enqueuePollScores()
+			spy.mockReturnValue(1_000_000_010_000) // +10s, same 90s slot
+			await enqueuePollScores()
+			const a = publishJSONMock.mock.calls[0][0].deduplicationId
+			const b = publishJSONMock.mock.calls[1][0].deduplicationId
+			expect(a).toBe(b)
+		} finally {
+			spy.mockRestore()
+		}
 	})
 
 	it('enqueuePollScores throws when CRON_SECRET is missing', async () => {

--- a/src/lib/data/qstash.ts
+++ b/src/lib/data/qstash.ts
@@ -76,22 +76,41 @@ export async function enqueueAutoSubmit(
 }
 
 /**
- * Enqueue another call to /api/cron/poll-scores with the given delay (seconds).
- * Used to build a self-perpetuating chain during live match windows where
- * GitHub Actions free-tier scheduling can't deliver per-minute reliability.
- *
- * The route's CRON_SECRET bearer auth is satisfied via a forwarded
- * Authorization header (QStash sends the literal value verbatim — same
- * security envelope as a GH Actions secret).
+ * Default poll-chain interval (seconds). 90s (not 60s) so a full day of live
+ * coverage stays under the QStash free-tier 1000-msgs/day cap.
  */
-export async function enqueuePollScores(delaySeconds = 60): Promise<void> {
+export const POLL_CHAIN_INTERVAL_SECONDS = 90
+
+/**
+ * Enqueue the next /api/cron/poll-scores call to continue the live-score chain.
+ *
+ * SINGLE-CHAIN GUARANTEE: the next trigger is aligned to a fixed time grid and
+ * deduplicated on that grid slot. Every poll-scores invocation in the same slot
+ * — whether from one chain, several parallel chains, or a burst of fixture-kickoff
+ * triggers — enqueues the SAME (notBefore, deduplicationId), so QStash accepts
+ * exactly one. This collapses concurrent chains into a single chain.
+ *
+ * Without it, each invocation blindly enqueued a fresh link, so N starts → N
+ * self-perpetuating chains → N× the QStash quota. In production ~8 parallel
+ * chains burned ~480 msgs/hour and exhausted the daily cap in ~2h, which then
+ * 500s the chain entirely. The grid+dedup makes the chain converge back to one.
+ *
+ * The route's CRON_SECRET bearer auth is satisfied via a forwarded Authorization
+ * header (QStash sends the literal value verbatim — same envelope as a GH secret).
+ */
+export async function enqueuePollScores(delaySeconds = POLL_CHAIN_INTERVAL_SECONDS): Promise<void> {
 	const cronSecret = process.env.CRON_SECRET
 	if (!cronSecret) throw new Error('CRON_SECRET must be set to enqueue poll-scores')
+	// Next slot on the `delaySeconds` grid, at least one full interval out.
+	// Integer math (slotIndex * delaySeconds) keeps notBefore exactly grid-aligned.
+	const slotIndex = Math.ceil(Date.now() / (delaySeconds * 1000)) + 1
+	const nextSlotSec = slotIndex * delaySeconds
 	await client().publishJSON({
 		url: `${callbackBase()}/api/cron/poll-scores`,
 		body: { source: 'qstash-loop' },
 		headers: { Authorization: `Bearer ${cronSecret}` },
-		delay: delaySeconds,
+		notBefore: nextSlotSec,
+		deduplicationId: `poll-loop-${nextSlotSec}`,
 	})
 }
 

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -83,7 +83,12 @@ export async function bootstrapCompetitions(opts: BootstrapOptions): Promise<voi
  * DB state.
  */
 const PRE_SCHEDULE_LEAD_MS = 10 * 60 * 1000
-const PRE_SCHEDULE_LOOKAHEAD_MS = 7 * 24 * 60 * 60 * 1000
+// Only pre-schedule polls for fixtures within 2 days. daily-sync runs daily, so
+// each fixture still gets its kickoff trigger queued ~1-2 days out, but a 7-day
+// window made every daily run re-publish a week of fixtures — wasted QStash
+// quota (free-tier 1000/day). The single-chain dedup (enqueuePollScores) means
+// even if several of these triggers fire at once they converge to one chain.
+const PRE_SCHEDULE_LOOKAHEAD_MS = 2 * 24 * 60 * 60 * 1000
 
 export async function scheduleUpcomingFixturePolls(): Promise<void> {
 	const now = new Date()


### PR DESCRIPTION
## Investigation (answering "what actually exhausted the quota?")

Measured the QStash event log: **803 publishes in a 1.7-hour burst — ~480/hour (~8/min)**, split across two deployments. That's not a 60s chain (1/min); it's **~8 parallel self-perpetuating chains**.

Cause: `poll-scores` self-enqueued the next link with **no deduplication**, so every invocation started/continued an independent chain. Multiple fixture-kickoff triggers fired at each kickoff (duplicated by the **7-day × per-deployment** pre-scheduling — the `VERCEL_URL` bug), and each spawned its own chain → ~8× the publishes → the free-tier **1000/day** cap blown in ~2h, which then 500s the chain entirely (it's idle between match windows, so it re-detonates each window rather than running away permanently).

`#95`'s stable-URL change collapsed the *per-deployment* multiplication but **not** the parallel chains. This PR is the actual fix.

## Fix
- **Single-chain guarantee:** `enqueuePollScores` grid-aligns the next trigger and dedups on the slot (`notBefore` + `deduplicationId = poll-loop-<slot>`). Concurrent chains in the same slot enqueue the *identical* message, so QStash accepts exactly one → they converge to a single chain no matter how many triggers fire.
- **Interval 60s → 90s**, **pre-schedule lookahead 7d → 2d** (the secondary levers that didn't make the #95 squash merge).

Net: a full day of live coverage stays comfortably under 1000/day.

## Tests
qstash: notBefore is 90s-grid-aligned with matching `poll-loop-<slot>` dedup id; two calls in the same slot produce the **same** dedup id (collapse). bootstrap/poll-scores behaviour unchanged. typecheck · biome · unit · build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)