### PR TITLE
feat(admin): edit entry fee for an in-progress game

### DIFF
--- a/src/app/api/games/[id]/admin/entry-fee/route.test.ts
+++ b/src/app/api/games/[id]/admin/entry-fee/route.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/auth-helpers', () => ({
+	requireSession: vi.fn().mockResolvedValue({ user: { id: 'admin' } }),
+}))
+
+const { dbMock, txUpdate } = vi.hoisted(() => {
+	const txUpdate = vi.fn(() => ({
+		set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+	}))
+	return {
+		txUpdate,
+		dbMock: {
+			query: { game: { findFirst: vi.fn() } },
+			transaction: vi.fn(async (cb: (tx: { update: typeof txUpdate }) => unknown) =>
+				cb({ update: txUpdate }),
+			),
+		},
+	}
+})
+
+vi.mock('@/lib/db', () => ({ db: dbMock }))
+
+import { POST } from './route'
+
+const ctx = (gameId = 'g1') => ({ params: Promise.resolve({ id: gameId }) })
+const req = (body: unknown) =>
+	new Request('http://localhost/entry-fee', {
+		method: 'POST',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify(body),
+	})
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	dbMock.query.game.findFirst.mockResolvedValue({ id: 'g1', createdBy: 'admin', status: 'active' })
+})
+
+describe('POST admin/entry-fee', () => {
+	it('rejects a non-admin with 403', async () => {
+		dbMock.query.game.findFirst.mockResolvedValue({
+			id: 'g1',
+			createdBy: 'other',
+			status: 'active',
+		})
+		expect((await POST(req({ entryFee: '15' }), ctx())).status).toBe(403)
+	})
+
+	it('404s when the game does not exist', async () => {
+		dbMock.query.game.findFirst.mockResolvedValue(undefined)
+		expect((await POST(req({ entryFee: '15' }), ctx())).status).toBe(404)
+	})
+
+	it('rejects an invalid (negative / non-numeric) entry fee with 400', async () => {
+		expect((await POST(req({ entryFee: '-5' }), ctx())).status).toBe(400)
+		expect((await POST(req({ entryFee: 'abc' }), ctx())).status).toBe(400)
+		expect((await POST(req({}), ctx())).status).toBe(400)
+	})
+
+	it('refuses to change the fee on a completed game', async () => {
+		dbMock.query.game.findFirst.mockResolvedValue({
+			id: 'g1',
+			createdBy: 'admin',
+			status: 'completed',
+		})
+		const res = await POST(req({ entryFee: '15' }), ctx())
+		expect(res.status).toBe(400)
+		expect((await res.json()).error).toBe('game-completed')
+	})
+
+	it('updates the fee and bumps existing payments (normalised to 2dp)', async () => {
+		const res = await POST(req({ entryFee: '15' }), ctx())
+		expect(res.status).toBe(200)
+		const body = await res.json()
+		expect(body.entryFee).toBe('15.00')
+		// One transaction, two updates inside it: game.entryFee + payment.amount.
+		expect(dbMock.transaction).toHaveBeenCalledOnce()
+		expect(txUpdate).toHaveBeenCalledTimes(2)
+	})
+})

--- a/src/app/api/games/[id]/admin/entry-fee/route.ts
+++ b/src/app/api/games/[id]/admin/entry-fee/route.ts
@@ -1,0 +1,53 @@
+import { and, eq, ne } from 'drizzle-orm'
+import { NextResponse } from 'next/server'
+import { requireSession } from '@/lib/auth-helpers'
+import { db } from '@/lib/db'
+import { game } from '@/lib/schema/game'
+import { payment } from '@/lib/schema/payment'
+
+type Ctx = { params: Promise<{ id: string }> }
+
+/**
+ * Admin-only: change a game's entry fee mid-flight and bring the pot with it.
+ *
+ * The pot is derived from payment amounts, so changing `game.entryFee` alone
+ * wouldn't move the existing pot — it would only affect future joiners. To
+ * actually resize the pot we also bump every existing non-refunded payment to
+ * the new fee (each entry, original or rebuy, is one fee). Refunded rows
+ * (e.g. admin-removed players) are left alone.
+ *
+ * Refused on completed games: payouts are decided from the settled pot, so
+ * editing the fee afterwards would desync the recorded result.
+ */
+export async function POST(request: Request, ctx: Ctx): Promise<Response> {
+	const session = await requireSession()
+	const { id: gameId } = await ctx.params
+
+	const gameRow = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+	if (!gameRow) return NextResponse.json({ error: 'not-found' }, { status: 404 })
+	if (gameRow.createdBy !== session.user.id) {
+		return NextResponse.json({ error: 'forbidden' }, { status: 403 })
+	}
+	if (gameRow.status === 'completed') {
+		return NextResponse.json({ error: 'game-completed' }, { status: 400 })
+	}
+
+	const body = (await request.json().catch(() => null)) as { entryFee?: string | number } | null
+	const raw = body?.entryFee
+	const parsed = typeof raw === 'number' ? raw : Number.parseFloat(String(raw ?? ''))
+	if (!Number.isFinite(parsed) || parsed < 0) {
+		return NextResponse.json({ error: 'invalid-entry-fee' }, { status: 400 })
+	}
+	const entryFee = parsed.toFixed(2)
+
+	await db.transaction(async (tx) => {
+		await tx.update(game).set({ entryFee }).where(eq(game.id, gameId))
+		// Bump every live entry to the new fee so the pot tracks the change.
+		await tx
+			.update(payment)
+			.set({ amount: entryFee })
+			.where(and(eq(payment.gameId, gameId), ne(payment.status, 'refunded')))
+	})
+
+	return NextResponse.json({ ok: true, entryFee })
+}

