### PR TITLE
fix(wc): correct knockout round labels for the 48-team format (Round of 32)

### DIFF
--- a/src/lib/game/round-label.test.ts
+++ b/src/lib/game/round-label.test.ts
@@ -13,11 +13,12 @@ describe('roundLabel', () => {
 		expect(roundLabel('group_knockout', 3)).toBe('MD3')
 	})
 
-	it('formats group_knockout knockout rounds with stage names', () => {
-		expect(roundLabel('group_knockout', 4)).toBe('R16')
-		expect(roundLabel('group_knockout', 5)).toBe('QF')
-		expect(roundLabel('group_knockout', 6)).toBe('SF')
-		expect(roundLabel('group_knockout', 7)).toBe('F')
+	it('formats the WC-2026 48-team knockout rounds (Round of 32 first)', () => {
+		expect(roundLabel('group_knockout', 4)).toBe('R32')
+		expect(roundLabel('group_knockout', 5)).toBe('R16')
+		expect(roundLabel('group_knockout', 6)).toBe('QF')
+		expect(roundLabel('group_knockout', 7)).toBe('SF')
+		expect(roundLabel('group_knockout', 8)).toBe('F')
 	})
 
 	it('formats single-elim knockout rounds as R{n}', () => {
@@ -25,8 +26,8 @@ describe('roundLabel', () => {
 		expect(roundLabel('knockout', 2)).toBe('R2')
 	})
 
-	it('falls back to R{n} for out-of-range group_knockout rounds', () => {
-		expect(roundLabel('group_knockout', 8)).toBe('R8')
+	it('falls back to R{n} beyond the Final (round 9+)', () => {
+		expect(roundLabel('group_knockout', 9)).toBe('R9')
 	})
 })
 
@@ -39,10 +40,11 @@ describe('roundLabelLong', () => {
 		expect(roundLabelLong('group_knockout', 1)).toBe('Matchday 1')
 	})
 
-	it('formats group_knockout knockout rounds with full stage names', () => {
-		expect(roundLabelLong('group_knockout', 4)).toBe('Round of 16')
-		expect(roundLabelLong('group_knockout', 5)).toBe('Quarter-final')
-		expect(roundLabelLong('group_knockout', 6)).toBe('Semi-final')
-		expect(roundLabelLong('group_knockout', 7)).toBe('Final')
+	it('formats the WC-2026 knockout rounds with full names (Round of 32 first)', () => {
+		expect(roundLabelLong('group_knockout', 4)).toBe('Round of 32')
+		expect(roundLabelLong('group_knockout', 5)).toBe('Round of 16')
+		expect(roundLabelLong('group_knockout', 6)).toBe('Quarter-finals')
+		expect(roundLabelLong('group_knockout', 7)).toBe('Semi-finals')
+		expect(roundLabelLong('group_knockout', 8)).toBe('Final')
 	})
 })

--- a/src/lib/game/round-label.ts
+++ b/src/lib/game/round-label.ts
@@ -2,8 +2,12 @@
  * Competition-aware round labels.
  *
  * - 'league' (PL): GW{n} short, "Gameweek {n}" long.
- * - 'group_knockout' (WC): MD{n} for group stages (rounds 1-3), then R16,
- *   QF, SF, F for knockouts. Long form: "Matchday {n}", "Round of 16", etc.
+ * - 'group_knockout' (WC 2026): MD{n} for the group stage (rounds 1-3), then
+ *   the 48-team knockout bracket — Round of 32, Round of 16, QF, SF, Final
+ *   (rounds 4-8). Must match the rounds seeded from football-data's `stage`
+ *   field (KO_STAGE_ORDER in football-data.ts: LAST_32→4 … FINAL→8) and those
+ *   rounds' DB `name`s. The WC 2026 format has 48 teams, so the first knockout
+ *   round is the Round of 32 — NOT the Round of 16 (the pre-2026 32-team shape).
  * - 'knockout' (single-elim cups): R{n} short, "Round {n}" long.
  */
 export type CompetitionType = 'league' | 'knockout' | 'group_knockout'
@@ -11,10 +15,11 @@ export type CompetitionType = 'league' | 'knockout' | 'group_knockout'
 export function roundLabel(competitionType: CompetitionType, roundNumber: number): string {
 	if (competitionType === 'group_knockout') {
 		if (roundNumber <= 3) return `MD${roundNumber}`
-		if (roundNumber === 4) return 'R16'
-		if (roundNumber === 5) return 'QF'
-		if (roundNumber === 6) return 'SF'
-		if (roundNumber === 7) return 'F'
+		if (roundNumber === 4) return 'R32'
+		if (roundNumber === 5) return 'R16'
+		if (roundNumber === 6) return 'QF'
+		if (roundNumber === 7) return 'SF'
+		if (roundNumber === 8) return 'F'
 		return `R${roundNumber}`
 	}
 	if (competitionType === 'knockout') {
@@ -26,10 +31,11 @@ export function roundLabel(competitionType: CompetitionType, roundNumber: number
 export function roundLabelLong(competitionType: CompetitionType, roundNumber: number): string {
 	if (competitionType === 'group_knockout') {
 		if (roundNumber <= 3) return `Matchday ${roundNumber}`
-		if (roundNumber === 4) return 'Round of 16'
-		if (roundNumber === 5) return 'Quarter-final'
-		if (roundNumber === 6) return 'Semi-final'
-		if (roundNumber === 7) return 'Final'
+		if (roundNumber === 4) return 'Round of 32'
+		if (roundNumber === 5) return 'Round of 16'
+		if (roundNumber === 6) return 'Quarter-finals'
+		if (roundNumber === 7) return 'Semi-finals'
+		if (roundNumber === 8) return 'Final'
 		return `Round ${roundNumber}`
 	}
 	if (competitionType === 'knockout') {


### PR DESCRIPTION
## Bug
The upcoming knockout rounds were mislabelled: the next round showed as **R16** when it's the **Round of 32**, and the real **Final** (round 8) appeared *after* the "Final" — because `round-label.ts` predated WC 2026's 48-team bracket and assumed the knockouts begin at the Round of 16 (round 4 → R16, round 7 → Final, round 8 → "Round 8").

The rounds themselves are seeded correctly from football-data's `stage` (LAST_32→round 4 … FINAL→round 8) with correct DB `name`s — only this number→label helper was off by one. It's used in ~10 UI/share/query surfaces, so all of them showed the wrong labels.

## Fix
`group_knockout` mapping → **R32(4) / R16(5) / QF(6) / SF(7) / Final(8)**, matching the seeded rounds and their DB names. Long form matches the DB names ("Round of 32", "Round of 16", "Quarter-finals", "Semi-finals", "Final"). Tests updated.

## Note (not a bug)
Only 4 of 16 Round-of-32 fixtures are confirmed so far — the rest are drawn as the remaining groups finish (MD3 is still completing) and get added by the daily-sync. Selection of R32 opens once the bracket is confirmed + the round gets a deadline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)