### PR TITLE
feat(turbo): "Scenarios" view — who can still win + the picks that decide it

### DIFF
--- a/src/components/standings/scenarios-view.test.tsx
+++ b/src/components/standings/scenarios-view.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import type { Outcome, WinScenarios } from '@/lib/game-logic/win-scenarios'
+import { ScenariosView } from './scenarios-view'
+
+const names: Record<string, string> = { p1: 'Alice', p2: 'Bob', p3: 'Cara' }
+const playerName = (id: string) => names[id] ?? id
+const fixtureLabel = (id: string) => (id === 'f2' ? 'GHA v CRO' : id)
+const describeOutcome = (id: string, o: Outcome) =>
+	id === 'f2' ? (o === 'home_win' ? 'GHA win' : o === 'away_win' ? 'CRO win' : 'GHA v CRO draw') : o
+
+const scenarios: WinScenarios = {
+	outlooks: [
+		{
+			gamePlayerId: 'p1',
+			floor: 1,
+			ceiling: 2,
+			verdict: 'in_contention',
+			pivotalPicks: [{ rank: 2, fixtureId: 'f2' }],
+		},
+		{
+			gamePlayerId: 'p2',
+			floor: 1,
+			ceiling: 2,
+			verdict: 'in_contention',
+			pivotalPicks: [{ rank: 2, fixtureId: 'f2' }],
+		},
+		{ gamePlayerId: 'p3', floor: 0, ceiling: 0, verdict: 'out', pivotalPicks: [] },
+	],
+	table: [
+		{ conditions: [{ fixtureId: 'f2', outcome: 'home_win' }], winners: ['p1'], tieOnGoals: false },
+		{ conditions: [{ fixtureId: 'f2', outcome: 'away_win' }], winners: ['p2'], tieOnGoals: false },
+		{ conditions: [{ fixtureId: 'f2', outcome: 'draw' }], winners: ['p1', 'p2'], tieOnGoals: true },
+	],
+	pivotalFixtureIds: ['f2'],
+	tooManyToEnumerate: false,
+}
+
+describe('ScenariosView', () => {
+	it('renders per-player verdicts and the pivotal fixture', () => {
+		render(
+			<ScenariosView
+				scenarios={scenarios}
+				playerName={playerName}
+				fixtureLabel={fixtureLabel}
+				describeOutcome={describeOutcome}
+			/>,
+		)
+		expect(screen.getByText('Alice')).toBeTruthy()
+		expect(screen.getByText('Cara')).toBeTruthy()
+		expect(screen.getAllByText('In contention').length).toBe(2)
+		expect(screen.getByText("Can't win")).toBeTruthy()
+		// the pivotal fixture is surfaced for in-contention players
+		expect(screen.getAllByText('GHA v CRO').length).toBeGreaterThan(0)
+	})
+
+	it('renders the decision table with outcomes → winners', () => {
+		render(
+			<ScenariosView
+				scenarios={scenarios}
+				playerName={playerName}
+				fixtureLabel={fixtureLabel}
+				describeOutcome={describeOutcome}
+			/>,
+		)
+		expect(screen.getByText('GHA win')).toBeTruthy()
+		expect(screen.getByText('CRO win')).toBeTruthy()
+		expect(screen.getByText(/Alice wins/)).toBeTruthy()
+		expect(screen.getByText(/Bob wins/)).toBeTruthy()
+		expect(screen.getByText(/Alice & Bob tie \(goals decide\)/)).toBeTruthy()
+	})
+
+	it('shows the early-game note when too many results remain', () => {
+		render(
+			<ScenariosView
+				scenarios={{ ...scenarios, table: null, tooManyToEnumerate: true }}
+				playerName={playerName}
+				fixtureLabel={fixtureLabel}
+				describeOutcome={describeOutcome}
+			/>,
+		)
+		expect(screen.getByText(/Too many results still to play/)).toBeTruthy()
+	})
+})

