### PR TITLE
fix(cup): score knockout ties "to qualify" + capture ET/penalty results

### DIFF
--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -719,6 +719,105 @@ describe('lifecycle: cup-WC', () => {
 		expect(player?.status).toBe('alive')
 	})
 
+	it('knockout: a +1 underdog that QUALIFIES on penalties from a 90-min draw → win + 1 life', async () => {
+		// The "to qualify" rule (NED v MAR R32): Morocco (+1 underdog) drew 1-1 at 90
+		// and won the shootout. The pick must be a WIN earning the underdog its life —
+		// NOT merely a draw_success. The 90-minute score is level; the qualification
+		// `winner` (away) makes it a win.
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		const fav = await makeTeam({ name: 'Favourite', shortName: 'FAV', fifaPot: 1 })
+		const dog = await makeTeam({ name: 'Underdog', shortName: 'DOG', fifaPot: 2 }) // +1 underdog
+		const o1 = await makeTeam({ name: 'Other One', shortName: 'OON', fifaPot: 2 })
+		const o2 = await makeTeam({ name: 'Other Two', shortName: 'OTW', fifaPot: 2 })
+		const r = await makeRound(compId, { number: 4, status: 'open' }) // R32
+		const tie = await makeFixture({ roundId: r, homeTeamId: fav, awayTeamId: dog })
+		const unplayed = await makeFixture({ roundId: r, homeTeamId: o1, awayTeamId: o2 })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'cup',
+			currentRoundId: r,
+			modeConfig: { numberOfPicks: 1, startingLives: 0 },
+		})
+		const gpDog = await makePlayer({ gameId, userId: 'u-dog', livesRemaining: 0 })
+		const gpFiller = await makePlayer({ gameId, userId: 'u-fill', livesRemaining: 0 })
+		const dogPick = await makePick({
+			gameId,
+			gamePlayerId: gpDog,
+			roundId: r,
+			teamId: dog,
+			fixtureId: tie,
+			confidenceRank: 1,
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpFiller,
+			roundId: r,
+			teamId: o1,
+			fixtureId: unplayed,
+			confidenceRank: 1,
+		})
+
+		// 1-1 at 90 minutes; underdog (away) wins on penalties — full-time carries the
+		// shootout-inflated score (2-4) + winner=away, regularTime stays 1-1.
+		await finishFixture(tie, 2, 4, 'away', { home: 1, away: 1 })
+		await settleFixture(tie)
+
+		const p = await db.query.pick.findFirst({ where: eq(pick.id, dogPick) })
+		expect(p?.result).toBe('win')
+		expect(p?.lifeGained).toBe(1)
+		const player = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gpDog) })
+		expect(player?.status).toBe('alive')
+		expect(player?.livesRemaining).toBe(1)
+	})
+
+	it('knockout: derives the qualify-win from full-time when football-data winner lags (winner=null)', async () => {
+		// football-data leaves `winner` null on some finished shootouts. The
+		// penalty-inclusive full-time score (2-4, away ahead) still tells us the
+		// underdog advanced → win + life, even with no `winner`.
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		const fav = await makeTeam({ name: 'Favourite', shortName: 'FAV', fifaPot: 1 })
+		const dog = await makeTeam({ name: 'Underdog', shortName: 'DOG', fifaPot: 2 })
+		const o1 = await makeTeam({ name: 'Other One', shortName: 'OON', fifaPot: 2 })
+		const o2 = await makeTeam({ name: 'Other Two', shortName: 'OTW', fifaPot: 2 })
+		const r = await makeRound(compId, { number: 4, status: 'open' })
+		const tie = await makeFixture({ roundId: r, homeTeamId: fav, awayTeamId: dog })
+		const unplayed = await makeFixture({ roundId: r, homeTeamId: o1, awayTeamId: o2 })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'cup',
+			currentRoundId: r,
+			modeConfig: { numberOfPicks: 1, startingLives: 0 },
+		})
+		const gpDog = await makePlayer({ gameId, userId: 'u-dog', livesRemaining: 0 })
+		const gpFiller = await makePlayer({ gameId, userId: 'u-fill', livesRemaining: 0 })
+		const dogPick = await makePick({
+			gameId,
+			gamePlayerId: gpDog,
+			roundId: r,
+			teamId: dog,
+			fixtureId: tie,
+			confidenceRank: 1,
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpFiller,
+			roundId: r,
+			teamId: o1,
+			fixtureId: unplayed,
+			confidenceRank: 1,
+		})
+
+		// winner deliberately null; full-time 2-4 (away advanced), regulation 1-1.
+		await finishFixture(tie, 2, 4, null, { home: 1, away: 1 })
+		await settleFixture(tie)
+
+		const p = await db.query.pick.findFirst({ where: eq(pick.id, dogPick) })
+		expect(p?.result).toBe('win')
+		expect(p?.lifeGained).toBe(1)
+	})
+
 	it('does NOT crown while a higher-confidence pick is unplayed — the 1f0d292d mis-crowning', async () => {
 		// Mirrors the incident: rank-1 pick on an UNPLAYED fixture, rank-2 on a
 		// played one. The gameweek is incomplete → no winner, no payout, game stays

--- a/src/app/api/cron/poll-scores/route.ts
+++ b/src/app/api/cron/poll-scores/route.ts
@@ -56,7 +56,12 @@ async function pollScores(apiKey: string): Promise<NextResponse> {
 
 	// Load every fixture in the active rounds and short-circuit if none are in their live window.
 	const fixturesInRounds = await db
-		.select({ id: fixture.id, kickoff: fixture.kickoff, roundId: fixture.roundId })
+		.select({
+			id: fixture.id,
+			kickoff: fixture.kickoff,
+			roundId: fixture.roundId,
+			status: fixture.status,
+		})
 		.from(fixture)
 		.where(inArray(fixture.roundId, activeRoundIds))
 

--- a/src/lib/data/match-window.test.ts
+++ b/src/lib/data/match-window.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { hasActiveFixture, isFixtureInLiveWindow } from './match-window'
 
 const LIVE_WINDOW_BEFORE_MS = 10 * 60 * 1000
-const LIVE_WINDOW_AFTER_MS = 150 * 60 * 1000
+const MIN = 60 * 1000
 
 describe('isFixtureInLiveWindow', () => {
 	const kickoff = new Date('2026-06-11T15:00:00Z')
@@ -17,17 +17,26 @@ describe('isFixtureInLiveWindow', () => {
 	})
 
 	it('returns false 11 minutes before kickoff', () => {
-		const now = new Date(kickoff.getTime() - LIVE_WINDOW_BEFORE_MS - 60_000)
+		const now = new Date(kickoff.getTime() - LIVE_WINDOW_BEFORE_MS - MIN)
 		expect(isFixtureInLiveWindow(kickoff, now)).toBe(false)
 	})
 
-	it('returns true 2.5 hours after kickoff', () => {
-		const now = new Date(kickoff.getTime() + LIVE_WINDOW_AFTER_MS)
+	it('stays open through extra time + penalties (175 minutes after kickoff)', () => {
+		// A knockout tie that goes the distance — 90 + stoppage + ET + a penalty
+		// shootout — finishes ~3 hours after kickoff. The old 150-minute window
+		// closed before the shootout ended, so the FINISHED transition (and the
+		// penalty winner) were never polled.
+		const now = new Date(kickoff.getTime() + 175 * MIN)
 		expect(isFixtureInLiveWindow(kickoff, now)).toBe(true)
 	})
 
-	it('returns false 2.5 hours and 1 minute after kickoff', () => {
-		const now = new Date(kickoff.getTime() + LIVE_WINDOW_AFTER_MS + 60_000)
+	it('returns true at 210 minutes after kickoff (window edge)', () => {
+		const now = new Date(kickoff.getTime() + 210 * MIN)
+		expect(isFixtureInLiveWindow(kickoff, now)).toBe(true)
+	})
+
+	it('returns false at 211 minutes after kickoff', () => {
+		const now = new Date(kickoff.getTime() + 211 * MIN)
 		expect(isFixtureInLiveWindow(kickoff, now)).toBe(false)
 	})
 
@@ -63,5 +72,30 @@ describe('hasActiveFixture', () => {
 	it('ignores fixtures with null kickoff', () => {
 		const fixtures = [{ kickoff: null }]
 		expect(hasActiveFixture(fixtures, now)).toBe(false)
+	})
+
+	it('keeps polling a still-in-play tie deep into extra time / penalties', () => {
+		// kickoff 175 min ago, still live (shootout in progress) → must stay active
+		// so the FINISHED transition gets polled.
+		const fixtures = [{ kickoff: new Date(now.getTime() - 175 * MIN), status: 'live' as const }]
+		expect(hasActiveFixture(fixtures, now)).toBe(true)
+	})
+
+	it('treats an already-finished fixture as inactive even within the window', () => {
+		// Once a fixture is terminal, polling it again does nothing — so a regulation
+		// match that finished an hour ago must not keep the chain alive (QStash quota).
+		const fixtures = [{ kickoff: new Date(now.getTime() - 60 * MIN), status: 'finished' as const }]
+		expect(hasActiveFixture(fixtures, now)).toBe(false)
+	})
+
+	it('treats a cancelled fixture as inactive', () => {
+		const fixtures = [{ kickoff: new Date(now.getTime() - 30 * MIN), status: 'cancelled' as const }]
+		expect(hasActiveFixture(fixtures, now)).toBe(false)
+	})
+
+	it('still active when a within-window fixture has no status supplied', () => {
+		// Backward-compatible: callers that pass only kickoff get the time-based gate.
+		const fixtures = [{ kickoff: new Date(now.getTime() - 30 * MIN) }]
+		expect(hasActiveFixture(fixtures, now)).toBe(true)
 	})
 })

--- a/src/lib/data/match-window.ts
+++ b/src/lib/data/match-window.ts
@@ -1,5 +1,14 @@
 const LIVE_WINDOW_BEFORE_MS = 10 * 60 * 1000
-const LIVE_WINDOW_AFTER_MS = 150 * 60 * 1000
+// A knockout tie that goes to extra time + a penalty shootout finishes roughly
+// three hours after kickoff (90' + stoppage + 15' half-time + 30' ET + breaks +
+// the shootout). The window must stay open past that, or the poll chain
+// terminates before the FINISHED transition (and the penalty winner) can be
+// observed — the NED v MAR R32 incident, where the 150-minute window closed ~30
+// minutes before the shootout ended. 210 minutes covers the worst case with
+// margin for football-data's status-flip lag.
+const LIVE_WINDOW_AFTER_MS = 210 * 60 * 1000
+
+const TERMINAL_STATUSES = new Set(['finished', 'cancelled'])
 
 export function isFixtureInLiveWindow(
 	kickoff: Date | null | undefined,
@@ -12,8 +21,18 @@ export function isFixtureInLiveWindow(
 }
 
 export function hasActiveFixture(
-	fixtures: Array<{ kickoff: Date | null | undefined }>,
+	fixtures: Array<{ kickoff: Date | null | undefined; status?: string | null }>,
 	now: Date = new Date(),
 ): boolean {
-	return fixtures.some((f) => isFixtureInLiveWindow(f.kickoff, now))
+	// A fixture is "active" (worth polling) when it's inside its live window AND
+	// not already in a terminal state. The terminal exclusion lets the chain
+	// self-terminate promptly once every fixture has finished, instead of polling
+	// idle until the (now longer) window edge — important given the QStash quota.
+	// Status is optional so callers that only have kickoffs still get the
+	// time-based gate.
+	return fixtures.some(
+		(f) =>
+			isFixtureInLiveWindow(f.kickoff, now) &&
+			!(f.status != null && TERMINAL_STATUSES.has(f.status)),
+	)
 }

--- a/src/lib/game-logic/cup.test.ts
+++ b/src/lib/game-logic/cup.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { CupPickInput } from './cup'
-import { evaluateCupPicks } from './cup'
+import { evaluateCupPicks, resolveCupQualifier } from './cup'
 
 function makePick(
 	rank: number,
@@ -8,8 +8,9 @@ function makePick(
 	homeScore: number,
 	awayScore: number,
 	tierDifference: number,
+	winner?: 'home' | 'away' | null,
 ): CupPickInput {
-	return { confidenceRank: rank, pickedTeam, homeScore, awayScore, tierDifference }
+	return { confidenceRank: rank, pickedTeam, homeScore, awayScore, tierDifference, winner }
 }
 
 describe('evaluateCupPicks', () => {
@@ -39,6 +40,104 @@ describe('evaluateCupPicks', () => {
 			const res = evaluateCupPicks([makePick(1, 'home', 2, 1, 0)], 0)
 			expect(res.pickResults[0].result).toBe('win')
 			expect(res.eliminated).toBe(false)
+		})
+	})
+
+	describe("knockout qualification ('to qualify') overrides a level 90-minute score", () => {
+		// A knockout pick is "to qualify": when the picked team advances (incl. on
+		// ET/penalties) the `winner` says so and the pick is a WIN — earning the
+		// underdog its life — even though the 90-minute score was level. When the
+		// picked team is level at 90 but does NOT qualify, it is floored at a draw
+		// (draw_success for an underdog) rather than scored a loss. `winner` is the
+		// authoritative qualification signal; the home/away score is the 90-minute
+		// (regulation) result used for the draw floor + goals.
+		it('+1 underdog level at 90 that QUALIFIES (won on pens) → win + 1 life', () => {
+			// picked away; home one tier higher (away is +1 underdog); 1-1 at 90;
+			// away qualified (won the shootout).
+			const res = evaluateCupPicks([makePick(1, 'away', 1, 1, 1, 'away')], 0)
+			expect(res.pickResults[0].result).toBe('win')
+			expect(res.pickResults[0].livesGained).toBe(1)
+			expect(res.finalLives).toBe(1)
+			expect(res.eliminated).toBe(false)
+		})
+
+		it('+1 underdog level at 90 that does NOT qualify (lost on pens) → draw_success, no life', () => {
+			const res = evaluateCupPicks([makePick(1, 'away', 1, 1, 1, 'home')], 0)
+			expect(res.pickResults[0].result).toBe('draw_success')
+			expect(res.pickResults[0].livesGained).toBe(0)
+			expect(res.eliminated).toBe(false)
+		})
+
+		it('counts the 90-minute goals when a qualifying underdog was level at 90', () => {
+			const res = evaluateCupPicks([makePick(1, 'away', 1, 1, 1, 'away')], 0)
+			expect(res.pickResults[0].goalsCounted).toBe(1)
+		})
+
+		it('same-tier pick that QUALIFIES from a 90-minute draw → win (no life)', () => {
+			const res = evaluateCupPicks([makePick(1, 'home', 1, 1, 0, 'home')], 0)
+			expect(res.pickResults[0].result).toBe('win')
+			expect(res.pickResults[0].livesGained).toBe(0)
+			expect(res.eliminated).toBe(false)
+		})
+
+		it('picked team behind at 90 and does NOT qualify → loss (not floored to draw)', () => {
+			// 2-0 to home at 90, picked away, away did not qualify.
+			const res = evaluateCupPicks([makePick(1, 'away', 2, 0, 1, 'home')], 0)
+			expect(res.pickResults[0].result).toBe('loss')
+			expect(res.eliminated).toBe(true)
+		})
+
+		it('qualifying win still earns no life after the streak has broken', () => {
+			// rank 1 loses with no life → streak broken. rank 2 is a +1 underdog that
+			// qualifies from a 90-min draw — a win (goals count) but life frozen.
+			const picks = [makePick(1, 'home', 0, 2, 0), makePick(2, 'away', 1, 1, 1, 'away')]
+			const res = evaluateCupPicks(picks, 0)
+			expect(res.pickResults[0].result).toBe('loss')
+			expect(res.pickResults[1].result).toBe('win')
+			expect(res.pickResults[1].livesGained).toBe(0)
+			expect(res.finalLives).toBe(0)
+		})
+	})
+
+	describe('resolveCupQualifier (winner with full-time fallback)', () => {
+		it('returns the stored winner when present', () => {
+			expect(
+				resolveCupQualifier({ winner: 'away', finished: true, fullHomeScore: 3, fullAwayScore: 4 }),
+			).toBe('away')
+		})
+
+		it('derives the qualifier from full-time (penalty-inclusive) when winner is null and finished', () => {
+			// football-data leaves `winner` null on some shootouts, but fullTime folds
+			// in the penalty aggregate — NED 1 MAR 1, pens 2-3 → fullTime 3-4 → away.
+			expect(
+				resolveCupQualifier({ winner: null, finished: true, fullHomeScore: 3, fullAwayScore: 4 }),
+			).toBe('away')
+			expect(
+				resolveCupQualifier({ winner: null, finished: true, fullHomeScore: 5, fullAwayScore: 4 }),
+			).toBe('home')
+		})
+
+		it('returns null when full-time is level and no winner (cannot tell)', () => {
+			expect(
+				resolveCupQualifier({ winner: null, finished: true, fullHomeScore: 1, fullAwayScore: 1 }),
+			).toBeNull()
+		})
+
+		it('does NOT derive a qualifier from a still-in-play match (avoids phantom wins)', () => {
+			expect(
+				resolveCupQualifier({ winner: null, finished: false, fullHomeScore: 1, fullAwayScore: 0 }),
+			).toBeNull()
+		})
+
+		it('returns null when full-time scores are missing', () => {
+			expect(
+				resolveCupQualifier({
+					winner: null,
+					finished: true,
+					fullHomeScore: null,
+					fullAwayScore: null,
+				}),
+			).toBeNull()
 		})
 	})
 

--- a/src/lib/game-logic/cup.ts
+++ b/src/lib/game-logic/cup.ts
@@ -1,16 +1,23 @@
 export interface CupPickInput {
 	confidenceRank: number
 	pickedTeam: 'home' | 'away'
-	// The 90-MINUTE (regulation) score. Cup is scored on the 90-minute result —
-	// NOT the qualification outcome — so a handicapped underdog that is level at
-	// 90 minutes survives the round even if the tie is then lost in ET/penalties
-	// (the same "draw and survive" behaviour the group stage had). The caller is
-	// responsible for passing the regulation score; the ET/penalty `winner` is
-	// intentionally not an input here (that signal belongs to classic's
-	// "to qualify" logic).
+	// The 90-MINUTE (regulation) score — the result used for the "draw floor" and
+	// for counting goals. A knockout pick is "to qualify": the `winner` below
+	// decides whether the picked team advanced; the 90-minute score only matters
+	// when the team did NOT qualify (a level-at-90 side is floored at a draw, so a
+	// handicapped underdog that drew at 90 but lost on penalties still survives —
+	// the same "draw and survive" behaviour the group stage had).
 	homeScore: number
 	awayScore: number
 	tierDifference: number // from HOME team perspective: positive = home higher tier
+	// Authoritative qualification outcome for a knockout tie ('home' | 'away'),
+	// incl. ties decided in ET/penalties. When the picked side qualifies it is a
+	// WIN regardless of the level 90-minute score (and an underdog earns its life);
+	// when it does NOT qualify but was level at 90 it is floored at a draw rather
+	// than a loss. `null`/`undefined` → no qualification decided (group draw, or a
+	// match still in play): fall back to the 90-minute score. Group/league wins
+	// and losses set `winner` too, so the same logic scores them correctly.
+	winner?: 'home' | 'away' | null
 }
 
 export interface CupPickResult {
@@ -25,6 +32,31 @@ export interface CupResult {
 	finalLives: number
 	eliminated: boolean
 	pickResults: CupPickResult[]
+}
+
+/**
+ * Resolve who qualified from a (knockout) tie for cup scoring.
+ *
+ * The stored `winner` is authoritative when present. But football-data leaves
+ * `score.winner` null on some penalty shootouts (it can lag the score by a
+ * poll or two), so when the fixture is FINISHED and `winner` is absent we fall
+ * back to the full-time score — which folds in the penalty aggregate (e.g. a
+ * 1-1 shootout won 3-2 on penalties stores fullTime 4-3), so the higher side is
+ * the side that advanced. A still-in-play match never derives a qualifier (its
+ * full-time score is just the current live score), and a finished match level
+ * on full-time with no winner is genuinely undecidable → null.
+ */
+export function resolveCupQualifier(opts: {
+	winner: 'home' | 'away' | null
+	finished: boolean
+	fullHomeScore: number | null
+	fullAwayScore: number | null
+}): 'home' | 'away' | null {
+	if (opts.winner != null) return opts.winner
+	if (!opts.finished) return null
+	const { fullHomeScore: h, fullAwayScore: a } = opts
+	if (h == null || a == null || h === a) return null
+	return h > a ? 'home' : 'away'
 }
 
 export function evaluateCupPicks(picks: CupPickInput[], startingLives: number): CupResult {
@@ -50,11 +82,16 @@ export function evaluateCupPicks(picks: CupPickInput[], startingLives: number): 
 
 		const pickedTeamGoals = pick.pickedTeam === 'home' ? pick.homeScore : pick.awayScore
 		const opponentGoals = pick.pickedTeam === 'home' ? pick.awayScore : pick.homeScore
-		// Scored on the 90-minute result only. A level 90-minute score is a draw
-		// (→ underdog survives via draw_success) regardless of any ET/penalty
-		// outcome — the qualification result is intentionally not considered here.
-		const pickedTeamWon = pickedTeamGoals > opponentGoals
-		const isDraw = pickedTeamGoals === opponentGoals
+		// A knockout pick is "to qualify". When the qualification outcome is known
+		// (`winner` set) it is authoritative: the picked side qualifying is a WIN
+		// (regardless of a level 90-minute score), and a side that did NOT qualify
+		// but was level at 90 is floored at a draw (so a handicapped underdog that
+		// drew at 90 but lost the shootout still survives). When no winner is decided
+		// (group draw, or a match still in play) fall back to the 90-minute score.
+		const qualified = pick.winner != null ? pick.winner === pick.pickedTeam : null
+		const level90 = pickedTeamGoals === opponentGoals
+		const pickedTeamWon = qualified ?? pickedTeamGoals > opponentGoals
+		const isDraw = qualified === true ? false : level90
 
 		let result: CupPickResult['result'] = 'loss'
 		let livesGained = 0

--- a/src/lib/game/cup-standings-queries.test.ts
+++ b/src/lib/game/cup-standings-queries.test.ts
@@ -28,7 +28,89 @@ import {
 	getCupStandingsData,
 	isCrucial,
 	mapPickResult,
+	projectCupCellFromFixture,
 } from './cup-standings-queries'
+
+describe('projectCupCellFromFixture', () => {
+	const fx = (over: Partial<Parameters<typeof projectCupCellFromFixture>[2]> = {}) => ({
+		homeScore: null,
+		awayScore: null,
+		regularHomeScore: null,
+		regularAwayScore: null,
+		winner: null,
+		status: 'scheduled',
+		...over,
+	})
+
+	it('projects a finished tie that the underdog QUALIFIED (won on pens) as a win', () => {
+		// NED v MAR: away (Morocco) +1 underdog, 1-1 at 90, won the shootout.
+		const cell = projectCupCellFromFixture('away', -1, {
+			homeScore: 3,
+			awayScore: 4,
+			regularHomeScore: 1,
+			regularAwayScore: 1,
+			winner: 'away',
+			status: 'finished',
+		})
+		expect(cell).toBe('win')
+	})
+
+	it('derives the qualifier from full-time when winner lags (finished shootout, winner null)', () => {
+		const cell = projectCupCellFromFixture('away', -1, {
+			homeScore: 3,
+			awayScore: 4,
+			regularHomeScore: 1,
+			regularAwayScore: 1,
+			winner: null,
+			status: 'finished',
+		})
+		expect(cell).toBe('win')
+	})
+
+	it('projects an underdog that is LEVEL in a live tie as surviving (not red)', () => {
+		// The reported bug: a live 1-1 underdog cell was rendered as a loss.
+		const cell = projectCupCellFromFixture(
+			'away',
+			-1,
+			fx({ homeScore: 1, awayScore: 1, status: 'live' }),
+		)
+		expect(cell).toBe('win')
+	})
+
+	it('projects a finished underdog draw that did NOT qualify as surviving', () => {
+		const cell = projectCupCellFromFixture('away', -1, {
+			homeScore: 4, // lost the shootout
+			awayScore: 3,
+			regularHomeScore: 1,
+			regularAwayScore: 1,
+			winner: 'home',
+			status: 'finished',
+		})
+		expect(cell).toBe('win') // draw_success renders as a (green) survival
+	})
+
+	it('still projects a same-tier live draw as a loss (no survival without the handicap)', () => {
+		const cell = projectCupCellFromFixture(
+			'home',
+			0,
+			fx({ homeScore: 1, awayScore: 1, status: 'live' }),
+		)
+		expect(cell).toBe('loss')
+	})
+
+	it('projects a clear lead as a win and a deficit as a loss', () => {
+		expect(
+			projectCupCellFromFixture('home', 0, fx({ homeScore: 2, awayScore: 0, status: 'live' })),
+		).toBe('win')
+		expect(
+			projectCupCellFromFixture('home', 0, fx({ homeScore: 0, awayScore: 2, status: 'live' })),
+		).toBe('loss')
+	})
+
+	it('returns pending when there is no score yet', () => {
+		expect(projectCupCellFromFixture('home', 0, fx())).toBe('pending')
+	})
+})
 
 describe('getCupStandingsData', () => {
 	it('returns null when game is missing', async () => {

--- a/src/lib/game/cup-standings-queries.ts
+++ b/src/lib/game/cup-standings-queries.ts
@@ -3,6 +3,7 @@ import { db } from '@/lib/db'
 import { roundLabel } from '@/lib/game/round-label'
 import { deriveGameRoundStatus } from '@/lib/game/round-status'
 import { determineFixtureOutcome } from '@/lib/game-logic/common'
+import { resolveCupQualifier } from '@/lib/game-logic/cup'
 import { computeTierDifference } from '@/lib/game-logic/cup-tier'
 import {
 	type FixtureOutcomes,
@@ -194,7 +195,7 @@ export async function getCupStandingsData(
 				// settlement when the streak/lives state is known.
 				const mapped =
 					pk.result === 'pending'
-						? projectCupCellFromFixture(pickedSide, fx)
+						? projectCupCellFromFixture(pickedSide, tierFromPicked, fx)
 						: mapPickResult(pk.result)
 				return {
 					gamePlayerId: p.id,
@@ -316,24 +317,47 @@ export function mapPickResult(r: string): 'win' | 'saved_by_life' | 'loss' | 'pe
 }
 
 /**
- * Project the cell visual for a still-pending cup pick from the
- * fixture's current score. Same outcome buckets the settled mapping
- * uses (`win` / `loss` / `pending`). Cup-specific saved_by_life /
- * draw_success outcomes need streak + lives context and only appear
- * once the pick is fully settled by reevaluateCupGame.
+ * Project the cell visual for a still-pending cup pick from the fixture's
+ * state. Same outcome buckets the settled mapping uses (`win` / `loss` /
+ * `pending`, where a survived draw renders as `win`).
+ *
+ * A knockout pick is "to qualify": once the tie is finished, the side that
+ * advanced (incl. on ET/penalties) is a `win` — derived from `winner`, or from
+ * the penalty-inclusive full-time score when football-data's winner lags. A
+ * handicapped underdog that is level on the 90-minute (regulation) score is a
+ * `draw_success` survival (renders `win`) whether the tie is in progress or was
+ * lost in the shootout. The `saved_by_life` outcome still needs streak + lives
+ * context and only appears once the pick is fully settled by reevaluateCupGame.
  */
-function projectCupCellFromFixture(
+export function projectCupCellFromFixture(
 	pickedSide: 'home' | 'away',
-	fx: { homeScore: number | null; awayScore: number | null },
+	tierFromPicked: number,
+	fx: {
+		homeScore: number | null
+		awayScore: number | null
+		regularHomeScore: number | null
+		regularAwayScore: number | null
+		winner: 'home' | 'away' | null
+		status: string
+	},
 ): 'win' | 'loss' | 'pending' {
-	if (fx.homeScore == null || fx.awayScore == null) return 'pending'
-	const pickedScore = pickedSide === 'home' ? fx.homeScore : fx.awayScore
-	const otherScore = pickedSide === 'home' ? fx.awayScore : fx.homeScore
-	if (pickedScore > otherScore) return 'win'
-	if (pickedScore < otherScore) return 'loss'
-	// Draw — in cup, draws can be 'draw_success' (underdog) or 'loss'
-	// (favourite/same-tier). Without streak context, render as loss for
-	// the in-progress projection; the post-settlement value corrects it.
+	const home90 = fx.regularHomeScore ?? fx.homeScore
+	const away90 = fx.regularAwayScore ?? fx.awayScore
+	if (home90 == null || away90 == null) return 'pending'
+	const pickedScore = pickedSide === 'home' ? home90 : away90
+	const otherScore = pickedSide === 'home' ? away90 : home90
+	const qualified = resolveCupQualifier({
+		winner: fx.winner,
+		finished: fx.status === 'finished',
+		fullHomeScore: fx.homeScore,
+		fullAwayScore: fx.awayScore,
+	})
+	const pickedWon = qualified != null ? qualified === pickedSide : pickedScore > otherScore
+	const isDraw = qualified === pickedSide ? false : pickedScore === otherScore
+	if (pickedWon) return 'win'
+	// A level 90-minute score is a draw_success survival for an underdog
+	// (tierFromPicked <= -1) — render it green, the same as a settled draw.
+	if (isDraw && tierFromPicked <= -1) return 'win'
 	return 'loss'
 }
 

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -14,7 +14,7 @@ import {
 import { isRebuyEligible } from '@/lib/game/rebuy'
 import { roundLabel, roundLabelLong } from '@/lib/game/round-label'
 import { deriveGameRoundStatus } from '@/lib/game/round-status'
-import { evaluateCupPicks } from '@/lib/game-logic/cup'
+import { evaluateCupPicks, resolveCupQualifier } from '@/lib/game-logic/cup'
 import { computeTierDifference } from '@/lib/game-logic/cup-tier'
 import { calculatePot, expectedEntryCount } from '@/lib/game-logic/prizes'
 import {
@@ -1220,6 +1220,7 @@ function computeLiveProjection(input: {
 		awayScore: number | null
 		regularHomeScore: number | null
 		regularAwayScore: number | null
+		winner: 'home' | 'away' | null
 		status: 'scheduled' | 'live' | 'finished' | 'postponed' | 'cancelled'
 		homeTeam: { id: string; externalIds: Record<string, string | number> | null }
 		awayTeam: { id: string; externalIds: Record<string, string | number> | null }
@@ -1403,6 +1404,7 @@ function projectCupPlayer(
 			awayTeamId: string
 			homeScore: number | null
 			awayScore: number | null
+			winner: 'home' | 'away' | null
 			status: string
 			homeTeam: { externalIds: Record<string, string | number> | null }
 			awayTeam: { externalIds: Record<string, string | number> | null }
@@ -1424,6 +1426,7 @@ function projectCupPlayer(
 		homeScore: number
 		awayScore: number
 		tierDifference: number
+		winner: 'home' | 'away' | null
 	}> = []
 	for (const p of playerPicks) {
 		if (p.result === 'void') continue
@@ -1446,6 +1449,16 @@ function projectCupPlayer(
 			homeScore: fx.regularHomeScore ?? fx.homeScore,
 			awayScore: fx.regularAwayScore ?? fx.awayScore,
 			tierDifference: tierDiff,
+			// "To qualify": a finished tie's winner (incl. ET/penalties) decides a
+			// win; derived from the penalty-inclusive full-time score when winner
+			// lags. A still-in-play match resolves to null → projects on the 90-min
+			// score, matching the cell projection.
+			winner: resolveCupQualifier({
+				winner: fx.winner,
+				finished: fx.status === 'finished',
+				fullHomeScore: fx.homeScore,
+				fullAwayScore: fx.awayScore,
+			}),
 		})
 	}
 	if (inputs.length === 0) {

--- a/src/lib/game/settle.ts
+++ b/src/lib/game/settle.ts
@@ -9,7 +9,7 @@ import {
 import { openRoundForGame } from '@/lib/game/round-lifecycle'
 import type { WipeoutPlayerInput } from '@/lib/game-logic/auto-complete-tiebreakers'
 import { determinePickResult } from '@/lib/game-logic/common'
-import { evaluateCupPicks } from '@/lib/game-logic/cup'
+import { evaluateCupPicks, resolveCupQualifier } from '@/lib/game-logic/cup'
 import { computeTierDifference } from '@/lib/game-logic/cup-tier'
 import {
 	computeWcClassicAutoElims,
@@ -323,16 +323,23 @@ export async function reevaluateCupGame(gameId: string): Promise<boolean> {
 			return {
 				confidenceRank: pickRow.confidenceRank ?? 0,
 				pickedTeam,
-				// Cup scores on the 90-minute (regulation) result, so an underdog
-				// level at 90 minutes survives even if the tie is then lost in
-				// ET/penalties (consistent with how the group stage scored draws).
-				// Fall back to the full-time score when regulation isn't reported
-				// separately (regulation-only matches, where the two are equal).
-				// NOTE: `winner` is deliberately NOT passed — that's the "to qualify"
-				// signal used by CLASSIC; cup is purely 90-minute-based.
+				// A knockout pick is "to qualify": `winner` (incl. ET/penalty ties)
+				// decides whether the picked side advanced. The 90-minute (regulation)
+				// score is the draw floor + goals source — an underdog level at 90 that
+				// loses the shootout still survives (draw_success), and one that wins it
+				// is a win. Fall back to the full-time score when regulation isn't
+				// reported separately. resolveCupQualifier covers football-data's
+				// winner-lag by deriving the qualifier from the penalty-inclusive
+				// full-time score when `winner` is absent on a finished tie.
 				homeScore: fx.regularHomeScore ?? fx.homeScore ?? 0,
 				awayScore: fx.regularAwayScore ?? fx.awayScore ?? 0,
 				tierDifference: tierDiff,
+				winner: resolveCupQualifier({
+					winner: fx.winner,
+					finished: fx.status === 'finished',
+					fullHomeScore: fx.homeScore,
+					fullAwayScore: fx.awayScore,
+				}),
 			}
 		})
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,12 @@ export default defineConfig({
 			'**/node_modules/**',
 			'**/dist/**',
 			'**/.next/**',
-			'**/.worktrees/**',
+			// Local git worktrees live under .claude/worktrees/ — exclude them so the
+			// primary checkout's tests are the only authoritative ones. (The old
+			// '**/.worktrees/**' pattern never matched this path, so stale worktree
+			// snapshots leaked into the run and showed phantom failures.)
+			'**/.claude/worktrees/**',
+			'**/worktrees/**',
 			'**/*.smoke.test.ts',
 		],
 	},


### PR DESCRIPTION
## What & why

A live cup game (WC R32) surfaced that **PR #102 broke "to qualify" scoring**. #102 replaced the qualification `winner` with a 90-minute-only result, so a handicapped underdog that *qualified on penalties* could only ever be a `draw_success` — never a **win**, never the life.

Concrete case: **NED v MAR** — Morocco (+1 underdog) drew 1-1 at 90 and **won the shootout**. Expected: win + 1 life. Actual: shown red.

## The rule (hybrid — restores qualify-win, keeps #102's underdog protection)

| Knockout outcome for picked team | Result | Underdog (+1) |
|---|---|---|
| **Qualified** (won tie, incl. ET/penalties) | **win** | +1 life |
| Level at 90, did **not** qualify (lost shootout) | `draw_success` (survives) | no life |
| Behind at 90, did not qualify | loss | — |

Group-stage / regulation results are unchanged — the same logic scores them via the score fallback.

## Robust qualification (football-data winner-lag)

`resolveCupQualifier`: use `winner` when present, else derive from the **penalty-inclusive full-time score** (a 1-1 won 3-2 on pens stores `fullTime 4-3`, so the higher side advanced). football-data leaves `score.winner` null on some shootouts; this recovers the result anyway. A still-in-play match never derives a phantom winner.

Wired into **both** callers: settlement (`reevaluateCupGame`) and live projection (`detail-queries` + `projectCupCellFromFixture`).

## Also fixes: why the result was never captured

The poll live-window closed at **kickoff + 150 min**, but a tie that goes to ET + penalties ends **~kickoff + 180 min** — so the `FINISHED` transition (and the penalty winner) were never polled, leaving the fixture stuck `live 1-1`. Now:
- after-window extended to **210 min** (covers ET + a long shootout + football-data's status-flip lag)
- `hasActiveFixture` treats already-`finished` fixtures as inactive, so regulation matches still let the QStash chain self-terminate promptly

## Projection

`projectCupCellFromFixture` no longer paints a pending / lost-shootout **underdog** draw red — it renders the green survival it settles to.

## Chore

`vitest.config.ts` worktree exclude was `**/.worktrees/**` but worktrees live under `**/.claude/worktrees/**` — corrected, so stale worktree snapshots stop leaking phantom test failures.

## Tests
- cup unit: qualify-win (+life), lost-pens `draw_success`, winner-lag fallback, post-break frozen-life win
- `resolveCupQualifier` unit; `match-window` unit (ET+pens window + finished-exclusion); `projectCupCellFromFixture` unit
- 2 smoke scenarios: qualify-on-pens → win+life; winner-lag fullTime fallback
- **564 unit + 42 smoke green; typecheck, lint, build clean**

## Follow-up (operational, not in this PR)
After merge+deploy, heal the live game: refresh NED v MAR from football-data (winner=away, regular 1-1) and reconcile → Morocco settles win + 1 life.

🤖 Generated with [Claude Code](https://claude.com/claude-code)