### PR TITLE
feat(cup): score knockout ties on the 90-minute result (underdog draws survive)

### DIFF
--- a/drizzle/0008_outgoing_misty_knight.sql
+++ b/drizzle/0008_outgoing_misty_knight.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "fixture" ADD COLUMN "regular_home_score" integer;--> statement-breakpoint
+ALTER TABLE "fixture" ADD COLUMN "regular_away_score" integer;

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1690 @@
+{
+  "id": "e215c93f-6a0a-4d52-8f3e-912b3f9072f8",
+  "prevId": "59fce0f3-bff9-4e07-9366-2586d1f0e1d8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition": {
+      "name": "competition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "competition_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_source": {
+          "name": "data_source",
+          "type": "competition_data_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "season": {
+          "name": "season",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fixture": {
+      "name": "fixture",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_team_id": {
+          "name": "home_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "away_team_id": {
+          "name": "away_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kickoff": {
+          "name": "kickoff",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_score": {
+          "name": "home_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "away_score": {
+          "name": "away_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regular_home_score": {
+          "name": "regular_home_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regular_away_score": {
+          "name": "regular_away_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winner": {
+          "name": "winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "fixture_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ids": {
+          "name": "external_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fixture_round_id_round_id_fk": {
+          "name": "fixture_round_id_round_id_fk",
+          "tableFrom": "fixture",
+          "tableTo": "round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fixture_home_team_id_team_id_fk": {
+          "name": "fixture_home_team_id_team_id_fk",
+          "tableFrom": "fixture",
+          "tableTo": "team",
+          "columnsFrom": [
+            "home_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "fixture_away_team_id_team_id_fk": {
+          "name": "fixture_away_team_id_team_id_fk",
+          "tableFrom": "fixture",
+          "tableTo": "team",
+          "columnsFrom": [
+            "away_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.round": {
+      "name": "round",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "round_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upcoming'"
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "round_competition_id_competition_id_fk": {
+          "name": "round_competition_id_competition_id_fk",
+          "tableFrom": "round",
+          "tableTo": "competition",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team": {
+      "name": "team",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_url": {
+          "name": "badge_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_color": {
+          "name": "primary_color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_ids": {
+          "name": "external_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "league_position": {
+          "name": "league_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_form": {
+      "name": "team_form",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recent_results": {
+          "name": "recent_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "home_form": {
+          "name": "home_form",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "away_form": {
+          "name": "away_form",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "league_position": {
+          "name": "league_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_form_team_comp_idx": {
+          "name": "team_form_team_comp_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_form_team_id_team_id_fk": {
+          "name": "team_form_team_id_team_id_fk",
+          "tableFrom": "team_form",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_form_competition_id_competition_id_fk": {
+          "name": "team_form_competition_id_competition_id_fk",
+          "tableFrom": "team_form",
+          "tableTo": "competition",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game": {
+      "name": "game",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "game_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'setup'"
+        },
+        "game_mode": {
+          "name": "game_mode",
+          "type": "game_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode_config": {
+          "name": "mode_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_players": {
+          "name": "max_players",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_round_id": {
+          "name": "current_round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_competition_id_competition_id_fk": {
+          "name": "game_competition_id_competition_id_fk",
+          "tableFrom": "game",
+          "tableTo": "competition",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_current_round_id_round_id_fk": {
+          "name": "game_current_round_id_round_id_fk",
+          "tableFrom": "game",
+          "tableTo": "round",
+          "columnsFrom": [
+            "current_round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "game_invite_code_unique": {
+          "name": "game_invite_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_player": {
+      "name": "game_player",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "player_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'alive'"
+        },
+        "eliminated_round_id": {
+          "name": "eliminated_round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eliminated_reason": {
+          "name": "eliminated_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lives_remaining": {
+          "name": "lives_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_player_unique_idx": {
+          "name": "game_player_unique_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_player_game_id_game_id_fk": {
+          "name": "game_player_game_id_game_id_fk",
+          "tableFrom": "game_player",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "game_player_eliminated_round_id_round_id_fk": {
+          "name": "game_player_eliminated_round_id_round_id_fk",
+          "tableFrom": "game_player",
+          "tableTo": "round",
+          "columnsFrom": [
+            "eliminated_round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pick": {
+      "name": "pick",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_player_id": {
+          "name": "game_player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fixture_id": {
+          "name": "fixture_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_rank": {
+          "name": "confidence_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "predicted_result": {
+          "name": "predicted_result",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "pick_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "goals_scored": {
+          "name": "goals_scored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "life_gained": {
+          "name": "life_gained",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "life_spent": {
+          "name": "life_spent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_submitted": {
+          "name": "auto_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_auto": {
+          "name": "is_auto",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pick_player_round_idx": {
+          "name": "pick_player_round_idx",
+          "columns": [
+            {
+              "expression": "game_player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "round_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "confidence_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pick_game_id_game_id_fk": {
+          "name": "pick_game_id_game_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_game_player_id_game_player_id_fk": {
+          "name": "pick_game_player_id_game_player_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "game_player",
+          "columnsFrom": [
+            "game_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_round_id_round_id_fk": {
+          "name": "pick_round_id_round_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_team_id_team_id_fk": {
+          "name": "pick_team_id_team_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pick_fixture_id_fixture_id_fk": {
+          "name": "pick_fixture_id_fixture_id_fk",
+          "tableFrom": "pick",
+          "tableTo": "fixture",
+          "columnsFrom": [
+            "fixture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.planned_pick": {
+      "name": "planned_pick",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_player_id": {
+          "name": "game_player_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_submit": {
+          "name": "auto_submit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "planned_pick_unique_idx": {
+          "name": "planned_pick_unique_idx",
+          "columns": [
+            {
+              "expression": "game_player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "round_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "planned_pick_game_player_id_game_player_id_fk": {
+          "name": "planned_pick_game_player_id_game_player_id_fk",
+          "tableFrom": "planned_pick",
+          "tableTo": "game_player",
+          "columnsFrom": [
+            "game_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "planned_pick_round_id_round_id_fk": {
+          "name": "planned_pick_round_id_round_id_fk",
+          "tableFrom": "planned_pick",
+          "tableTo": "round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "planned_pick_team_id_team_id_fk": {
+          "name": "planned_pick_team_id_team_id_fk",
+          "tableFrom": "planned_pick",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_run": {
+      "name": "cron_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "route": {
+          "name": "route",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment": {
+      "name": "payment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payment_game_id_game_id_fk": {
+          "name": "payment_game_id_game_id_fk",
+          "tableFrom": "payment",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payout": {
+      "name": "payout",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_split": {
+          "name": "is_split",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "payout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payout_game_id_game_id_fk": {
+          "name": "payout_game_id_game_id_fk",
+          "tableFrom": "payout",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.competition_data_source": {
+      "name": "competition_data_source",
+      "schema": "public",
+      "values": [
+        "fpl",
+        "football_data",
+        "manual"
+      ]
+    },
+    "public.competition_type": {
+      "name": "competition_type",
+      "schema": "public",
+      "values": [
+        "league",
+        "knockout",
+        "group_knockout"
+      ]
+    },
+    "public.fixture_status": {
+      "name": "fixture_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "live",
+        "finished",
+        "postponed",
+        "cancelled"
+      ]
+    },
+    "public.round_status": {
+      "name": "round_status",
+      "schema": "public",
+      "values": [
+        "upcoming",
+        "open",
+        "active",
+        "completed"
+      ]
+    },
+    "public.game_mode": {
+      "name": "game_mode",
+      "schema": "public",
+      "values": [
+        "classic",
+        "turbo",
+        "cup"
+      ]
+    },
+    "public.game_status": {
+      "name": "game_status",
+      "schema": "public",
+      "values": [
+        "setup",
+        "open",
+        "active",
+        "completed"
+      ]
+    },
+    "public.pick_result": {
+      "name": "pick_result",
+      "schema": "public",
+      "values": [
+        "pending",
+        "win",
+        "loss",
+        "draw",
+        "saved_by_life",
+        "void"
+      ]
+    },
+    "public.player_status": {
+      "name": "player_status",
+      "schema": "public",
+      "values": [
+        "alive",
+        "eliminated",
+        "winner"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "manual",
+        "mangopay"
+      ]
+    },
+    "public.payment_status": {
+      "name": "payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "claimed",
+        "paid",
+        "refunded"
+      ]
+    },
+    "public.payout_status": {
+      "name": "payout_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1782250018684,
       "tag": "0007_fast_gunslinger",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1782635794192,
+      "tag": "0008_outgoing_misty_knight",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/smoke/helpers.ts
+++ b/scripts/smoke/helpers.ts
@@ -214,10 +214,19 @@ export async function finishFixture(
 	homeScore: number,
 	awayScore: number,
 	winner?: 'home' | 'away' | null,
+	regular?: { home: number; away: number },
 ): Promise<void> {
 	await db
 		.update(fixture)
-		.set({ status: 'finished', homeScore, awayScore, winner: winner ?? null })
+		.set({
+			status: 'finished',
+			homeScore,
+			awayScore,
+			winner: winner ?? null,
+			// Optional 90-minute (regulation) score — for knockout ties decided in
+			// ET/penalties, where it differs from the full-time/winner result.
+			...(regular ? { regularHomeScore: regular.home, regularAwayScore: regular.away } : {}),
+		})
 		.where(sql`${fixture.id} = ${fixtureId}`)
 }
 

--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -666,6 +666,59 @@ describe('lifecycle: cup-WC', () => {
 		expect(hero?.status).toBe('alive')
 	})
 
+	it('knockout: a +1 underdog level at 90 minutes survives (draw_success) even if the tie is lost on penalties', async () => {
+		// Cup scores on the 90-minute result, not qualification. A +1 underdog that
+		// is level at 90 minutes survives the round even though the favourite then
+		// wins the shootout — the behaviour Sean asked for. Classic (separate) still
+		// scores knockouts by the qualification `winner`.
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		const fav = await makeTeam({ name: 'Favourite', shortName: 'FAV', fifaPot: 1 })
+		const dog = await makeTeam({ name: 'Underdog', shortName: 'DOG', fifaPot: 2 }) // +1 underdog
+		const o1 = await makeTeam({ name: 'Other One', shortName: 'OON', fifaPot: 2 })
+		const o2 = await makeTeam({ name: 'Other Two', shortName: 'OTW', fifaPot: 2 })
+		const r = await makeRound(compId, { number: 4, status: 'open' }) // R32
+		const tie = await makeFixture({ roundId: r, homeTeamId: fav, awayTeamId: dog })
+		const unplayed = await makeFixture({ roundId: r, homeTeamId: o1, awayTeamId: o2 })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'cup',
+			currentRoundId: r,
+			modeConfig: { numberOfPicks: 1, startingLives: 0 },
+		})
+		const gpDog = await makePlayer({ gameId, userId: 'u-dog', livesRemaining: 0 })
+		const gpFiller = await makePlayer({ gameId, userId: 'u-fill', livesRemaining: 0 })
+		const dogPick = await makePick({
+			gameId,
+			gamePlayerId: gpDog,
+			roundId: r,
+			teamId: dog,
+			fixtureId: tie,
+			confidenceRank: 1,
+		})
+		// filler keeps the gameweek incomplete (unplayed fixture) so we assert the
+		// pick result rather than completion.
+		await makePick({
+			gameId,
+			gamePlayerId: gpFiller,
+			roundId: r,
+			teamId: o1,
+			fixtureId: unplayed,
+			confidenceRank: 1,
+		})
+
+		// 1-1 at 90 minutes; favourite (home) wins on penalties — full-time carries
+		// the shootout-inflated score + winner=home, but regularTime is 1-1.
+		await finishFixture(tie, 4, 2, 'home', { home: 1, away: 1 })
+		await settleFixture(tie)
+
+		// draw_success persists as 'draw'; the player survives (NOT 'loss'/eliminated).
+		const p = await db.query.pick.findFirst({ where: eq(pick.id, dogPick) })
+		expect(p?.result).toBe('draw')
+		const player = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gpDog) })
+		expect(player?.status).toBe('alive')
+	})
+
 	it('does NOT crown while a higher-confidence pick is unplayed — the 1f0d292d mis-crowning', async () => {
 		// Mirrors the incident: rank-1 pick on an UNPLAYED fixture, rank-2 on a
 		// played one. The gameweek is incomplete → no winner, no payout, game stays

--- a/src/app/api/cron/poll-scores/route.ts
+++ b/src/app/api/cron/poll-scores/route.ts
@@ -111,6 +111,8 @@ async function pollScores(apiKey: string): Promise<NextResponse> {
 					.set({
 						homeScore: score.homeScore,
 						awayScore: score.awayScore,
+						regularHomeScore: score.regularHomeScore ?? null,
+						regularAwayScore: score.regularAwayScore ?? null,
 						status: score.status,
 						winner: score.winner ?? null,
 					})

--- a/src/lib/data/football-data.test.ts
+++ b/src/lib/data/football-data.test.ts
@@ -133,6 +133,8 @@ describe('FootballDataAdapter', () => {
 			externalId: '501',
 			homeScore: 2,
 			awayScore: 0,
+			regularHomeScore: null,
+			regularAwayScore: null,
 			status: 'finished',
 			winner: null,
 		})
@@ -339,8 +341,10 @@ describe('FootballDataAdapter', () => {
 			expect(rounds).toHaveLength(6)
 		})
 
-		it('live scores resolve a knockout round by stage, not matchday', async () => {
-			// A resolved + finished Round of 32 tie.
+		it('live scores resolve a knockout round by stage + capture the 90-minute (regularTime) score', async () => {
+			// A finished Round of 32 tie: 1-1 at 90 minutes, home wins on penalties.
+			// football-data's fullTime carries the shootout-inflated score; regularTime
+			// is the 90-minute result we need for cup scoring.
 			const resolved = {
 				matches: [
 					...wcPayload.matches.filter((m) => m.stage !== 'LAST_32'),
@@ -352,7 +356,12 @@ describe('FootballDataAdapter', () => {
 						awayTeam: { id: 770, name: 'Brazil', tla: 'BRA', crest: '' },
 						utcDate: '2026-06-28T19:00:00Z',
 						status: 'FINISHED',
-						score: { winner: 'AWAY_TEAM', fullTime: { home: 1, away: 2 } },
+						score: {
+							winner: 'HOME_TEAM',
+							duration: 'PENALTY_SHOOTOUT',
+							fullTime: { home: 4, away: 3 },
+							regularTime: { home: 1, away: 1 },
+						},
 					},
 				],
 			}
@@ -364,10 +373,12 @@ describe('FootballDataAdapter', () => {
 			expect(scores).toHaveLength(1)
 			expect(scores[0]).toEqual({
 				externalId: '100',
-				homeScore: 1,
-				awayScore: 2,
+				homeScore: 4, // full-time (incl. shootout) — what we store as the score
+				awayScore: 3,
+				regularHomeScore: 1, // 90-minute score — used by cup scoring
+				regularAwayScore: 1,
 				status: 'finished',
-				winner: 'away',
+				winner: 'home',
 			})
 		})
 	})

--- a/src/lib/data/football-data.ts
+++ b/src/lib/data/football-data.ts
@@ -49,7 +49,13 @@ interface FdMatch {
 	// `winner` is the authoritative outcome ('HOME_TEAM' | 'AWAY_TEAM' | 'DRAW' |
 	// null). For knockout ties decided in ET/penalties, fullTime stays level but
 	// winner names the side that advanced.
-	score: { winner?: string | null; fullTime: { home: number | null; away: number | null } }
+	score: {
+		winner?: string | null
+		// `fullTime` includes extra time (and, for shootouts, penalties).
+		// `regularTime` is the 90-minute score (present for ET/penalty matches).
+		fullTime: { home: number | null; away: number | null }
+		regularTime?: { home: number | null; away: number | null }
+	}
 }
 
 /** Map football-data `score.winner` to our home/away marker (DRAW/null → null). */
@@ -215,6 +221,8 @@ export class FootballDataAdapter implements CompetitionAdapter {
 							status: this.mapStatus(m.status),
 							homeScore: m.score.fullTime.home,
 							awayScore: m.score.fullTime.away,
+							regularHomeScore: m.score.regularTime?.home ?? null,
+							regularAwayScore: m.score.regularTime?.away ?? null,
 							winner: mapWinner(m.score.winner),
 						}),
 					),
@@ -241,6 +249,8 @@ export class FootballDataAdapter implements CompetitionAdapter {
 				externalId: String(m.id),
 				homeScore: m.score.fullTime.home as number,
 				awayScore: m.score.fullTime.away as number,
+				regularHomeScore: m.score.regularTime?.home ?? null,
+				regularAwayScore: m.score.regularTime?.away ?? null,
 				status: m.status === 'FINISHED' ? ('finished' as const) : ('live' as const),
 				winner: mapWinner(m.score.winner),
 			}))

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -39,6 +39,11 @@ export interface AdapterFixture {
 	status: 'scheduled' | 'live' | 'finished' | 'postponed' | 'cancelled'
 	homeScore: number | null
 	awayScore: number | null
+	/** 90-minute (regulation) score, when the source reports it separately (e.g.
+	 * football-data's `regularTime` for ET/penalty knockouts). Null/undefined when
+	 * not applicable — regulation-only matches equal the full-time score. */
+	regularHomeScore?: number | null
+	regularAwayScore?: number | null
 	/** Authoritative winner for ET/penalty results (level full-time score); null otherwise. */
 	winner?: 'home' | 'away' | null
 }
@@ -48,6 +53,9 @@ export interface AdapterFixtureScore {
 	homeScore: number
 	awayScore: number
 	status: 'live' | 'finished' | 'cancelled'
+	/** 90-minute (regulation) score when reported separately (ET/penalty knockouts). */
+	regularHomeScore?: number | null
+	regularAwayScore?: number | null
 	/** Authoritative winner for ET/penalty results (level full-time score); null otherwise. */
 	winner?: 'home' | 'away' | null
 }

--- a/src/lib/game-logic/cup.test.ts
+++ b/src/lib/game-logic/cup.test.ts
@@ -13,40 +13,32 @@ function makePick(
 }
 
 describe('evaluateCupPicks', () => {
-	describe('penalty/extra-time winner (knockout)', () => {
-		it('treats a level score with winner = picked team as a win, not a draw', () => {
-			const res = evaluateCupPicks(
-				[
-					{
-						confidenceRank: 1,
-						pickedTeam: 'home',
-						homeScore: 1,
-						awayScore: 1,
-						tierDifference: 0,
-						winner: 'home',
-					},
-				],
-				0,
-			)
-			expect(res.pickResults[0].result).toBe('win')
+	describe('knockout draws are scored on the 90-minute result (not qualification)', () => {
+		// Inputs carry the 90-MINUTE (regulation) score; the ET/penalty outcome is
+		// deliberately not an input. So an underdog level at 90 minutes survives the
+		// round even if the tie is then lost in ET/penalties — the behaviour Sean
+		// asked for, matching how the group stage scored draws.
+		it('+1 underdog level at 90 minutes → draw_success, survives (even if it later loses on pens)', () => {
+			// picked = away; tierDifference +1 (home one tier higher) → away is a +1 underdog.
+			const res = evaluateCupPicks([makePick(1, 'away', 1, 1, 1)], 0)
+			expect(res.pickResults[0].result).toBe('draw_success')
 			expect(res.eliminated).toBe(false)
 		})
-		it('treats a level score with winner = opponent as a loss (streak breaks)', () => {
-			const res = evaluateCupPicks(
-				[
-					{
-						confidenceRank: 1,
-						pickedTeam: 'away',
-						homeScore: 1,
-						awayScore: 1,
-						tierDifference: 0,
-						winner: 'home',
-					},
-				],
-				0,
-			)
+		it('+2 underdog level at 90 minutes → draw_success AND gains a life', () => {
+			const res = evaluateCupPicks([makePick(1, 'away', 0, 0, 2)], 0)
+			expect(res.pickResults[0].result).toBe('draw_success')
+			expect(res.pickResults[0].livesGained).toBe(1)
+			expect(res.eliminated).toBe(false)
+		})
+		it('even-match draw at 90 minutes is NOT a survival — streak breaks with no lives', () => {
+			const res = evaluateCupPicks([makePick(1, 'home', 1, 1, 0)], 0)
 			expect(res.pickResults[0].result).toBe('loss')
 			expect(res.eliminated).toBe(true)
+		})
+		it('a 90-minute win is still a win', () => {
+			const res = evaluateCupPicks([makePick(1, 'home', 2, 1, 0)], 0)
+			expect(res.pickResults[0].result).toBe('win')
+			expect(res.eliminated).toBe(false)
 		})
 	})
 

--- a/src/lib/game-logic/cup.ts
+++ b/src/lib/game-logic/cup.ts
@@ -1,15 +1,16 @@
 export interface CupPickInput {
 	confidenceRank: number
 	pickedTeam: 'home' | 'away'
+	// The 90-MINUTE (regulation) score. Cup is scored on the 90-minute result —
+	// NOT the qualification outcome — so a handicapped underdog that is level at
+	// 90 minutes survives the round even if the tie is then lost in ET/penalties
+	// (the same "draw and survive" behaviour the group stage had). The caller is
+	// responsible for passing the regulation score; the ET/penalty `winner` is
+	// intentionally not an input here (that signal belongs to classic's
+	// "to qualify" logic).
 	homeScore: number
 	awayScore: number
 	tierDifference: number // from HOME team perspective: positive = home higher tier
-	/**
-	 * Authoritative winner for a knockout fixture decided on ET/penalties (level
-	 * full-time score). When set it overrides the score: the match is a win for
-	 * that side, never a draw. Null/undefined → use the score.
-	 */
-	winner?: 'home' | 'away' | null
 }
 
 export interface CupPickResult {
@@ -49,11 +50,11 @@ export function evaluateCupPicks(picks: CupPickInput[], startingLives: number): 
 
 		const pickedTeamGoals = pick.pickedTeam === 'home' ? pick.homeScore : pick.awayScore
 		const opponentGoals = pick.pickedTeam === 'home' ? pick.awayScore : pick.homeScore
-		// A recorded winner (ET/penalties) is authoritative — the match is a win
-		// for that side and never a draw, regardless of the level full-time score.
-		const pickedTeamWon =
-			pick.winner != null ? pick.winner === pick.pickedTeam : pickedTeamGoals > opponentGoals
-		const isDraw = pick.winner != null ? false : pickedTeamGoals === opponentGoals
+		// Scored on the 90-minute result only. A level 90-minute score is a draw
+		// (→ underdog survives via draw_success) regardless of any ET/penalty
+		// outcome — the qualification result is intentionally not considered here.
+		const pickedTeamWon = pickedTeamGoals > opponentGoals
+		const isDraw = pickedTeamGoals === opponentGoals
 
 		let result: CupPickResult['result'] = 'loss'
 		let livesGained = 0

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -396,6 +396,8 @@ export async function syncCompetition(
 						status: af.status,
 						homeScore: af.homeScore,
 						awayScore: af.awayScore,
+						regularHomeScore: af.regularHomeScore ?? null,
+						regularAwayScore: af.regularAwayScore ?? null,
 						winner: af.winner ?? null,
 						externalIds: {
 							...((existingFixture.externalIds as Record<string, string | number>) ?? {}),
@@ -423,6 +425,8 @@ export async function syncCompetition(
 					status: af.status,
 					homeScore: af.homeScore,
 					awayScore: af.awayScore,
+					regularHomeScore: af.regularHomeScore ?? null,
+					regularAwayScore: af.regularAwayScore ?? null,
 					winner: af.winner ?? null,
 					externalId: af.externalId,
 					externalIds: { [key]: af.externalId },

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -1176,6 +1176,8 @@ function computeLiveProjection(input: {
 		awayTeamId: string
 		homeScore: number | null
 		awayScore: number | null
+		regularHomeScore: number | null
+		regularAwayScore: number | null
 		status: 'scheduled' | 'live' | 'finished' | 'postponed' | 'cancelled'
 		homeTeam: { id: string; externalIds: Record<string, string | number> | null }
 		awayTeam: { id: string; externalIds: Record<string, string | number> | null }
@@ -1362,6 +1364,8 @@ function projectCupPlayer(
 			status: string
 			homeTeam: { externalIds: Record<string, string | number> | null }
 			awayTeam: { externalIds: Record<string, string | number> | null }
+			regularHomeScore: number | null
+			regularAwayScore: number | null
 		}
 	>,
 	input: { competitionType: string; modeConfig: { startingLives?: number } | null },
@@ -1394,8 +1398,11 @@ function projectCupPlayer(
 		inputs.push({
 			confidenceRank: p.confidenceRank ?? 0,
 			pickedTeam,
-			homeScore: fx.homeScore,
-			awayScore: fx.awayScore,
+			// Prefer the 90-minute (regulation) score so the projection matches the
+			// eventual settled result for knockout ties; falls back to the live /
+			// full-time score while a match is in progress (regulation not yet set).
+			homeScore: fx.regularHomeScore ?? fx.homeScore,
+			awayScore: fx.regularAwayScore ?? fx.awayScore,
 			tierDifference: tierDiff,
 		})
 	}

--- a/src/lib/game/settle.ts
+++ b/src/lib/game/settle.ts
@@ -323,10 +323,16 @@ export async function reevaluateCupGame(gameId: string): Promise<boolean> {
 			return {
 				confidenceRank: pickRow.confidenceRank ?? 0,
 				pickedTeam,
-				homeScore: fx.homeScore ?? 0,
-				awayScore: fx.awayScore ?? 0,
+				// Cup scores on the 90-minute (regulation) result, so an underdog
+				// level at 90 minutes survives even if the tie is then lost in
+				// ET/penalties (consistent with how the group stage scored draws).
+				// Fall back to the full-time score when regulation isn't reported
+				// separately (regulation-only matches, where the two are equal).
+				// NOTE: `winner` is deliberately NOT passed — that's the "to qualify"
+				// signal used by CLASSIC; cup is purely 90-minute-based.
+				homeScore: fx.regularHomeScore ?? fx.homeScore ?? 0,
+				awayScore: fx.regularAwayScore ?? fx.awayScore ?? 0,
 				tierDifference: tierDiff,
-				winner: fx.winner,
 			}
 		})
 

--- a/src/lib/schema/competition.ts
+++ b/src/lib/schema/competition.ts
@@ -92,10 +92,24 @@ export const fixture = pgTable('fixture', {
 		.notNull()
 		.references(() => team.id),
 	kickoff: timestamp('kickoff'),
+	// Final score as reported by the source. NOTE: for knockout matches this is
+	// football-data's `fullTime`, which INCLUDES extra time (and, for shootouts,
+	// the penalty score). Classic "to qualify" scoring relies on `winner` (below),
+	// not this value, so that's fine for classic. Cup scoring uses the 90-minute
+	// score below instead.
 	homeScore: integer('home_score'),
 	awayScore: integer('away_score'),
+	// 90-minute (regulation) score — football-data's `regularTime`. Null for
+	// sources/matches that don't report it (regulation-only matches have it equal
+	// to the full-time score). Cup mode scores on THIS so an underdog level at 90
+	// minutes survives even if the tie is then lost in ET/penalties; the group
+	// stage already scored on the 90-minute result, and this keeps knockouts
+	// consistent. Classic is unaffected — it keeps using `winner`.
+	regularHomeScore: integer('regular_home_score'),
+	regularAwayScore: integer('regular_away_score'),
 	// Authoritative winner for knockout ties decided in ET/penalties (full-time
 	// score stays level). Null for draws / regulation results / non-knockout.
+	// Classic "to qualify" scoring is driven by this.
 	winner: text('winner').$type<'home' | 'away'>(),
 	status: fixtureStatusEnum('status').notNull().default('scheduled'),
 	// Source-specific id from the adapter that originally inserted the fixture.


### PR DESCRIPTION
## What
Cup mode now scores knockout picks on the **90-minute** result, not qualification. A handicapped **underdog level at 90 minutes survives the round** (`draw_success`) even if the tie is then lost in extra time / on penalties — the same "draw and survive" behaviour the group stage had. (Sean's request.)

## Why it needed a schema change
`fixture.homeScore/awayScore` come from football-data's **`fullTime`, which includes extra time and even the penalty score** (a 1-1 pen win stores `5-4`), so we couldn't tell "level at 90 min". football-data does expose **`regularTime`** (the 90-minute score), so we capture it.

## Changes
- **Migration 0008** — additive nullable columns `regular_home_score` / `regular_away_score`.
- **Adapter** — map football-data `score.regularTime` through `fetchRounds` + `fetchLiveScores`; persisted in the bootstrap upsert and the poll-scores update.
- **Cup eval** — `reevaluateCupGame` and the live projection feed `evaluateCupPicks` the 90-minute score (falls back to full-time when regulation isn't reported); the ET/penalty `winner` override is removed → purely 90-minute-based.

## Classic is untouched
The schema change is purely additive — `homeScore`/`awayScore`/`winner` are unchanged, and **classic still scores knockouts by `winner` ("to qualify")**. The live classic games (World Cup LPS on R32) are unaffected.

## Tests
- cup unit: +1 underdog level-at-90 → `draw_success`; +2 underdog → `draw_success` + life; even-match draw → no survival; 90-min win → win.
- smoke: knockout +1 underdog level at 90 minutes survives even when the favourite wins the shootout.
- typecheck · cup unit (274) · smoke (40/40) green. (Classic ET/penalty `winner` test still passes — qualification logic intact.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)