### PR TITLE
fix(cup): a broken streak no longer eliminates the player

### DIFF
--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -735,6 +735,123 @@ describe('lifecycle: cup-WC', () => {
 		expect(r2?.result).toBe('pending')
 	})
 
+	it('does NOT eliminate a player whose streak breaks — a frozen streak still competes', async () => {
+		// The 1f0d292d "Feargal" incident: a played losing pick broke his streak,
+		// so he was marked eliminated mid-gameweek. But cup is won by the LONGEST
+		// streak (checkCupCompletion counts every player, broken or not), and other
+		// still-unplayed results may leave his frozen streak the winner. Cup must
+		// never eliminate on a streak break — it ranks by streak, like turbo.
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		const a = await makeTeam({ name: 'Aaa', shortName: 'AAA', fifaPot: 2 })
+		const b = await makeTeam({ name: 'Bbb', shortName: 'BBB', fifaPot: 2 })
+		const c = await makeTeam({ name: 'Ccc', shortName: 'CCC', fifaPot: 2 })
+		const d = await makeTeam({ name: 'Ddd', shortName: 'DDD', fifaPot: 2 })
+		const r1 = await makeRound(compId, { number: 1, status: 'open' })
+		const fxPlayed = await makeFixture({ roundId: r1, homeTeamId: a, awayTeamId: b })
+		const fxUnplayed = await makeFixture({ roundId: r1, homeTeamId: c, awayTeamId: d })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'cup',
+			currentRoundId: r1,
+			modeConfig: { numberOfPicks: 2, startingLives: 0 },
+		})
+		const gpHero = await makePlayer({ gameId, userId: 'u-hero', livesRemaining: 0 })
+		const gpFiller = await makePlayer({ gameId, userId: 'u-filler', livesRemaining: 0 })
+		// hero rank-1 on the PLAYED fixture (will LOSE → streak breaks at rank 1);
+		// rank-2 on the unplayed fixture keeps the gameweek incomplete.
+		await makePick({
+			gameId,
+			gamePlayerId: gpHero,
+			roundId: r1,
+			teamId: a,
+			fixtureId: fxPlayed,
+			confidenceRank: 1,
+			predictedResult: 'home_win',
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpHero,
+			roundId: r1,
+			teamId: c,
+			fixtureId: fxUnplayed,
+			confidenceRank: 2,
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpFiller,
+			roundId: r1,
+			teamId: d,
+			fixtureId: fxUnplayed,
+			confidenceRank: 1,
+		})
+
+		// AAA (hero's rank-1) LOSES 0-2 → streak broken at rank 1.
+		await finishFixture(fxPlayed, 0, 2)
+		await settleFixture(fxPlayed)
+
+		const heroPick = await db.query.pick.findFirst({
+			where: and(eq(pick.gamePlayerId, gpHero), eq(pick.confidenceRank, 1)),
+		})
+		expect(heroPick?.result).toBe('loss') // the streak did break...
+		const hero = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gpHero) })
+		expect(hero?.status).toBe('alive') // ...but the player is NOT eliminated
+	})
+
+	it('self-heals: re-settle revives a cup player wrongly eliminated by a streak break, but keeps admin removals', async () => {
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		const a = await makeTeam({ name: 'Aaa', shortName: 'AAA', fifaPot: 2 })
+		const b = await makeTeam({ name: 'Bbb', shortName: 'BBB', fifaPot: 2 })
+		const r1 = await makeRound(compId, { number: 1, status: 'open' })
+		const fxPlayed = await makeFixture({ roundId: r1, homeTeamId: a, awayTeamId: b })
+		const fxUnplayed = await makeFixture({ roundId: r1, homeTeamId: a, awayTeamId: b })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'cup',
+			currentRoundId: r1,
+			modeConfig: { numberOfPicks: 2, startingLives: 0 },
+		})
+		const gpStreak = await makePlayer({ gameId, userId: 'u-streak', livesRemaining: 0 })
+		const gpAdmin = await makePlayer({ gameId, userId: 'u-admin-rm', livesRemaining: 0 })
+		// Simulate the old buggy state: both pre-marked eliminated. Only the
+		// admin-removed one should stay eliminated after re-settle.
+		await db
+			.update(gamePlayer)
+			.set({ status: 'eliminated', eliminatedRoundId: r1, eliminatedReason: null })
+			.where(eq(gamePlayer.id, gpStreak))
+		await db
+			.update(gamePlayer)
+			.set({ status: 'eliminated', eliminatedRoundId: r1, eliminatedReason: 'admin_removed' })
+			.where(eq(gamePlayer.id, gpAdmin))
+		await makePick({
+			gameId,
+			gamePlayerId: gpStreak,
+			roundId: r1,
+			teamId: a,
+			fixtureId: fxPlayed,
+			confidenceRank: 1,
+			predictedResult: 'home_win',
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpStreak,
+			roundId: r1,
+			teamId: a,
+			fixtureId: fxUnplayed,
+			confidenceRank: 2,
+		})
+
+		await finishFixture(fxPlayed, 2, 0)
+		await settleFixture(fxPlayed)
+
+		const streak = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gpStreak) })
+		expect(streak?.status).toBe('alive') // streak-break elimination undone
+		expect(streak?.eliminatedRoundId).toBeNull()
+		const admin = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gpAdmin) })
+		expect(admin?.status).toBe('eliminated') // admin removal preserved
+	})
+
 	it('cup re-eval is idempotent — re-settling the same fixture changes nothing', async () => {
 		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
 		const t1 = await makeTeam({ name: 'X', shortName: 'X', fifaPot: 2 })

--- a/src/lib/game/settle.ts
+++ b/src/lib/game/settle.ts
@@ -367,18 +367,31 @@ export async function reevaluateCupGame(gameId: string): Promise<boolean> {
 				.where(eq(pick.id, target.pickRow.id))
 		}
 
-		// Persist lives + eliminated state.
-		const updates: { livesRemaining: number; status?: 'eliminated'; eliminatedRoundId?: string } = {
-			livesRemaining: evalResult.finalLives,
+		// Persist lives. A broken streak does NOT eliminate a cup player: cup is
+		// won by the LONGEST streak (checkCupCompletion ranks every player, broken
+		// or not — exactly like turbo), so a frozen streak can still be the winning
+		// one. Marking it 'eliminated' wrongly drops the player from the
+		// in-contention standings/podium (the 1f0d292d "Feargal" incident, where
+		// the current leader's frozen streak of 4 was shown as OUT). The winner is
+		// crowned only at gameweek completion (applyAutoCompletion → 'winner');
+		// every other cup player stays 'alive'. `evalResult.eliminated` still drives
+		// the lives/goals freeze inside evaluateCupPicks — it just no longer touches
+		// player status here.
+		const updates: {
+			livesRemaining: number
+			status?: 'alive'
+			eliminatedRoundId?: string | null
+		} = { livesRemaining: evalResult.finalLives }
+		// Self-heal: revive any cup player a previous (buggy) settle wrongly marked
+		// eliminated on a streak break. Admin removals (eliminatedReason
+		// 'admin_removed') are a deliberate action and must persist.
+		const wronglyEliminated =
+			player.status === 'eliminated' && player.eliminatedReason !== 'admin_removed'
+		if (wronglyEliminated) {
+			updates.status = 'alive'
+			updates.eliminatedRoundId = null
 		}
-		if (evalResult.eliminated) {
-			updates.status = 'eliminated'
-			updates.eliminatedRoundId = roundId
-		}
-		if (
-			player.livesRemaining !== evalResult.finalLives ||
-			(evalResult.eliminated && player.status === 'alive')
-		) {
+		if (player.livesRemaining !== evalResult.finalLives || wronglyEliminated) {
 			anyChanged = true
 			await db.update(gamePlayer).set(updates).where(eq(gamePlayer.id, player.id))
 		}


### PR DESCRIPTION
## The bug (live game `1f0d292d`)

Feargal was marked **eliminated** the moment his streak broke (a played rank-5 loss capped him at 4). But cup is won by the **longest** streak — his frozen 4 is currently the leader, and the other players' streaks are still unplayed, so his streak may yet win. He shouldn't be out.

## Root cause

`reevaluateCupGame` (`settle.ts`) propagated `evaluateCupPicks().eliminated` (= "streak broke") straight into `gamePlayer.status='eliminated'`. That status then drops the player from the in-contention surfaces — the cup-ladder podium filters `status !== 'eliminated'`, and the grid buckets them under "Eliminated".

But:
- `checkCupCompletion` ranks **every** player regardless of status ("a long broken streak still beats a short unbroken one") — so a frozen streak is still a contender.
- **Turbo**, the other longest-streak mode, never eliminates on a streak break — it just ranks by streak.
- Cup completion is gated on the whole gameweek finishing, so there was no wrong-crown — purely a status/display correctness bug.

## Fix

Cup never eliminates on a streak break (mirrors turbo). Players stay `alive` until the gameweek completes and the longest streak is crowned `winner`. `reevaluateCupGame` also **self-heals**: it revives any cup player a previous settle wrongly eliminated on a streak break (deliberate **admin removals** are preserved via `eliminatedReason`), so the recovery surfaces (`reconcileGameState`, which runs on game-detail SSR / `/live` / daily-sync) auto-correct live games like `1f0d292d` on the next load — no manual data fix needed.

`evaluateCupPicks` is unchanged — its `eliminated` flag still freezes lives/goals accrual internally; it just no longer drives player status.

## Testing

- **Smoke (RED→GREEN):** a cup player whose streak breaks mid-gameweek stays `alive`; a wrongly-eliminated player is revived on re-settle while an `admin_removed` player stays eliminated.
- Full smoke **39 passing**; unit **528 passing**; typecheck / biome / build clean.

Post-merge: once deployed, loading game `1f0d292d` (or the next fixture settling) will revive Feargal to `alive` automatically. I'll verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)