### PR TITLE
feat(live-scores): auto-sync the bracket after each knockout fixture

### DIFF
--- a/src/app/api/cron/poll-scores/route.ts
+++ b/src/app/api/cron/poll-scores/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from 'next/server'
 import { serializeError } from '@/lib/cron/serialize-error'
 import { FootballDataAdapter, resolveFootballDataCode } from '@/lib/data/football-data'
 import { hasActiveFixture } from '@/lib/data/match-window'
-import { enqueuePollScores } from '@/lib/data/qstash'
+import { enqueueCompetitionSync, enqueuePollScores } from '@/lib/data/qstash'
 import { db } from '@/lib/db'
 import { settleFixture } from '@/lib/game/settle'
 import { fixture, round } from '@/lib/schema/competition'
@@ -71,8 +71,18 @@ async function pollScores(apiKey: string): Promise<NextResponse> {
 		if (!list.includes(currentRoundId)) list.push(currentRoundId)
 		competitionsByExternalCode.set(code, list)
 	}
+	// Resolve each external code back to its competition (id + type) so we can
+	// trigger a bracket re-sync after a knockout fixture finishes.
+	const compByCode = new Map<string, { id: string; type: string }>()
+	for (const g of activeGames) {
+		const code = resolveFootballDataCode(g.competition)
+		if (code) compByCode.set(code, { id: g.competition.id, type: g.competition.type })
+	}
 
 	let totalUpdated = 0
+	// Competitions whose bracket should be re-synced because a knockout-stage
+	// fixture just finished (its result may confirm the next round's matchups).
+	const syncCompetitionIds = new Set<string>()
 
 	for (const [code, roundIds] of competitionsByExternalCode) {
 		const adapter = new FootballDataAdapter(code, apiKey)
@@ -124,6 +134,29 @@ async function pollScores(apiKey: string): Promise<NextResponse> {
 			for (const fid of transitionedFixtureIds) {
 				await settleFixture(fid)
 			}
+
+			// A finished group_knockout fixture from matchday 3 onward (the
+			// group→knockout boundary and every knockout round) may confirm the
+			// next round's matchups — flag the competition for a re-sync.
+			const comp = compByCode.get(code)
+			if (
+				transitionedFixtureIds.length > 0 &&
+				comp?.type === 'group_knockout' &&
+				roundData.number >= 3
+			) {
+				syncCompetitionIds.add(comp.id)
+			}
+		}
+	}
+
+	// Populate the next round's fixtures (and advance/open rounds) shortly after a
+	// knockout match settles — keeps the bracket current as the tournament plays
+	// out, independent of the daily cron. Deduped + delayed inside the helper.
+	for (const compId of syncCompetitionIds) {
+		try {
+			await enqueueCompetitionSync(compId)
+		} catch (e) {
+			console.warn('[poll-scores] enqueueCompetitionSync failed', e)
 		}
 	}
 

--- a/src/app/api/cron/qstash-handler/route.ts
+++ b/src/app/api/cron/qstash-handler/route.ts
@@ -1,9 +1,14 @@
 import { verifySignatureAppRouter } from '@upstash/qstash/nextjs'
+import { eq } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import type { QStashJob } from '@/lib/data/qstash'
+import { db } from '@/lib/db'
 import { submitPlannedPick } from '@/lib/game/auto-submit'
+import { syncCompetition } from '@/lib/game/bootstrap-competitions'
 import { writeEvent } from '@/lib/game/events'
 import { processGameRound } from '@/lib/game/process-round'
