### PR TITLE
feat(cup): win-scenarios for cup mode (lives + tier)

### DIFF
--- a/src/components/standings/cup-standings.tsx
+++ b/src/components/standings/cup-standings.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Clock, LayoutGrid, ListTree, Lock, UserCircle2 } from 'lucide-react'
+import { Clock, LayoutGrid, ListTree, Lock, Trophy, UserCircle2 } from 'lucide-react'
 import { useState } from 'react'
 import { Disclosure } from '@/components/ui/disclosure'
 import type { CupLadderData } from '@/lib/game/cup-standings-queries'
@@ -9,8 +9,9 @@ import { AdminPlayerActions } from './admin-player-actions'
 import { CupGrid } from './cup-grid'
 import { CupLadder } from './cup-ladder'
 import { CupTimeline } from './cup-timeline'
+import { ScenariosView } from './scenarios-view'
 
-type ViewMode = 'ladder' | 'grid' | 'timeline'
+type ViewMode = 'ladder' | 'grid' | 'timeline' | 'scenarios'
 
 interface CupStandingsProps {
 	data: CupLadderData
@@ -59,7 +60,14 @@ export function CupStandings({ data, onShare, showAdminActions, gameId }: CupSta
 				<>
 					<div className="px-4 md:px-5 pt-3 flex flex-wrap items-center gap-2">
 						<div className="flex gap-1 border border-border rounded-md p-0.5">
-							{(['ladder', 'timeline', 'grid'] as const).map((m) => (
+							{(
+								[
+									'ladder',
+									'timeline',
+									'grid',
+									...(data.scenarios ? (['scenarios'] as const) : []),
+								] as ViewMode[]
+							).map((m) => (
 								<button
 									key={m}
 									type="button"
@@ -74,6 +82,7 @@ export function CupStandings({ data, onShare, showAdminActions, gameId }: CupSta
 									{m === 'ladder' && <ListTree className="h-3 w-3" />}
 									{m === 'timeline' && <Clock className="h-3 w-3" />}
 									{m === 'grid' && <LayoutGrid className="h-3 w-3" />}
+									{m === 'scenarios' && <Trophy className="h-3 w-3" />}
 									{m[0].toUpperCase() + m.slice(1)}
 								</button>
 							))}
@@ -90,6 +99,23 @@ export function CupStandings({ data, onShare, showAdminActions, gameId }: CupSta
 							<div className="overflow-x-auto">
 								<CupTimeline data={data} />
 							</div>
+						)}
+						{view === 'scenarios' && data.scenarios && (
+							<ScenariosView
+								scenarios={data.scenarios}
+								playerName={(id) => data.players.find((p) => p.id === id)?.name ?? 'Player'}
+								fixtureLabel={(id) => {
+									const f = data.fixtures.find((x) => x.id === id)
+									return f ? `${f.homeTeam.shortName} v ${f.awayTeam.shortName}` : '?'
+								}}
+								describeOutcome={(id, outcome) => {
+									const f = data.fixtures.find((x) => x.id === id)
+									if (!f) return outcome
+									if (outcome === 'home_win') return `${f.homeTeam.shortName} win`
+									if (outcome === 'away_win') return `${f.awayTeam.shortName} win`
+									return `${f.homeTeam.shortName} v ${f.awayTeam.shortName} draw`
+								}}
+							/>
 						)}
 					</div>
 				</>

--- a/src/lib/game-logic/win-scenarios.test.ts
+++ b/src/lib/game-logic/win-scenarios.test.ts
@@ -165,3 +165,72 @@ describe('winScenarios (turbo)', () => {
 		expect(res.pivotalFixtureIds).toEqual([])
 	})
 })
+
+function cupPlayer(
+	id: string,
+	startingLives: number,
+	picks: [rank: number, fixtureId: string, side: 'home' | 'away', tierDiff: number][],
+): ScenarioPlayerInput {
+	return {
+		gamePlayerId: id,
+		livesRemaining: 0,
+		startingLives,
+		picks: picks.map(([rank, fixtureId, pickedSide, tierDifference]) => ({
+			rank,
+			fixtureId,
+			predictedResult: pickedSide === 'home' ? 'home_win' : 'away_win',
+			pickedSide,
+			tierDifference,
+		})),
+	}
+}
+
+const cup = { mode: 'cup' as const }
+
+describe('winScenarios (cup)', () => {
+	it('CUP-A: a life keeps the streak alive through a loss (turbo would break)', () => {
+		// startingLives 1. f1 home win, f2 away win, f3 pending.
+		// p1 backs home both played: r1 win, r2 loses-but-saved (life→0). p2 backs away: r1 saved, r2 win.
+		// Both bank streak 2 into the pending r3 → f3 decides.
+		const fixtures: FixtureOutcomes = { f1: 'home_win', f2: 'away_win', f3: null }
+		const res = winScenarios(
+			[
+				cupPlayer('p1', 1, [
+					[1, 'f1', 'home', 0],
+					[2, 'f2', 'home', 0],
+					[3, 'f3', 'home', 0],
+				]),
+				cupPlayer('p2', 1, [
+					[1, 'f1', 'away', 0],
+					[2, 'f2', 'away', 0],
+					[3, 'f3', 'away', 0],
+				]),
+			],
+			fixtures,
+			cup,
+		)
+		// streak 2 banked (r2 survived only via the life) → in contention, can reach 3.
+		expect(outlook(res, 'p1')).toMatchObject({ floor: 2, ceiling: 3, verdict: 'in_contention' })
+		expect(outlook(res, 'p1').pivotalPicks).toEqual([{ rank: 3, fixtureId: 'f3' }])
+		expect(branchFor(res, 'f3', 'home_win')?.winners).toEqual(['p1'])
+		expect(branchFor(res, 'f3', 'away_win')?.winners).toEqual(['p2'])
+		expect(branchFor(res, 'f3', 'draw')?.winners.sort()).toEqual(['p1', 'p2'])
+	})
+
+	it('CUP-B: lives break a streak tie — a clear winner, not a goals tie', () => {
+		// Both finish on streak 1, but p1 backed an underdog (tierDiff -1) so gained a life.
+		// Cup ranks streak then LIVES → p1 wins outright; p2 is out.
+		const fixtures: FixtureOutcomes = { f1: 'home_win' }
+		const res = winScenarios(
+			[
+				cupPlayer('p1', 0, [[1, 'f1', 'home', -1]]), // underdog home win → +1 life
+				cupPlayer('p2', 0, [[1, 'f1', 'home', 0]]), // even win → no life
+			],
+			fixtures,
+			cup,
+		)
+		expect(outlook(res, 'p1').verdict).toBe('leading')
+		expect(outlook(res, 'p2').verdict).toBe('out')
+		expect(res.table).toBeNull() // decided
+	})
+})

--- a/src/lib/game-logic/win-scenarios.ts
+++ b/src/lib/game-logic/win-scenarios.ts
@@ -1,11 +1,11 @@
-// Win-scenario engine for the single-round modes (turbo now; cup to follow).
+// Win-scenario engine for the single-round modes (turbo + cup).
 //
 // Given each player's confidence-ranked picks and the current fixture results,
 // it answers: who can still win, and which unplayed picks decide it. The heart
-// is reuse of the canonical winner-determination logic (`resolveWipeout` + the
-// mode tiebreaker) over HYPOTHETICAL completions — so a "scenario" is just the
-// real settlement run on a what-if result set, and stays consistent with how
-// the game actually crowns a winner.
+// is reuse of the canonical winner-determination logic (`resolveWipeout`, plus
+// the streak→(lives)→goals tiebreak) over HYPOTHETICAL completions — so a
+// "scenario" is just real settlement run on a what-if result set, and stays
+// consistent with how the game actually crowns a winner.
 //
 // Approach:
 //   1. Per player, find the unplayed picks inside their reachable streak window
@@ -18,8 +18,15 @@
 //      (wins-in-all = leading, wins-in-none = out, else in-contention) plus a
 //      decision table. Above the cap, fall back to an approximate per-player
 //      streak range (early game; labelled).
+//
+// Cup vs turbo: the only mode-specific bit is how a pick survives. Turbo: the
+// predicted result must match. Cup: lives + the tier handicap, evaluated by the
+// canonical `evaluateCupPicks`, and the winner tiebreak adds a lives level
+// before goals. Anything goal-dependent (the final separator) is reported as a
+// tie rather than guessed, since scenarios fix outcomes, not scorelines.
 
-import { resolveWipeout, turboTiebreaker } from './auto-complete-tiebreakers'
+import { resolveWipeout } from './auto-complete-tiebreakers'
+import { type CupPickResult, evaluateCupPicks } from './cup'
 
 export type Outcome = 'home_win' | 'draw' | 'away_win'
 const OUTCOMES: Outcome[] = ['home_win', 'draw', 'away_win']
@@ -29,12 +36,18 @@ export interface ScenarioPick {
 	fixtureId: string
 	/** turbo: the player's predicted result for the fixture. */
 	predictedResult: Outcome
+	/** cup: which side the player backed. */
+	pickedSide?: 'home' | 'away'
+	/** cup: tier difference from the HOME team's perspective (+ = home higher tier). */
+	tierDifference?: number
 }
 
 export interface ScenarioPlayerInput {
 	gamePlayerId: string
-	/** final lives — cup tiebreak only; pass 0 for turbo. */
+	/** kept for back-compat; cup uses `startingLives`, turbo ignores both. */
 	livesRemaining: number
+	/** cup: the game's configured starting lives (evaluateCupPicks recomputes from scratch). */
+	startingLives?: number
 	picks: ScenarioPick[]
 }
 
@@ -55,7 +68,7 @@ export interface PlayerOutlook {
 export interface ScenarioBranch {
 	/** the unplayed-fixture outcomes that produce this result. */
 	conditions: { fixtureId: string; outcome: Outcome }[]
-	/** winning gamePlayerIds; >1 = a streak tie the goals tiebreak (unknown here) would settle. */
+	/** winning gamePlayerIds; >1 = a tie the goals tiebreak (unknown here) would settle. */
 	winners: string[]
 	tieOnGoals: boolean
 }
@@ -69,49 +82,126 @@ export interface WinScenarios {
 	tooManyToEnumerate: boolean
 }
 
+type Mode = 'turbo' | 'cup'
+
 const DEFAULT_CAP = 5
 
-/** Did a pick keep the streak alive, given its fixture's outcome? (turbo rules) */
-function isCorrect(pick: ScenarioPick, outcome: Outcome, _mode: 'turbo' | 'cup'): boolean {
-	// turbo: the predicted result must match. (cup adds tier/lives — handled in a follow-up.)
+/* ── per-pick survival ─────────────────────────────────────────────────── */
+
+/**
+ * Representative scoreline for an outcome — enough to drive survival/lives
+ * (which depend on the outcome + tier, not the exact score). Goals are not
+ * inferred, so goal-level ties are reported rather than resolved.
+ */
+function repScore(outcome: Outcome): { homeScore: number; awayScore: number } {
+	if (outcome === 'home_win') return { homeScore: 1, awayScore: 0 }
+	if (outcome === 'away_win') return { homeScore: 0, awayScore: 1 }
+	return { homeScore: 0, awayScore: 0 }
+}
+
+const pickedWin = (pk: ScenarioPick): Outcome =>
+	pk.pickedSide === 'away' ? 'away_win' : 'home_win'
+const pickedLose = (pk: ScenarioPick): Outcome =>
+	pk.pickedSide === 'away' ? 'home_win' : 'away_win'
+
+/**
+ * A cup pick keeps the streak alive on win / underdog-draw / life-save. Matches
+ * `checkCupCompletion` (where 'loss' and 'restricted' break the streak).
+ */
+const cupAlive = (r: CupPickResult['result']): boolean =>
+	r === 'win' || r === 'draw_success' || r === 'saved_by_life'
+
+function turboCorrect(pick: ScenarioPick, outcome: Outcome): boolean {
 	return pick.predictedResult === outcome
 }
 
 /**
- * The player's unplayed picks that their streak could still reach — i.e. the
- * leading run of picks up to (and not past) the first KNOWN losing pick.
- * Returned earliest-rank first; index 0 is the make-or-break pivot.
+ * Run the canonical cup evaluator over the picks whose outcome is known under
+ * `outcomeOf` (others omitted — they're beyond the reachable streak).
  */
+function cupResults(
+	player: ScenarioPlayerInput,
+	outcomeOf: (pk: ScenarioPick) => Outcome | null,
+): { results: CupPickResult[]; finalLives: number } {
+	const inputs = []
+	for (const pk of player.picks) {
+		const oc = outcomeOf(pk)
+		if (oc == null) continue
+		const { homeScore, awayScore } = repScore(oc)
+		inputs.push({
+			confidenceRank: pk.rank,
+			pickedTeam: pk.pickedSide ?? 'home',
+			homeScore,
+			awayScore,
+			tierDifference: pk.tierDifference ?? 0,
+			winner: null,
+		})
+	}
+	const r = evaluateCupPicks(inputs, player.startingLives ?? 0)
+	return { results: r.pickResults, finalLives: r.finalLives }
+}
+
+/** Length of the consecutive alive run from rank 1 (no wipeout rebasing). */
+function cupStreakReach(results: CupPickResult[]): number {
+	let n = 0
+	for (const r of [...results].sort((a, b) => a.confidenceRank - b.confidenceRank)) {
+		if (cupAlive(r.result)) n++
+		else break
+	}
+	return n
+}
+
+/* ── reachable window + range ──────────────────────────────────────────── */
+
 function reachablePending(
 	player: ScenarioPlayerInput,
 	fixtures: FixtureOutcomes,
-	mode: 'turbo' | 'cup',
+	mode: Mode,
 ): ScenarioPick[] {
 	const sorted = [...player.picks].sort((a, b) => a.rank - b.rank)
+	if (mode === 'turbo') {
+		const out: ScenarioPick[] = []
+		for (const pk of sorted) {
+			const oc = fixtures[pk.fixtureId] ?? null
+			if (oc === null) {
+				out.push(pk)
+				continue
+			}
+			if (!turboCorrect(pk, oc)) break // a known loss caps the window
+		}
+		return out
+	}
+	// cup: walk the BEST case (unplayed → picked side wins) so lives extend reach;
+	// the unplayed picks inside the surviving prefix are reachable.
+	const { results } = cupResults(player, (pk) => fixtures[pk.fixtureId] ?? pickedWin(pk))
+	const aliveByRank = new Map(results.map((r) => [r.confidenceRank, cupAlive(r.result)]))
 	const out: ScenarioPick[] = []
 	for (const pk of sorted) {
-		const oc = fixtures[pk.fixtureId] ?? null
-		if (oc === null) {
-			out.push(pk)
-			continue
-		}
-		if (!isCorrect(pk, oc, mode)) break // a known loss caps the reachable window
+		if (!aliveByRank.get(pk.rank)) break
+		if ((fixtures[pk.fixtureId] ?? null) === null) out.push(pk)
 	}
 	return out
 }
 
-/** Best/worst-case streak ignoring wipeout — only used for the >cap fallback. */
 function streakRange(
 	player: ScenarioPlayerInput,
 	fixtures: FixtureOutcomes,
-	mode: 'turbo' | 'cup',
+	mode: Mode,
 ): { floor: number; ceiling: number } {
+	if (mode === 'cup') {
+		const ceiling = cupStreakReach(
+			cupResults(player, (pk) => fixtures[pk.fixtureId] ?? pickedWin(pk)).results,
+		)
+		const floor = cupStreakReach(
+			cupResults(player, (pk) => fixtures[pk.fixtureId] ?? pickedLose(pk)).results,
+		)
+		return { floor, ceiling }
+	}
 	const sorted = [...player.picks].sort((a, b) => a.rank - b.rank)
 	let floor = 0
 	for (const pk of sorted) {
 		const oc = fixtures[pk.fixtureId] ?? null
-		if (oc === null) break // worst case: this unplayed pick loses
-		if (!isCorrect(pk, oc, mode)) break
+		if (oc === null || !turboCorrect(pk, oc)) break
 		floor++
 	}
 	let ceiling = 0
@@ -120,11 +210,65 @@ function streakRange(
 		if (oc === null) {
 			ceiling++
 			continue
-		} // best case: unplayed pick wins
-		if (!isCorrect(pk, oc, mode)) break
+		}
+		if (!turboCorrect(pk, oc)) break
 		ceiling++
 	}
 	return { floor, ceiling }
+}
+
+/* ── per-branch winner determination ──────────────────────────────────── */
+
+interface WipeIn {
+	gamePlayerId: string
+	livesRemaining: number
+	picks: { rank: number; correct: boolean; goals: number }[]
+}
+
+function buildWipeoutInput(
+	player: ScenarioPlayerInput,
+	merged: FixtureOutcomes,
+	mode: Mode,
+): WipeIn {
+	if (mode === 'turbo') {
+		return {
+			gamePlayerId: player.gamePlayerId,
+			livesRemaining: 0,
+			picks: player.picks
+				.filter((pk) => merged[pk.fixtureId] != null)
+				.map((pk) => ({
+					rank: pk.rank,
+					correct: turboCorrect(pk, merged[pk.fixtureId] as Outcome),
+					goals: 0,
+				})),
+		}
+	}
+	const { results, finalLives } = cupResults(player, (pk) => merged[pk.fixtureId] ?? null)
+	return {
+		gamePlayerId: player.gamePlayerId,
+		livesRemaining: finalLives,
+		picks: results.map((r) => ({ rank: r.confidenceRank, correct: cupAlive(r.result), goals: 0 })),
+	}
+}
+
+function maxBy<T>(items: T[], key: (t: T) => number): T[] {
+	if (items.length === 0) return []
+	const max = items.reduce((m, t) => Math.max(m, key(t)), Number.NEGATIVE_INFINITY)
+	return items.filter((t) => key(t) === max)
+}
+
+/**
+ * Winner(s) for one hypothetical: top streak, then (cup) top lives — both fully
+ * determined by the outcomes. The next separator is goals, which depend on
+ * scorelines we don't fix, so a remaining tie is reported, not guessed.
+ */
+function scenarioWinners(
+	scores: { gamePlayerId: string; streak: number; livesRemaining: number }[],
+	mode: Mode,
+): { winners: string[]; tieOnGoals: boolean } {
+	let top = maxBy(scores, (s) => s.streak)
+	if (mode === 'cup' && top.length > 1) top = maxBy(top, (s) => s.livesRemaining)
+	return { winners: top.map((s) => s.gamePlayerId), tieOnGoals: top.length > 1 }
 }
 
 function enumerateOutcomes(fixtureIds: string[]): Record<string, Outcome>[] {
@@ -174,7 +318,7 @@ function buildTable(branches: Branch[], pivotal: string[]): ScenarioBranch[] {
 export function winScenarios(
 	players: ScenarioPlayerInput[],
 	fixtures: FixtureOutcomes,
-	opts: { mode: 'turbo' | 'cup'; cap?: number },
+	opts: { mode: Mode; cap?: number },
 ): WinScenarios {
 	const { mode } = opts
 	const cap = opts.cap ?? DEFAULT_CAP
@@ -217,34 +361,17 @@ export function winScenarios(
 		return { outlooks, table: null, pivotalFixtureIds: [], tooManyToEnumerate: true }
 	}
 
-	// Enumerate every outcome combo over the decisive candidate fixtures and run the
-	// real winner-determination (resolveWipeout + tiebreak) on each hypothetical.
-	const tiebreak = turboTiebreaker // cup tiebreak swapped in with the cup evaluator
+	// Enumerate every outcome combo over the decisive candidate fixtures and run
+	// the real winner-determination (resolveWipeout + tiebreak) on each.
 	const branches: Branch[] = enumerateOutcomes(candidates).map((combo) => {
 		const merged: FixtureOutcomes = { ...fixtures, ...combo }
-		const wipeoutInput = players.map((p) => ({
-			gamePlayerId: p.gamePlayerId,
-			livesRemaining: p.livesRemaining,
-			picks: p.picks
-				.filter((pk) => merged[pk.fixtureId] != null)
-				.map((pk) => ({
-					rank: pk.rank,
-					correct: isCorrect(pk, merged[pk.fixtureId] as Outcome, mode),
-					goals: 0,
-				})),
-		}))
+		const wipeoutInput = players.map((p) => buildWipeoutInput(p, merged, mode))
 		const { scores } = resolveWipeout(wipeoutInput)
-		const winners = tiebreak(
-			scores.map((s) => ({
-				gamePlayerId: s.gamePlayerId,
-				streak: s.streak,
-				goalsInStreak: s.goalsInStreak,
-			})),
-		)
+		const { winners, tieOnGoals } = scenarioWinners(scores, mode)
 		return {
 			conditions: candidates.map((f) => ({ fixtureId: f, outcome: combo[f] })),
 			winners,
-			tieOnGoals: winners.length > 1,
+			tieOnGoals,
 			streaks: new Map(scores.map((s) => [s.gamePlayerId, s.streak])),
 		}
 	})

--- a/src/lib/game/cup-standings-queries.ts
+++ b/src/lib/game/cup-standings-queries.ts
@@ -4,6 +4,12 @@ import { roundLabel } from '@/lib/game/round-label'
 import { deriveGameRoundStatus } from '@/lib/game/round-status'
 import { determineFixtureOutcome } from '@/lib/game-logic/common'
 import { computeTierDifference } from '@/lib/game-logic/cup-tier'
+import {
+	type FixtureOutcomes,
+	type Outcome,
+	type WinScenarios,
+	winScenarios,
+} from '@/lib/game-logic/win-scenarios'
 import { pick } from '@/lib/schema/game'
 
 export interface CupStandingsPick {
@@ -44,6 +50,8 @@ export interface CupStandingsData {
 	maxLives: number
 	numberOfPicks: number
 	players: CupStandingsPlayer[]
+	/** win-scenario analysis; null pre-deadline (picks hidden) or when not computed. */
+	scenarios?: WinScenarios | null
 }
 
 export interface CupLadderBacker {
@@ -220,6 +228,49 @@ export async function getCupStandingsData(
 		})
 
 	const competitionType = g.competition.type as 'league' | 'knockout' | 'group_knockout'
+	const startingLives = (g.modeConfig as { startingLives?: number } | null)?.startingLives ?? 3
+
+	// Win scenarios — POST-DEADLINE ONLY (pre-deadline picks are hidden; revealing
+	// who-needs-what would leak them). Built from the raw picks + fixture results;
+	// the cup engine re-evaluates lives/tier via evaluateCupPicks.
+	let scenarios: WinScenarios | null = null
+	if (!hideOpenPicks) {
+		const fixtureOutcomes: FixtureOutcomes = {}
+		for (const fx of displayRound.fixtures) {
+			fixtureOutcomes[fx.id] =
+				fx.status === 'finished' && fx.homeScore != null && fx.awayScore != null
+					? fx.homeScore > fx.awayScore
+						? 'home_win'
+						: fx.awayScore > fx.homeScore
+							? 'away_win'
+							: 'draw'
+					: null
+		}
+		const scenarioPlayers = g.players
+			.filter((p) => p.eliminatedReason !== 'admin_removed')
+			.map((p) => ({
+				gamePlayerId: p.id,
+				livesRemaining: 0,
+				startingLives,
+				picks: allPicks
+					.filter((pk) => pk.gamePlayerId === p.id && pk.fixtureId)
+					.map((pk) => {
+						const fx = displayRound.fixtures.find((f) => f.id === pk.fixtureId)
+						const pickedSide: 'home' | 'away' = fx && pk.teamId === fx.homeTeamId ? 'home' : 'away'
+						return {
+							rank: pk.confidenceRank ?? 0,
+							fixtureId: pk.fixtureId as string,
+							predictedResult: (pickedSide === 'home' ? 'home_win' : 'away_win') as Outcome,
+							pickedSide,
+							// HOME-perspective tier (the engine re-derives the picked side).
+							tierDifference: fx
+								? computeTierDifference(fx.homeTeam, fx.awayTeam, g.competition.type)
+								: 0,
+						}
+					}),
+			}))
+		scenarios = winScenarios(scenarioPlayers, fixtureOutcomes, { mode: 'cup' })
+	}
 
 	return {
 		gameId: g.id,
@@ -243,9 +294,10 @@ export async function getCupStandingsData(
 			},
 			now,
 		}) as 'open' | 'active' | 'completed',
-		maxLives: (g.modeConfig as { startingLives?: number } | null)?.startingLives ?? 3,
+		maxLives: startingLives,
 		numberOfPicks: (g.modeConfig as { numberOfPicks?: number } | null)?.numberOfPicks ?? 6,
 		players,
+		scenarios,
 	}
 }
 


### PR DESCRIPTION
## Why

Cup was the motivating case for the Scenarios feature. #101 shipped the engine + view for turbo; this extends both to **cup**, so a frozen streak shows as *"leads unless someone beats N"* with the decisive upcoming picks surfaced — the honest version of the "Feargal" situation.

## Engine

The only mode-specific bit is **how a pick survives**. Cup runs the canonical **`evaluateCupPicks`** over hypothetical completions, so scenarios stay identical to real settlement:
- representative scorelines drive **survival / lives / tier** (a draw can be an underdog `draw_success`, a loss can be `saved_by_life`) — goals aren't inferred, so streak + lives are **exact**;
- the winner tiebreak adds a **lives** level before goals; any remaining goal-dependent tie is **reported, not guessed**;
- reachability + streak ranges account for lives — a saved loss extends a player's reachable window.

## Wiring + view

`getCupStandingsData` computes scenarios **post-deadline only** (pre-deadline picks are hidden — "who needs what" would leak them). `cup-standings` gains the **Scenarios** toggle alongside ladder / timeline / grid, rendering the shared `ScenariosView`.

## Testing

- **Engine (cup):** a life keeps the streak alive through a loss (turbo would break); lives break a streak tie into a clear winner rather than a goals tie.
- **539 unit**, typecheck · biome · build all green.
- **Dev-server SSR:** the Scenarios toggle appears on a post-deadline cup game, is absent pre-deadline (secrecy gate), and the `WinScenarios` object serialises cleanly across the RSC boundary.

Both single-round modes now have it. Follow-up remains: the in-grid pivotal-pick highlight (the view already names each player's pivotal fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)