--- a/src/components/standings/scenarios-view.tsx
+++ b/src/components/standings/scenarios-view.tsx
@@ -1,0 +1,146 @@
+import { Flame, Trophy } from 'lucide-react'
+import type { Outcome, PlayerOutlook, WinScenarios } from '@/lib/game-logic/win-scenarios'
+import { cn } from '@/lib/utils'
+
+interface ScenariosViewProps {
+	scenarios: WinScenarios
+	/** gamePlayerId → display name. */
+	playerName: (id: string) => string
+	/** fixtureId → "GHA v CRO". */
+	fixtureLabel: (id: string) => string
+	/** fixtureId + outcome → "GHA win" / "CRO win" / "draw". */
+	describeOutcome: (id: string, outcome: Outcome) => string
+}
+
+const VERDICT_ORDER: Record<PlayerOutlook['verdict'], number> = {
+	leading: 0,
+	in_contention: 1,
+	out: 2,
+}
+
+/**
+ * "What needs to happen" — each player's path to winning, plus (once it narrows
+ * to a few results) the exact branch table. Shared by turbo + cup.
+ */
+export function ScenariosView({
+	scenarios,
+	playerName,
+	fixtureLabel,
+	describeOutcome,
+}: ScenariosViewProps) {
+	const outlooks = [...scenarios.outlooks].sort(
+		(a, b) => VERDICT_ORDER[a.verdict] - VERDICT_ORDER[b.verdict] || b.ceiling - a.ceiling,
+	)
+
+	return (
+		<div className="space-y-5">
+			{scenarios.tooManyToEnumerate && (
+				<p className="text-xs text-muted-foreground italic">
+					Too many results still to play to map exact scenarios — showing each player's best/worst
+					case for now. This sharpens as fixtures finish.
+				</p>
+			)}
+
+			<div className="space-y-2">
+				{outlooks.map((o) => (
+					<OutlookCard
+						key={o.gamePlayerId}
+						outlook={o}
+						name={playerName(o.gamePlayerId)}
+						fixtureLabel={fixtureLabel}
+					/>
+				))}
+			</div>
+
+			{scenarios.table && scenarios.table.length > 0 && (
+				<div>
+					<h3 className="flex items-center gap-2 font-display text-lg font-semibold mb-2">
+						<Trophy className="h-4 w-4 text-[var(--accent)]" /> How it's decided
+					</h3>
+					<div className="space-y-1.5">
+						{scenarios.table.map((b) => (
+							<div
+								key={`${b.conditions.map((c) => `${c.fixtureId}:${c.outcome}`).join('|')}`}
+								className="flex flex-wrap items-center gap-x-2 gap-y-1 rounded-md border border-border bg-card px-3 py-2 text-sm"
+							>
+								<span className="text-muted-foreground">
+									{b.conditions.length === 0
+										? 'However it finishes'
+										: b.conditions.map((c) => describeOutcome(c.fixtureId, c.outcome)).join(' · ')}
+								</span>
+								<span className="text-muted-foreground">→</span>
+								<span className="font-semibold">
+									{b.tieOnGoals
+										? `${b.winners.map(playerName).join(' & ')} tie (goals decide)`
+										: `${b.winners.map(playerName).join(' & ')} win${b.winners.length > 1 ? ' (split)' : 's'}`}
+								</span>
+							</div>
+						))}
+					</div>
+				</div>
+			)}
+		</div>
+	)
+}
+
+function OutlookCard({
+	outlook,
+	name,
+	fixtureLabel,
+}: {
+	outlook: PlayerOutlook
+	name: string
+	fixtureLabel: (id: string) => string
+}) {
+	const { verdict, floor, ceiling, pivotalPicks } = outlook
+	const streak = floor === ceiling ? `${floor}` : `${floor}–${ceiling}`
+	return (
+		<div
+			className={cn(
+				'rounded-lg border px-3 py-2.5',
+				verdict === 'leading'
+					? 'border-[var(--alive)]/60 bg-[var(--alive-bg)]/40'
+					: verdict === 'out'
+						? 'border-border bg-muted/20 opacity-70'
+						: 'border-border bg-card',
+			)}
+		>
+			<div className="flex items-center justify-between gap-2">
+				<span className="font-semibold truncate">{name}</span>
+				<VerdictBadge verdict={verdict} />
+			</div>
+			<div className="mt-1 flex items-center gap-3 text-xs text-muted-foreground">
+				<span className="inline-flex items-center gap-1">
+					<Flame className="h-3 w-3 text-[var(--draw)]" /> streak {streak}
+				</span>
+				{verdict === 'in_contention' && pivotalPicks.length > 0 && (
+					<span>
+						hinges on{' '}
+						<span className="font-medium text-foreground">
+							{fixtureLabel(pivotalPicks[0].fixtureId)}
+						</span>
+						{pivotalPicks.length > 1 && `, then ${pivotalPicks.length - 1} more`}
+					</span>
+				)}
+			</div>
+		</div>
+	)
+}
+
+function VerdictBadge({ verdict }: { verdict: PlayerOutlook['verdict'] }) {
+	const map = {
+		leading: { label: 'Leading', cls: 'bg-[var(--alive)] text-white' },
+		in_contention: { label: 'In contention', cls: 'bg-[var(--draw-bg)] text-[var(--draw)]' },
+		out: { label: "Can't win", cls: 'bg-[var(--eliminated-bg)] text-[var(--eliminated)]' },
+	}[verdict]
+	return (
+		<span
+			className={cn(
+				'shrink-0 rounded px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide',
+				map.cls,
+			)}
+		>
+			{map.label}
+		</span>
+	)
+}