+import { reconcileAllActiveGames } from '@/lib/game/reconcile'
+import { competition } from '@/lib/schema/competition'
 
 async function handler(request: Request): Promise<Response> {
 	const body = (await request.json()) as QStashJob
@@ -23,6 +28,23 @@ async function handler(request: Request): Promise<Response> {
 		case 'auto_submit': {
 			await submitPlannedPick(body.gamePlayerId, body.roundId, body.teamId)
 			return NextResponse.json({ ok: true })
+		}
+		case 'sync_competition': {
+			// Re-sync one competition (ingest newly-confirmed fixtures, e.g. the
+			// next knockout round's matchups) then advance/open any game whose
+			// current round just completed. Triggered after a knockout match
+			// finishes so the bracket populates as the tournament progresses,
+			// independent of the daily cron. No FPL dependency (football-data only).
+			const [comp] = await db
+				.select()
+				.from(competition)
+				.where(eq(competition.id, body.competitionId))
+			if (!comp) return NextResponse.json({ ok: false, reason: 'competition-not-found' })
+			const summary = await syncCompetition(comp, {
+				footballDataApiKey: process.env.FOOTBALL_DATA_API_KEY,
+			})
+			const reconcile = await reconcileAllActiveGames()
+			return NextResponse.json({ ok: true, summary, reconcile })
 		}
 		default:
 			return NextResponse.json({ error: 'Unknown job type' }, { status: 400 })

--- a/src/lib/data/qstash.test.ts
+++ b/src/lib/data/qstash.test.ts
@@ -10,6 +10,7 @@ vi.mock('@upstash/qstash', () => ({
 
 import {
 	enqueueAutoSubmit,
+	enqueueCompetitionSync,
 	enqueueDeadlineReminder,
 	enqueuePollScores,
 	enqueuePollScoresAt,
@@ -63,6 +64,15 @@ describe('qstash helpers', () => {
 			window: '24h',
 		})
 		expect(call.notBefore).toBe(Math.floor(notBefore.getTime() / 1000))
+	})
+
+	it('enqueues a competition sync (delayed, deduped per competition) to the handler', async () => {
+		await enqueueCompetitionSync('comp-wc')
+		const call = publishJSONMock.mock.calls[0][0]
+		expect(call.url).toBe('https://example.com/api/cron/qstash-handler')
+		expect(call.body).toEqual({ type: 'sync_competition', competitionId: 'comp-wc' })
+		expect(call.delay).toBe(600)
+		expect(call.deduplicationId).toMatch(/^sync-comp-comp-wc-\d+$/)
 	})
 
 	it('enqueues an auto-submit at the given timestamp', async () => {

--- a/src/lib/data/qstash.ts
+++ b/src/lib/data/qstash.ts
@@ -4,6 +4,7 @@ export type QStashJob =
 	| { type: 'process_round'; gameId: string; roundId: string }
 	| { type: 'deadline_reminder'; gameId: string; roundId: string; window: '24h' | '2h' }
 	| { type: 'auto_submit'; gamePlayerId: string; roundId: string; teamId: string }
+	| { type: 'sync_competition'; competitionId: string }
 
 /**
  * Stable callback origin for QStash jobs.
@@ -59,6 +60,29 @@ export async function enqueueDeadlineReminder(
 		url: handlerUrl(),
 		body: { type: 'deadline_reminder', gameId, roundId, window } satisfies QStashJob,
 		notBefore: Math.floor(notBefore.getTime() / 1000),
+	})
+}
+
+/**
+ * Enqueue a delayed competition re-sync. Used to populate the next round's
+ * fixtures (and advance/open rounds) shortly after a knockout match finishes —
+ * so the bracket stays current "as we go" without waiting for the daily cron.
+ *
+ * Deduplicated to a 15-minute bucket per competition: a cluster of finishes in
+ * the same window collapses to ONE sync. The default ~10-minute delay lets the
+ * data source confirm the next-round matchup (incl. ET/penalties) before we
+ * fetch.
+ */
+export async function enqueueCompetitionSync(
+	competitionId: string,
+	delaySeconds = 600,
+): Promise<void> {
+	const bucket = Math.floor(Date.now() / (15 * 60 * 1000))
+	await client().publishJSON({
+		url: handlerUrl(),
+		body: { type: 'sync_competition', competitionId } satisfies QStashJob,
+		delay: delaySeconds,
+		deduplicationId: `sync-comp-${competitionId}-${bucket}`,
 	})
 }
 


### PR DESCRIPTION
## Why
The knockout bracket only got populated by the **daily-sync** — a GitHub-Actions cron that lags **3–6 hours** (scheduled 04:00 UTC, actually fires ~06:50–09:47). So a round's next-round matchups + deadline could be missing for hours after the prior round finished. This morning the **Round of 32 wasn't seeded by its own deadline day** because that day's daily-sync hadn't yet run, and both classic games were stuck on completed MD3.

## What
Event-driven, as @sean suggested — "run after every knockout game to populate as we go":

- **Trigger:** when `poll-scores` settles a `group_knockout` fixture from **matchday 3 onward** (the group→knockout boundary + every knockout round), it enqueues a delayed, deduped QStash `sync_competition` job.
- **Worker:** new `sync_competition` job type in `qstash-handler` → `syncCompetition(WC)` + `reconcileAllActiveGames` (football-data only, **no FPL dependency**). Ingests the now-confirmed next-round fixtures, derives the deadline, advances + opens rounds.
- **Delay ~10 min:** lets the data source confirm the next matchup (incl. ET/penalties) before fetching.
- **Dedup:** 15-min bucket per competition, so a cluster of finishes collapses to one sync.

Net: the bracket stays current as the tournament plays out, with **zero dependence on the daily cron** (which remains the once-a-day backstop). Quota impact is trivial (a handful of deduped syncs per match day).

It piggybacks on the live-score chain, which is now reliable (stable-URL kickoff jobs from #95/#96).

## Tests
`enqueueCompetitionSync` shape/delay/dedup; typecheck · biome · unit (144 in the touched areas) · build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)