--- a/src/components/game/game-detail-view.tsx
+++ b/src/components/game/game-detail-view.tsx
@@ -192,6 +192,8 @@ export function GameDetailView({
 							gameId={game.id}
 							gameName={game.name}
 							inviteCode={game.inviteCode}
+							entryFee={game.entryFee}
+							gameStatus={game.status}
 							totals={game.pot}
 							payments={game.adminPayments}
 							onChange={refresh}

--- a/src/components/game/payments-panel.test.tsx
+++ b/src/components/game/payments-panel.test.tsx
@@ -12,6 +12,8 @@ const baseProps = {
 	gameId: 'g1',
 	gameName: 'Cup Tuesday',
 	inviteCode: 'ABC123',
+	entryFee: '10.00',
+	gameStatus: 'active',
 	totals: { confirmed: '30.00', pending: '0.00', total: '30.00' },
 }
 
@@ -70,5 +72,44 @@ describe('PaymentsPanel synthetic (no-payment) rows', () => {
 		render(<PaymentsPanel {...baseProps} payments={[row({ id: 'p1', status: 'paid' })]} />)
 		expect(screen.queryByRole('button', { name: 'Mark paid' })).toBeNull()
 		expect(screen.getByRole('button', { name: 'Dispute' })).toBeTruthy()
+	})
+})
+
+describe('PaymentsPanel entry-fee editor', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks()
+	})
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('shows the current entry fee', () => {
+		render(<PaymentsPanel {...baseProps} entryFee="10.00" payments={[]} />)
+		expect(screen.getByText('£10.00')).toBeTruthy()
+	})
+
+	it('posts the new fee to the entry-fee endpoint on save', async () => {
+		const fetchMock = vi
+			.spyOn(globalThis, 'fetch')
+			.mockResolvedValue(
+				new Response(JSON.stringify({ ok: true, entryFee: '15.00' }), { status: 200 }),
+			)
+		render(<PaymentsPanel {...baseProps} entryFee="10.00" payments={[]} />)
+		fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+		fireEvent.change(screen.getByLabelText('New entry fee'), { target: { value: '15' } })
+		fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+		await waitFor(() =>
+			expect(fetchMock).toHaveBeenCalledWith('/api/games/g1/admin/entry-fee', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ entryFee: '15' }),
+			}),
+		)
+	})
+
+	it('hides the Edit control once the game is completed', () => {
+		render(<PaymentsPanel {...baseProps} gameStatus="completed" entryFee="10.00" payments={[]} />)
+		expect(screen.getByText('£10.00')).toBeTruthy()
+		expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull()
 	})
 })

--- a/src/components/game/payments-panel.tsx
+++ b/src/components/game/payments-panel.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import { toast } from 'sonner'
 import { PaymentReminderButton } from './payment-reminder'
 import { type AdminPaymentStatus, PaymentStatusChip } from './payment-status-chip'
@@ -20,6 +21,9 @@ interface PaymentsPanelProps {
 	gameId: string
 	gameName: string
 	inviteCode: string
+	entryFee: string | null
+	/** Game lifecycle status — the entry fee can't be edited once 'completed'. */
+	gameStatus: string
 	totals: { confirmed: string; pending: string; total: string }
 	payments: AdminPayment[]
 	onChange?: () => void
@@ -133,6 +137,13 @@ export function PaymentsPanel(props: PaymentsPanelProps) {
 				</div>
 			</div>
 
+			<EntryFeeEditor
+				gameId={props.gameId}
+				entryFee={props.entryFee}
+				editable={props.gameStatus !== 'completed'}
+				onChange={props.onChange}
+			/>
+
 			<div className="overflow-x-auto">
 				<div className="mb-1.5 text-[10px] font-semibold uppercase text-muted-foreground">
 					All payments
@@ -206,6 +217,107 @@ export function PaymentsPanel(props: PaymentsPanelProps) {
 				))}
 			</div>
 		</section>