--- a/src/components/standings/turbo-standings.tsx
+++ b/src/components/standings/turbo-standings.tsx
@@ -1,12 +1,14 @@
 'use client'
 
-import { Clock, Flame, LayoutGrid, ListTree, Target } from 'lucide-react'
+import { Clock, Flame, LayoutGrid, ListTree, Target, Trophy } from 'lucide-react'
 import { useState } from 'react'
 import { useLiveGame } from '@/components/live/use-live-game'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import type { WinScenarios } from '@/lib/game-logic/win-scenarios'
 import { cn } from '@/lib/utils'
 import { AdminPlayerActions } from './admin-player-actions'
+import { ScenariosView } from './scenarios-view'
 import { type LadderFixture, TurboLadder } from './turbo-ladder'
 import { TurboTimeline } from './turbo-timeline'
 
@@ -54,6 +56,8 @@ export interface TurboRoundSummary {
 	status: 'open' | 'active' | 'completed'
 	players: TurboPlayerRow[]
 	fixtures: LadderFixture[]
+	/** win-scenario analysis; null pre-deadline (picks hidden) or when not computed. */
+	scenarios?: WinScenarios | null
 }
 
 interface TurboStandingsProps {
@@ -66,7 +70,7 @@ interface TurboStandingsProps {
 
 const _PRED_ABBREV = { home_win: 'H', draw: 'D', away_win: 'A' } as const
 
-type ViewMode = 'ladder' | 'grid' | 'timeline'
+type ViewMode = 'ladder' | 'grid' | 'timeline' | 'scenarios'
 
 export function TurboStandings({
 	rounds,
@@ -151,6 +155,20 @@ export function TurboStandings({
 						>
 							<LayoutGrid className="h-3 w-3" /> Grid
 						</button>
+						{round.scenarios && (
+							<button
+								type="button"
+								onClick={() => setView('scenarios')}
+								className={cn(
+									'text-xs font-semibold px-2.5 py-1 rounded flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+									view === 'scenarios'
+										? 'bg-foreground text-background'
+										: 'text-muted-foreground hover:text-foreground',
+								)}
+							>
+								<Trophy className="h-3 w-3" /> Scenarios
+							</button>
+						)}
 					</div>
 					{rounds.length > 1 && (
 						<div className="flex gap-1 border border-border rounded-md p-0.5">
@@ -204,6 +222,26 @@ export function TurboStandings({
 					gameId={gameId}
 					roundStatus={round.status}
 				/>
+			)}
+
+			{view === 'scenarios' && round.scenarios && (
+				<div className="p-4 md:p-5">
+					<ScenariosView
+						scenarios={round.scenarios}
+						playerName={(id) => round.players.find((p) => p.id === id)?.name ?? 'Player'}
+						fixtureLabel={(id) => {
+							const f = round.fixtures.find((x) => x.id === id)
+							return f ? `${f.home.shortName} v ${f.away.shortName}` : '?'
+						}}
+						describeOutcome={(id, outcome) => {
+							const f = round.fixtures.find((x) => x.id === id)
+							if (!f) return outcome
+							if (outcome === 'home_win') return `${f.home.shortName} win`
+							if (outcome === 'away_win') return `${f.away.shortName} win`
+							return `${f.home.shortName} v ${f.away.shortName} draw`
+						}}
+					/>
+				</div>
 			)}
 		</div>
 	)

--- a/src/lib/game-logic/win-scenarios.test.ts
+++ b/src/lib/game-logic/win-scenarios.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+import {
+	type FixtureOutcomes,
+	type Outcome,
+	type ScenarioPlayerInput,
+	winScenarios,
+} from './win-scenarios'
+
+function player(
+	id: string,
+	picks: [rank: number, fixtureId: string, predictedResult: Outcome][],
+): ScenarioPlayerInput {
+	return {
+		gamePlayerId: id,
+		livesRemaining: 0,
+		picks: picks.map(([rank, fixtureId, predictedResult]) => ({
+			rank,
+			fixtureId,
+			predictedResult,
+		})),
+	}
+}
+
+const turbo = { mode: 'turbo' as const }
+
+function outlook(res: ReturnType<typeof winScenarios>, id: string) {
+	const o = res.outlooks.find((x) => x.gamePlayerId === id)
+	if (!o) throw new Error(`no outlook for ${id}`)
+	return o
+}
+
+function branchFor(res: ReturnType<typeof winScenarios>, fixtureId: string, outcome: Outcome) {
+	return (res.table ?? []).find(
+		(b) =>
+			b.conditions.length === 1 &&
+			b.conditions[0].fixtureId === fixtureId &&
+			b.conditions[0].outcome === outcome,
+	)
+}
+
+describe('winScenarios (turbo)', () => {
+	it('A: fully-played game → leading winner + out loser, no table', () => {
+		const fixtures: FixtureOutcomes = { f1: 'home_win', f2: 'home_win' }
+		const res = winScenarios(
+			[
+				player('p1', [
+					[1, 'f1', 'home_win'],
+					[2, 'f2', 'home_win'],
+				]), // streak 2
+				player('p2', [
+					[1, 'f1', 'away_win'],
+					[2, 'f2', 'home_win'],
+				]), // r1 wrong → streak 0
+			],
+			fixtures,
+			turbo,
+		)
+		expect(outlook(res, 'p1')).toMatchObject({ floor: 2, ceiling: 2, verdict: 'leading' })
+		expect(outlook(res, 'p2')).toMatchObject({ floor: 0, ceiling: 0, verdict: 'out' })
+		expect(res.table).toBeNull()
+		expect(res.pivotalFixtureIds).toEqual([])
+		expect(res.tooManyToEnumerate).toBe(false)
+	})
+
+	it('B: one pending fixture decides it → table with a branch per outcome', () => {
+		const fixtures: FixtureOutcomes = { f1: 'home_win', f2: null }
+		const res = winScenarios(
+			[
+				player('p1', [
+					[1, 'f1', 'home_win'],
+					[2, 'f2', 'home_win'],
+				]),
+				player('p2', [
+					[1, 'f1', 'home_win'],
+					[2, 'f2', 'away_win'],
+				]),
+			],
+			fixtures,
+			turbo,
+		)
+		expect(outlook(res, 'p1')).toMatchObject({ floor: 1, ceiling: 2, verdict: 'in_contention' })
+		expect(outlook(res, 'p2')).toMatchObject({ floor: 1, ceiling: 2, verdict: 'in_contention' })
+		// the pivotal pick for each is their rank-2 pick on f2
+		expect(outlook(res, 'p1').pivotalPicks).toEqual([{ rank: 2, fixtureId: 'f2' }])
+		expect(res.pivotalFixtureIds).toEqual(['f2'])
+		expect(branchFor(res, 'f2', 'home_win')?.winners).toEqual(['p1'])
+		expect(branchFor(res, 'f2', 'away_win')?.winners).toEqual(['p2'])
+		const draw = branchFor(res, 'f2', 'draw')
+		expect(draw?.winners.sort()).toEqual(['p1', 'p2'])
+		expect(draw?.tieOnGoals).toBe(true)
+	})
+
+	it('C: a guaranteed leader despite an unplayed pick → no table, no pivotal fixtures', () => {
+		const fixtures: FixtureOutcomes = { f1: 'home_win', f2: 'home_win', f3: null }
+		const res = winScenarios(
+			[
+				player('p1', [
+					[1, 'f1', 'home_win'],
+					[2, 'f2', 'home_win'],
+					[3, 'f3', 'home_win'],
+				]),
+				player('p2', [
+					[1, 'f1', 'away_win'],
+					[2, 'f2', 'home_win'],
+					[3, 'f3', 'home_win'],
+				]),
+			],
+			fixtures,
+			turbo,
+		)
+		expect(outlook(res, 'p1')).toMatchObject({ floor: 2, ceiling: 3, verdict: 'leading' })
+		expect(outlook(res, 'p2').verdict).toBe('out')
+		expect(res.table).toBeNull() // winner settled regardless of f3
+		expect(res.pivotalFixtureIds).toEqual([])
+	})
+
+	it('D: above the enumeration cap → approximate ranges, no table', () => {
+		const fixtures: FixtureOutcomes = { f1: null, f2: null }
+		const res = winScenarios(
+			[
+				player('p1', [
+					[1, 'f1', 'home_win'],
+					[2, 'f2', 'home_win'],
+				]),
+				player('p2', [
+					[1, 'f1', 'away_win'],
+					[2, 'f2', 'away_win'],
+				]),
+			],
+			fixtures,
+			{ mode: 'turbo', cap: 1 },
+		)
+		expect(res.tooManyToEnumerate).toBe(true)
+		expect(res.table).toBeNull()
+		// worst case both picks lose → 0; best case both win → 2
+		expect(outlook(res, 'p1')).toMatchObject({ floor: 0, ceiling: 2, verdict: 'in_contention' })
+		// pivotal picks = reachable unplayed picks, earliest first
+		expect(outlook(res, 'p1').pivotalPicks).toEqual([
+			{ rank: 1, fixtureId: 'f1' },
+			{ rank: 2, fixtureId: 'f2' },
+		])
+	})
+
+	it('E: a known early loss caps the window — later unplayed picks are not pivotal', () => {
+		// p1 rank-1 already lost → streak frozen at 0; rank-2 unplayed is unreachable.
+		const fixtures: FixtureOutcomes = { f1: 'away_win', f2: null }
+		const res = winScenarios(
+			[
+				player('p1', [
+					[1, 'f1', 'home_win'],
+					[2, 'f2', 'home_win'],
+				]), // r1 lost
+				player('p2', [
+					[1, 'f1', 'away_win'],
+					[2, 'f2', 'home_win'],
+				]), // r1 won, r2 pending
+			],
+			fixtures,
+			turbo,
+		)
+		expect(outlook(res, 'p1')).toMatchObject({ floor: 0, ceiling: 0 })
+		expect(outlook(res, 'p1').pivotalPicks).toEqual([]) // f2 unreachable for p1
+		// p2 leads with >=1 and can reach 2; p1 capped at 0 → p2 guaranteed
+		expect(outlook(res, 'p2').verdict).toBe('leading')
+		expect(res.pivotalFixtureIds).toEqual([])
+	})
+})

--- a/src/lib/game-logic/win-scenarios.ts
+++ b/src/lib/game-logic/win-scenarios.ts
@@ -1,0 +1,283 @@
+// Win-scenario engine for the single-round modes (turbo now; cup to follow).
+//
+// Given each player's confidence-ranked picks and the current fixture results,
+// it answers: who can still win, and which unplayed picks decide it. The heart
+// is reuse of the canonical winner-determination logic (`resolveWipeout` + the
+// mode tiebreaker) over HYPOTHETICAL completions — so a "scenario" is just the
+// real settlement run on a what-if result set, and stays consistent with how
+// the game actually crowns a winner.
+//
+// Approach:
+//   1. Per player, find the unplayed picks inside their reachable streak window
+//      (ranks the streak could still reach). These are the picks that matter —
+//      the "picks not yet played at the start of a streak".
+//   2. The decisive fixture set is the union of those across players. Everything
+//      else can't change the winner, so the scenario space is bounded by it.
+//   3. When that set is small enough (<= cap), enumerate every outcome combo,
+//      run the real winner-determination per combo, and derive exact verdicts
+//      (wins-in-all = leading, wins-in-none = out, else in-contention) plus a
+//      decision table. Above the cap, fall back to an approximate per-player
+//      streak range (early game; labelled).
+
+import { resolveWipeout, turboTiebreaker } from './auto-complete-tiebreakers'
+
+export type Outcome = 'home_win' | 'draw' | 'away_win'
+const OUTCOMES: Outcome[] = ['home_win', 'draw', 'away_win']
+
+export interface ScenarioPick {
+	rank: number
+	fixtureId: string
+	/** turbo: the player's predicted result for the fixture. */
+	predictedResult: Outcome
+}
+
+export interface ScenarioPlayerInput {
+	gamePlayerId: string
+	/** final lives — cup tiebreak only; pass 0 for turbo. */
+	livesRemaining: number
+	picks: ScenarioPick[]
+}
+
+/** Outcome of each fixture; `null` (or absent) = not yet played. */
+export type FixtureOutcomes = Record<string, Outcome | null>
+
+export type Verdict = 'leading' | 'in_contention' | 'out'
+
+export interface PlayerOutlook {
+	gamePlayerId: string
+	floor: number
+	ceiling: number
+	verdict: Verdict
+	/** unplayed picks inside the player's reachable window, earliest (most pivotal) first. */
+	pivotalPicks: { rank: number; fixtureId: string }[]
+}
+
+export interface ScenarioBranch {
+	/** the unplayed-fixture outcomes that produce this result. */
+	conditions: { fixtureId: string; outcome: Outcome }[]
+	/** winning gamePlayerIds; >1 = a streak tie the goals tiebreak (unknown here) would settle. */
+	winners: string[]
+	tieOnGoals: boolean
+}
+
+export interface WinScenarios {
+	outlooks: PlayerOutlook[]
+	/** decisive branches grouped per combo; null when the winner is already settled or too many fixtures remain. */
+	table: ScenarioBranch[] | null
+	pivotalFixtureIds: string[]
+	/** true when too many unplayed fixtures remain to enumerate — outlooks are then approximate. */
+	tooManyToEnumerate: boolean
+}
+
+const DEFAULT_CAP = 5
+
+/** Did a pick keep the streak alive, given its fixture's outcome? (turbo rules) */
+function isCorrect(pick: ScenarioPick, outcome: Outcome, _mode: 'turbo' | 'cup'): boolean {
+	// turbo: the predicted result must match. (cup adds tier/lives — handled in a follow-up.)
+	return pick.predictedResult === outcome
+}
+
+/**
+ * The player's unplayed picks that their streak could still reach — i.e. the
+ * leading run of picks up to (and not past) the first KNOWN losing pick.
+ * Returned earliest-rank first; index 0 is the make-or-break pivot.
+ */
+function reachablePending(
+	player: ScenarioPlayerInput,
+	fixtures: FixtureOutcomes,
+	mode: 'turbo' | 'cup',
+): ScenarioPick[] {
+	const sorted = [...player.picks].sort((a, b) => a.rank - b.rank)
+	const out: ScenarioPick[] = []
+	for (const pk of sorted) {
+		const oc = fixtures[pk.fixtureId] ?? null
+		if (oc === null) {
+			out.push(pk)
+			continue
+		}
+		if (!isCorrect(pk, oc, mode)) break // a known loss caps the reachable window
+	}
+	return out
+}
+
+/** Best/worst-case streak ignoring wipeout — only used for the >cap fallback. */
+function streakRange(
+	player: ScenarioPlayerInput,
+	fixtures: FixtureOutcomes,
+	mode: 'turbo' | 'cup',
+): { floor: number; ceiling: number } {
+	const sorted = [...player.picks].sort((a, b) => a.rank - b.rank)
+	let floor = 0
+	for (const pk of sorted) {
+		const oc = fixtures[pk.fixtureId] ?? null
+		if (oc === null) break // worst case: this unplayed pick loses
+		if (!isCorrect(pk, oc, mode)) break
+		floor++
+	}
+	let ceiling = 0
+	for (const pk of sorted) {
+		const oc = fixtures[pk.fixtureId] ?? null
+		if (oc === null) {
+			ceiling++
+			continue
+		} // best case: unplayed pick wins
+		if (!isCorrect(pk, oc, mode)) break
+		ceiling++
+	}
+	return { floor, ceiling }
+}
+
+function enumerateOutcomes(fixtureIds: string[]): Record<string, Outcome>[] {
+	let combos: Record<string, Outcome>[] = [{}]
+	for (const f of fixtureIds) {
+		const next: Record<string, Outcome>[] = []
+		for (const c of combos) for (const o of OUTCOMES) next.push({ ...c, [f]: o })
+		combos = next
+	}
+	return combos
+}
+
+interface Branch {
+	conditions: { fixtureId: string; outcome: Outcome }[]
+	winners: string[]
+	tieOnGoals: boolean
+	streaks: Map<string, number>
+}
+
+/** A candidate fixture is decisive if, holding the others fixed, varying it changes the winner. */
+function isDecisive(fixtureId: string, branches: Branch[], candidates: string[]): boolean {
+	const others = candidates.filter((c) => c !== fixtureId)
+	const byOthers = new Map<string, Set<string>>()
+	for (const b of branches) {
+		const key = others.map((o) => b.conditions.find((c) => c.fixtureId === o)?.outcome).join('|')
+		const ws = [...b.winners].sort().join(',')
+		const set = byOthers.get(key) ?? new Set<string>()
+		set.add(ws)
+		byOthers.set(key, set)
+	}
+	return [...byOthers.values()].some((s) => s.size > 1)
+}
+
+function buildTable(branches: Branch[], pivotal: string[]): ScenarioBranch[] {
+	const seen = new Map<string, ScenarioBranch>()
+	for (const b of branches) {
+		const conditions = b.conditions.filter((c) => pivotal.includes(c.fixtureId))
+		const key = `${conditions
+			.map((c) => `${c.fixtureId}:${c.outcome}`)
+			.sort()
+			.join('|')}=>${[...b.winners].sort().join(',')}`
+		if (!seen.has(key)) seen.set(key, { conditions, winners: b.winners, tieOnGoals: b.tieOnGoals })
+	}
+	return [...seen.values()]
+}
+
+export function winScenarios(
+	players: ScenarioPlayerInput[],
+	fixtures: FixtureOutcomes,
+	opts: { mode: 'turbo' | 'cup'; cap?: number },
+): WinScenarios {
+	const { mode } = opts
+	const cap = opts.cap ?? DEFAULT_CAP
+
+	const reachable = new Map<string, ScenarioPick[]>()
+	for (const p of players) reachable.set(p.gamePlayerId, reachablePending(p, fixtures, mode))
+
+	const candidateSet = new Set<string>()
+	for (const picks of reachable.values()) for (const pk of picks) candidateSet.add(pk.fixtureId)
+	const candidates = [...candidateSet]
+
+	// Fallback: too many unplayed fixtures still bear on the outcome to enumerate.
+	if (candidates.length > cap) {
+		const ranges = new Map(players.map((p) => [p.gamePlayerId, streakRange(p, fixtures, mode)]))
+		const outlooks = players.map((p): PlayerOutlook => {
+			const { floor, ceiling } = ranges.get(p.gamePlayerId) as { floor: number; ceiling: number }
+			const out = players.some(
+				(q) =>
+					q.gamePlayerId !== p.gamePlayerId && (ranges.get(q.gamePlayerId)?.floor ?? 0) > ceiling,
+			)
+			const leading = players.every(
+				(q) =>
+					q.gamePlayerId === p.gamePlayerId || floor >= (ranges.get(q.gamePlayerId)?.ceiling ?? 0),
+			)
+			const verdict: Verdict = out ? 'out' : leading ? 'leading' : 'in_contention'
+			return {
+				gamePlayerId: p.gamePlayerId,
+				floor,
+				ceiling,
+				verdict,
+				pivotalPicks:
+					verdict === 'in_contention'
+						? (reachable.get(p.gamePlayerId) ?? []).map((pk) => ({
+								rank: pk.rank,
+								fixtureId: pk.fixtureId,
+							}))
+						: [],
+			}
+		})
+		return { outlooks, table: null, pivotalFixtureIds: [], tooManyToEnumerate: true }
+	}
+
+	// Enumerate every outcome combo over the decisive candidate fixtures and run the
+	// real winner-determination (resolveWipeout + tiebreak) on each hypothetical.
+	const tiebreak = turboTiebreaker // cup tiebreak swapped in with the cup evaluator
+	const branches: Branch[] = enumerateOutcomes(candidates).map((combo) => {
+		const merged: FixtureOutcomes = { ...fixtures, ...combo }
+		const wipeoutInput = players.map((p) => ({
+			gamePlayerId: p.gamePlayerId,
+			livesRemaining: p.livesRemaining,
+			picks: p.picks
+				.filter((pk) => merged[pk.fixtureId] != null)
+				.map((pk) => ({
+					rank: pk.rank,
+					correct: isCorrect(pk, merged[pk.fixtureId] as Outcome, mode),
+					goals: 0,
+				})),
+		}))
+		const { scores } = resolveWipeout(wipeoutInput)
+		const winners = tiebreak(
+			scores.map((s) => ({
+				gamePlayerId: s.gamePlayerId,
+				streak: s.streak,
+				goalsInStreak: s.goalsInStreak,
+			})),
+		)
+		return {
+			conditions: candidates.map((f) => ({ fixtureId: f, outcome: combo[f] })),
+			winners,
+			tieOnGoals: winners.length > 1,
+			streaks: new Map(scores.map((s) => [s.gamePlayerId, s.streak])),
+		}
+	})
+
+	const outlooks = players.map((p): PlayerOutlook => {
+		const id = p.gamePlayerId
+		const streaks = branches.map((b) => b.streaks.get(id) ?? 0)
+		const winsCount = branches.filter((b) => b.winners.includes(id)).length
+		const verdict: Verdict =
+			winsCount === branches.length ? 'leading' : winsCount === 0 ? 'out' : 'in_contention'
+		return {
+			gamePlayerId: id,
+			floor: Math.min(...streaks),
+			ceiling: Math.max(...streaks),
+			verdict,
+			pivotalPicks:
+				verdict === 'in_contention'
+					? (reachable.get(id) ?? []).map((pk) => ({ rank: pk.rank, fixtureId: pk.fixtureId }))
+					: [],
+		}
+	})
+
+	const winnerSets = new Set(branches.map((b) => [...b.winners].sort().join(',')))
+	if (winnerSets.size <= 1) {
+		// Winner already settled regardless of remaining results.
+		return { outlooks, table: null, pivotalFixtureIds: [], tooManyToEnumerate: false }
+	}
+
+	const pivotalFixtureIds = candidates.filter((f) => isDecisive(f, branches, candidates))
+	return {
+		outlooks,
+		table: buildTable(branches, pivotalFixtureIds),
+		pivotalFixtureIds,
+		tooManyToEnumerate: false,
+	}
+}

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -17,6 +17,12 @@ import { deriveGameRoundStatus } from '@/lib/game/round-status'
 import { evaluateCupPicks } from '@/lib/game-logic/cup'
 import { computeTierDifference } from '@/lib/game-logic/cup-tier'
 import { calculatePot, expectedEntryCount } from '@/lib/game-logic/prizes'
+import {
+	type FixtureOutcomes,
+	type Outcome,
+	type WinScenarios,
+	winScenarios,
+} from '@/lib/game-logic/win-scenarios'
 import { fixture, round, team } from '@/lib/schema/competition'
 import { game, type gamePlayer, pick } from '@/lib/schema/game'
 import { payment } from '@/lib/schema/payment'
@@ -789,6 +795,41 @@ export async function getTurboStandingsData(
 			}))
 			fixtures.sort((a, b) => a.avgRank - b.avgRank)
 
+			// Win scenarios — only once the deadline has passed. Pre-deadline picks
+			// are hidden, and "who needs what to win" would leak them, so the engine
+			// is skipped while the round is open.
+			let scenarios: WinScenarios | null = null
+			if (!isRoundOpen) {
+				const roundPicks = gameData.picks.filter((pk) => pk.roundId === r.id && pk.fixtureId)
+				const fixtureOutcomes: FixtureOutcomes = {}
+				for (const pk of roundPicks) {
+					const fx = pk.fixture
+					if (!fx || !pk.fixtureId || pk.fixtureId in fixtureOutcomes) continue
+					// Only a FINISHED fixture is a known outcome; in-progress fixtures are
+					// still undecided (treated as unplayed for scenario purposes).
+					fixtureOutcomes[pk.fixtureId] =
+						fx.status === 'finished' && fx.homeScore != null && fx.awayScore != null
+							? fx.homeScore > fx.awayScore
+								? 'home_win'
+								: fx.awayScore > fx.homeScore
+									? 'away_win'
+									: 'draw'
+							: null
+				}
+				const scenarioPlayers = gameData.players.map((p) => ({
+					gamePlayerId: p.id,
+					livesRemaining: 0,
+					picks: roundPicks
+						.filter((pk) => pk.gamePlayerId === p.id)
+						.map((pk) => ({
+							rank: pk.confidenceRank ?? 0,
+							fixtureId: pk.fixtureId as string,
+							predictedResult: (pk.predictedResult ?? 'draw') as Outcome,
+						})),
+				}))
+				scenarios = winScenarios(scenarioPlayers, fixtureOutcomes, { mode: 'turbo' })
+			}
+
 			return {
 				id: r.id,
 				number: r.number,
@@ -797,6 +838,7 @@ export async function getTurboStandingsData(
 				status: derivedStatus as 'open' | 'active' | 'completed',
 				players,
 				fixtures,
+				scenarios,
 			}
 		}),
 	}


### PR DESCRIPTION
## The idea

Turbo/cup already have ladder + timeline views for *what's coming*. This adds the thing players actually want late in a gameweek: **what still has to happen for each player to win**, and **which unplayed picks decide it** — with the most important being the unplayed picks at the *start* of a player's streak.

This is also the correct, non-binary version of "elimination" we discussed: instead of marking a frozen streak as "out", it says *"leads unless someone beats N"* and shows exactly which results could.

> Scope: **turbo first** (clean rules — no lives/tier/wipeout coupling) as a reviewable slice. Cup is the follow-up (it layers lives + tier + wipeout via `evaluateCupPicks`); the engine is built to slot it in.

## Engine — `src/lib/game-logic/win-scenarios.ts` (pure, fully tested)

Reuses the **canonical** `resolveWipeout` + tiebreaker over *hypothetical* completions, so a "scenario" is just real settlement run on a what-if result set — it can't drift from how the game actually crowns a winner.

- **Reachable window** per player → the unplayed picks the streak could still reach (the "picks at the start of a streak"); their union bounds the decisive fixture set, so the scenario space stays small.
- **Small enough (≤ cap):** enumerate every outcome combo, run the real winner-determination, and derive **exact** verdicts — wins-in-all = `leading`, wins-in-none = `out`, else `in_contention` — plus a **decision table** ("`POR win` → Sean wins", "`draw` → Alice & Bob tie (goals decide)").
- **Above the cap (early game):** fall back to an approximate best/worst streak range, labelled.

## View — new "Scenarios" toggle (turbo)

Per-player verdict cards (badge + streak range + the fixture the streak *hinges on*) and, once it narrows, the decision table. Computed in `getTurboStandingsData` **post-deadline only** — pre-deadline picks are hidden and "who needs what" would leak them.

## Testing

- **Engine** (`win-scenarios.test.ts`): fully-played, single-decisive-fixture table, guaranteed-winner short-circuit, above-cap fallback, and known-early-loss window capping.
- **View** (`scenarios-view.test.tsx`): verdicts, decision table, early-game note.
- typecheck · biome · **537 unit** · build all green.
- **Dev-server SSR:** toggle present on a post-deadline turbo game, absent pre-deadline (secrecy gate), and the `WinScenarios` object serialises cleanly across the RSC boundary.

Follow-ups: cup mode; in-grid pivotal-pick highlight (the view already names each player's pivotal fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)