+	)
+}
+
+/**
+ * Edit the per-player entry fee mid-game. Saving updates `game.entryFee` AND
+ * bumps every existing non-refunded payment to the new fee, so the pot resizes
+ * to match (the pot is derived from paid amounts). Hidden as read-only once the
+ * game is completed.
+ */
+function EntryFeeEditor({
+	gameId,
+	entryFee,
+	editable,
+	onChange,
+}: {
+	gameId: string
+	entryFee: string | null
+	editable: boolean
+	onChange?: () => void
+}) {
+	const current = entryFee ?? '0.00'
+	const [editing, setEditing] = useState(false)
+	const [value, setValue] = useState(current)
+	const [saving, setSaving] = useState(false)
+
+	async function save() {
+		const num = Number.parseFloat(value)
+		if (!Number.isFinite(num) || num < 0) {
+			toast.error('Enter a valid amount')
+			return
+		}
+		setSaving(true)
+		const res = await fetch(`/api/games/${gameId}/admin/entry-fee`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ entryFee: value }),
+		})
+		setSaving(false)
+		if (res.ok) {
+			toast.success(`Entry fee set to £${num.toFixed(2)} — existing entries updated`)
+			setEditing(false)
+			onChange?.()
+		} else {
+			const body = await res.json().catch(() => ({ error: 'failed' }))
+			toast.error(
+				body.error === 'game-completed'
+					? "Can't change the fee on a finished game"
+					: 'Failed to update entry fee',
+			)
+		}
+	}
+
+	return (
+		<div className="flex items-center justify-between gap-2 rounded-lg border border-border bg-muted/20 px-3 py-2">
+			<div className="text-xs text-muted-foreground">
+				Entry fee <span className="font-semibold text-foreground">£{current}</span>
+				<span className="ml-1">per player</span>
+			</div>
+			{editable &&
+				(editing ? (
+					<div className="flex items-center gap-1">
+						<span className="text-xs text-muted-foreground">£</span>
+						<input
+							type="number"
+							min="0"
+							step="0.01"
+							inputMode="decimal"
+							value={value}
+							onChange={(e) => setValue(e.target.value)}
+							aria-label="New entry fee"
+							className="w-20 rounded border border-border px-2 py-1 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+						/>
+						<button
+							type="button"
+							onClick={save}
+							disabled={saving}
+							className="rounded border border-[var(--alive)] px-3 py-1.5 text-xs font-semibold text-[var(--alive)] disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+						>
+							Save
+						</button>
+						<button
+							type="button"
+							onClick={() => {
+								setEditing(false)
+								setValue(current)
+							}}
+							className="rounded border border-border px-3 py-1.5 text-xs font-semibold text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+						>
+							Cancel
+						</button>
+					</div>
+				) : (
+					<button
+						type="button"
+						onClick={() => setEditing(true)}
+						className="rounded border border-border px-3 py-1.5 text-xs font-semibold text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+					>
+						Edit
+					</button>
+				))}
+		</div>
 	)
 }
 


### PR DESCRIPTION
## Why

The pot is derived from payment amounts (`pot = Σ paid`), with `game.entryFee` as the per-player lever. There was no way to resize the pot once a game was underway. This adds an admin control to change the entry fee mid-game and bring the existing pot with it.

## What

- **New `POST /api/games/[id]/admin/entry-fee`** — admin-only. In one transaction it updates `game.entryFee` **and** bumps every existing non-refunded payment to the new fee, so the realized pot tracks the change (refunded rows — e.g. admin-removed players — are left alone). Validates a finite, non-negative amount. **Refused on completed games**, since payouts are decided from the settled pot.
- **PaymentsPanel** — inline entry-fee editor: shows the current fee with an **Edit → input → Save**. Wired with `entryFee` + `gameStatus` from `game-detail-view`; read-only once the game is completed.

Per-player fee was the confirmed model (e.g. £10 → £15 makes a 10-player pot £100 → £150; new joiners owe £15) rather than a total-pot target.

## Testing

- **Endpoint** (5): admin gate (403), missing game (404), invalid/negative/missing fee (400), completed-game guard (`game-completed`), and the happy path asserting the transaction runs both updates with the fee normalised to 2dp.
- **Panel editor** (3): renders the current fee, posts the new fee to the endpoint on save, and hides the Edit control once completed.
- typecheck ✓ · biome ✓ · build ✓ (route registered) · full suite **528 passing**.
- **End-to-end on the dev server**: changing a cup game's fee £10 → £17.50 bumped all four non-refunded payments to £17.50 and the pot followed; restored to £10.00 cleanly. Editor renders on cup / turbo / classic (HTTP 200, no RSC errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)