### PR TITLE
fix(cup): heart-count lives + provisional live standings

### DIFF
--- a/src/components/standings/cup-grid.test.tsx
+++ b/src/components/standings/cup-grid.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { render, screen, within } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { CupStandingsData, CupStandingsPlayer } from '@/lib/game/cup-standings-queries'
+import { CupGrid } from './cup-grid'
+
+// CupGrid reads the live context only for goal/elimination animations — the
+// displayed values all come from the `data` prop. A null payload is the default.
+vi.mock('@/components/live/use-live-game', () => ({
+	useLiveGame: () => ({
+		payload: null,
+		events: { goals: [], settlements: [] },
+		isStale: false,
+		reconnecting: false,
+	}),
+}))
+
+function player(over: Partial<CupStandingsPlayer>): CupStandingsPlayer {
+	return {
+		id: 'gp',
+		userId: 'u',
+		name: 'Player',
+		status: 'alive',
+		livesRemaining: 0,
+		streak: 0,
+		goals: 0,
+		provisional: false,
+		hasSubmitted: true,
+		eliminatedRoundNumber: null,
+		eliminatedRoundLabel: null,
+		picks: [],
+		...over,
+	}
+}
+
+function data(players: CupStandingsPlayer[]): CupStandingsData {
+	return {
+		gameId: 'g',
+		roundId: 'r',
+		roundNumber: 4,
+		roundLabel: 'Round of 32',
+		roundStatus: 'active',
+		maxLives: 0,
+		numberOfPicks: 2,
+		players,
+	}
+}
+
+describe('CupGrid lives + provisional rendering', () => {
+	it('renders lives as a heart + count, never an X/Y fraction', () => {
+		render(<CupGrid data={data([player({ id: 'a', name: 'Alice', livesRemaining: 2 })])} />)
+		const row = screen.getByText('Alice').closest('[data-gpid]') as HTMLElement
+		expect(within(row).getByText('♥')).toBeTruthy()
+		expect(within(row).getByText('2')).toBeTruthy()
+		// No fraction denominator anywhere in the row.
+		expect(row.textContent).not.toMatch(/\d\/\d/)
+	})
+
+	it('flags zero lives with a warning and dims (no phantom 0/0)', () => {
+		render(<CupGrid data={data([player({ id: 'a', name: 'Alice', livesRemaining: 0 })])} />)
+		const row = screen.getByText('Alice').closest('[data-gpid]') as HTMLElement
+		expect(row.textContent).toContain('♥')
+		expect(row.textContent).toContain('⚠')
+		expect(row.textContent).not.toContain('0/0')
+	})
+
+	it('marks a provisional row with a * on streak / goals / lives + shows the legend', () => {
+		render(
+			<CupGrid
+				data={data([
+					player({
+						id: 'a',
+						name: 'Alice',
+						streak: 1,
+						goals: 1,
+						livesRemaining: 1,
+						provisional: true,
+					}),
+				])}
+			/>,
+		)
+		const row = screen.getByText('Alice').closest('[data-gpid]') as HTMLElement
+		// streak "1*", goals "1*", lives "1*"
+		expect(within(row).getAllByText('*', { exact: false }).length).toBeGreaterThanOrEqual(1)
+		expect(row.textContent).toContain('1*')
+		// Legend explaining the marker is present once any row is provisional.
+		expect(screen.getByText(/provisional/i)).toBeTruthy()
+	})
+
+	it('does NOT show the provisional legend when every row is settled', () => {
+		render(
+			<CupGrid data={data([player({ id: 'a', name: 'Alice', streak: 2, provisional: false })])} />,
+		)
+		expect(screen.queryByText(/provisional/i)).toBeNull()
+	})
+})

--- a/src/components/standings/cup-grid.tsx
+++ b/src/components/standings/cup-grid.tsx
@@ -94,9 +94,7 @@ export function CupGrid({ data, showAdminActions, gameId }: CupGridProps) {
 						key={player.id}
 						player={player}
 						numberOfPicks={data.numberOfPicks}
-						maxLives={data.maxLives}
 						position={idx + 1}
-						roundNumber={data.roundNumber}
 						roundLabel={data.roundLabel}
 						liveMeta={liveMeta}
 						pickFixtureByRank={pickFixtureByPlayer.get(player.id)}
@@ -115,9 +113,7 @@ export function CupGrid({ data, showAdminActions, gameId }: CupGridProps) {
 								key={player.id}
 								player={player}
 								numberOfPicks={data.numberOfPicks}
-								maxLives={data.maxLives}
 								position={alive.length + idx + 1}
-								roundNumber={data.roundNumber}
 								roundLabel={data.roundLabel}
 								liveMeta={liveMeta}
 								pickFixtureByRank={pickFixtureByPlayer.get(player.id)}
@@ -128,6 +124,11 @@ export function CupGrid({ data, showAdminActions, gameId }: CupGridProps) {
 							/>
 						))}
 					</div>
+				)}
+				{data.players.some((p) => p.provisional) && (
+					<p className="mt-3 px-1 text-[10px] text-muted-foreground italic">
+						* provisional — reflects in-progress results; settles as earlier picks finish
+					</p>
 				)}
 			</div>
 		</div>
@@ -161,9 +162,7 @@ function HeaderRow({ numberOfPicks }: { numberOfPicks: number }) {
 function PlayerRow({
 	player,
 	numberOfPicks,
-	maxLives,
 	position,
-	roundNumber,
 	roundLabel,
 	liveMeta,
 	pickFixtureByRank,
@@ -174,9 +173,7 @@ function PlayerRow({
 }: {
 	player: CupStandingsData['players'][number]
 	numberOfPicks: number
-	maxLives: number
 	position: number
-	roundNumber: number
 	roundLabel: string
 	liveMeta: LiveRowMeta
 	pickFixtureByRank?: Map<number, string>
@@ -233,9 +230,24 @@ function PlayerRow({
 						/>
 					)}
 			</div>
-			<LivesCell remaining={player.livesRemaining} max={maxLives} />
-			<div className="text-center font-bold">{player.streak || '—'}</div>
-			<div className="text-center">{player.goals || '—'}</div>
+			<LivesCell remaining={player.livesRemaining} provisional={player.provisional} />
+			<div
+				className={cn(
+					'text-center font-bold',
+					player.provisional && 'italic text-muted-foreground',
+				)}
+				title={player.provisional ? PROVISIONAL_TITLE : undefined}
+			>
+				{player.streak || '—'}
+				{player.provisional && player.streak > 0 ? '*' : ''}
+			</div>
+			<div
+				className={cn('text-center', player.provisional && 'italic text-muted-foreground')}
+				title={player.provisional ? PROVISIONAL_TITLE : undefined}
+			>
+				{player.goals || '—'}
+				{player.provisional && player.goals > 0 ? '*' : ''}
+			</div>
 			{Array.from({ length: numberOfPicks }, (_, i) => {
 				const rank = i + 1
 				const pick = player.picks.find((p) => p.confidenceRank === rank)
@@ -248,28 +260,30 @@ function PlayerRow({
 	)
 }
 
-function LivesCell({ remaining, max }: { remaining: number; max: number }) {
+const PROVISIONAL_TITLE = 'Provisional — settles as earlier picks finish'
+
+// Cup lives are EARNED and uncapped, so there is no meaningful denominator —
+// render a heart glyph + the count (not a fraction). Zero lives dims the heart
+// and flags ⚠; a provisional (not-yet-settled) projection is italic with a *.
+function LivesCell({ remaining, provisional }: { remaining: number; provisional?: boolean }) {
+	const zero = remaining === 0
 	return (
-		<div className="flex items-center gap-0.5">
-			{Array.from({ length: max }, (_, i) => (
-				<span
-					// biome-ignore lint/suspicious/noArrayIndexKey: stable index
-					key={i}
-					className={cn(
-						'inline-block h-2.5 w-2.5 rounded-full',
-						i < remaining ? 'bg-[#dc2626]' : 'ring-1 ring-inset ring-border',
-					)}
-				/>
-			))}
-			<span
-				className={cn(
-					'ml-1 text-[10px]',
-					remaining === 0 ? 'text-red-600 font-bold' : 'text-muted-foreground',
-				)}
-			>
-				{remaining}/{max}
-				{remaining === 0 ? ' ⚠' : ''}
+		<div
+			className={cn(
+				'flex items-center gap-1 text-[11px]',
+				zero ? 'text-red-600 font-bold' : 'text-muted-foreground',
+				provisional && 'italic',
+			)}
+			title={provisional ? PROVISIONAL_TITLE : undefined}
+		>
+			<span aria-hidden className={cn('text-[#dc2626]', zero && 'opacity-40')}>
+				♥
 			</span>
+			<span>
+				{remaining}
+				{provisional ? '*' : ''}
+			</span>
+			{zero ? <span aria-hidden> ⚠</span> : null}
 		</div>
 	)
 }

--- a/src/components/standings/cup-ladder.tsx
+++ b/src/components/standings/cup-ladder.tsx
@@ -52,7 +52,7 @@ export function CupLadder({ data }: CupLadderProps) {
 
 	return (
 		<div className="space-y-6">
-			<Podium players={top3} maxLives={data.maxLives} />
+			<Podium players={top3} />
 			{unplayed.length > 0 && (
 				<section>
 					<h3 className="flex items-center gap-2 font-display text-lg font-semibold mb-3">
@@ -93,7 +93,7 @@ export function CupLadder({ data }: CupLadderProps) {
 	)
 }
 
-function Podium({ players, maxLives }: { players: CupStandingsPlayer[]; maxLives: number }) {
+function Podium({ players }: { players: CupStandingsPlayer[] }) {
 	if (players.length === 0) return null
 	return (
 		<div className="grid grid-cols-1 md:grid-cols-3 gap-3">
@@ -128,11 +128,17 @@ function Podium({ players, maxLives }: { players: CupStandingsPlayer[]; maxLives
 								className={cn(
 									'flex items-center gap-1 text-xs',
 									lowLives ? 'text-[var(--eliminated)] font-bold' : 'text-muted-foreground',
+									p.provisional && 'italic',
 								)}
-								title={`${p.livesRemaining} of ${maxLives} lives`}
+								title={
+									p.provisional
+										? `${p.livesRemaining} lives (provisional — settles as earlier picks finish)`
+										: `${p.livesRemaining} lives`
+								}
 							>
 								<HeartIcon size={12} />
-								{p.livesRemaining}/{maxLives}
+								{p.livesRemaining}
+								{p.provisional ? '*' : ''}
 							</div>
 							<div className="flex items-center gap-1 text-xs text-muted-foreground">
 								<Target className="h-3 w-3" />

--- a/src/lib/game/cup-standings-queries.test.ts
+++ b/src/lib/game/cup-standings-queries.test.ts
@@ -22,6 +22,7 @@ import {
 	type CupLadderBacker,
 	type CupStandingsPick,
 	type CupStandingsPlayer,
+	computeCupProjection,
 	computeLivesGained,
 	computeLivesSpent,
 	computeStreak,
@@ -30,6 +31,141 @@ import {
 	mapPickResult,
 	projectCupCellFromFixture,
 } from './cup-standings-queries'
+
+describe('computeCupProjection', () => {
+	type Entry = Parameters<typeof computeCupProjection>[0][number]
+	const scheduled = {
+		homeScore: null,
+		awayScore: null,
+		regularHomeScore: null,
+		regularAwayScore: null,
+		winner: null,
+		status: 'scheduled',
+	} as const
+	const entry = (over: Partial<Entry> & { fixture?: Partial<Entry['fixture']> } = {}): Entry => ({
+		confidenceRank: 1,
+		pickedTeam: 'home',
+		tierDifference: 0,
+		result: 'pending',
+		...over,
+		fixture: { ...scheduled, ...(over.fixture ?? {}) },
+	})
+
+	it('projects a qualifying underdog (pending + scored) as a provisional win + life', () => {
+		// away +1 underdog (tierDiff +1 from home), 1-1 at 90, won the shootout.
+		const res = computeCupProjection(
+			[
+				entry({
+					pickedTeam: 'away',
+					tierDifference: 1,
+					result: 'pending',
+					fixture: {
+						homeScore: 3,
+						awayScore: 4,
+						regularHomeScore: 1,
+						regularAwayScore: 1,
+						winner: 'away',
+						status: 'finished',
+					},
+				}),
+			],
+			0,
+		)
+		expect(res).toEqual({ streak: 1, goals: 1, lives: 1, provisional: true })
+	})
+
+	it('is NOT provisional once the contributing pick has settled', () => {
+		const res = computeCupProjection(
+			[
+				entry({
+					pickedTeam: 'away',
+					tierDifference: 1,
+					result: 'win',
+					fixture: {
+						homeScore: 3,
+						awayScore: 4,
+						regularHomeScore: 1,
+						regularAwayScore: 1,
+						winner: 'away',
+						status: 'finished',
+					},
+				}),
+			],
+			0,
+		)
+		expect(res.provisional).toBe(false)
+		expect(res).toEqual({ streak: 1, goals: 1, lives: 1, provisional: false })
+	})
+
+	it('ignores unplayed (unscored) picks — startingLives, empty streak, not provisional', () => {
+		const res = computeCupProjection([entry({ result: 'pending' })], 2)
+		expect(res).toEqual({ streak: 0, goals: 0, lives: 2, provisional: false })
+	})
+
+	it('reflects a spent life consistently (favourite draw saved by a life)', () => {
+		// same-tier draw, no qualifier → saved_by_life when a life is available.
+		const res = computeCupProjection(
+			[
+				entry({
+					pickedTeam: 'home',
+					tierDifference: 0,
+					result: 'pending',
+					fixture: {
+						homeScore: 1,
+						awayScore: 1,
+						regularHomeScore: null,
+						regularAwayScore: null,
+						winner: null,
+						status: 'finished',
+					},
+				}),
+			],
+			1,
+		)
+		expect(res.lives).toBe(0) // spent
+		expect(res.streak).toBe(1) // saved_by_life still extends the streak
+		expect(res.provisional).toBe(true)
+	})
+
+	it('streak is the leading consecutive run — a middle loss stops it', () => {
+		// rank 1 a same-tier win (earns NO life), so rank 2's loss can't be saved.
+		const res = computeCupProjection(
+			[
+				entry({
+					confidenceRank: 1,
+					pickedTeam: 'home',
+					tierDifference: 0,
+					result: 'win',
+					fixture: {
+						homeScore: 1,
+						awayScore: 0,
+						regularHomeScore: null,
+						regularAwayScore: null,
+						winner: 'home',
+						status: 'finished',
+					},
+				}),
+				entry({
+					confidenceRank: 2,
+					pickedTeam: 'home',
+					tierDifference: 0,
+					result: 'loss',
+					fixture: {
+						homeScore: 0,
+						awayScore: 2,
+						regularHomeScore: null,
+						regularAwayScore: null,
+						winner: 'away',
+						status: 'finished',
+					},
+				}),
+			],
+			0,
+		)
+		expect(res.streak).toBe(1)
+		expect(res.provisional).toBe(false) // both settled
+	})
+})
 
 describe('projectCupCellFromFixture', () => {
 	const fx = (over: Partial<Parameters<typeof projectCupCellFromFixture>[2]> = {}) => ({
@@ -314,6 +450,7 @@ describe('isCrucial', () => {
 		livesRemaining,
 		streak: 0,
 		goals: 0,
+		provisional: false,
 		hasSubmitted: true,
 		eliminatedRoundNumber: null,
 		eliminatedRoundLabel: null,

--- a/src/lib/game/cup-standings-queries.ts
+++ b/src/lib/game/cup-standings-queries.ts
@@ -3,7 +3,7 @@ import { db } from '@/lib/db'
 import { roundLabel } from '@/lib/game/round-label'
 import { deriveGameRoundStatus } from '@/lib/game/round-status'
 import { determineFixtureOutcome } from '@/lib/game-logic/common'
-import { resolveCupQualifier } from '@/lib/game-logic/cup'
+import { evaluateCupPicks, resolveCupQualifier } from '@/lib/game-logic/cup'
 import { computeTierDifference } from '@/lib/game-logic/cup-tier'
 import {
 	type FixtureOutcomes,
@@ -33,9 +33,15 @@ export interface CupStandingsPlayer {
 	userId: string
 	name: string
 	status: 'alive' | 'eliminated' | 'winner'
+	// streak / goals / livesRemaining are the PROJECTED aggregate during live play
+	// (consistent — all from one evaluateCupPicks pass over scored fixtures); they
+	// equal the persisted/settled values once everything contributing has settled.
 	livesRemaining: number
 	streak: number
 	goals: number
+	// True when the projection runs ahead of settlement (a scored pick is still
+	// `pending`) — the grid renders streak/goals/lives as provisional.
+	provisional: boolean
 	hasSubmitted: boolean
 	eliminatedRoundNumber: number | null
 	eliminatedRoundLabel: string | null
@@ -160,6 +166,10 @@ export async function getCupStandingsData(
 	const hideOpenPicks =
 		displayRound.status !== 'completed' && (!displayRound.deadline || now < displayRound.deadline)
 
+	// Starting lives default 0 (lives are EARNED in cup) — must match settlement
+	// (settle.ts) so projected lives equal persisted once settled.
+	const startingLives = (g.modeConfig as { startingLives?: number } | null)?.startingLives ?? 0
+
 	const players: CupStandingsPlayer[] = g.players
 		.filter((p) => p.eliminatedReason !== 'admin_removed')
 		.map((p) => {
@@ -212,15 +222,42 @@ export async function getCupStandingsData(
 					goalsCounted: pk.goalsScored ?? 0,
 				}
 			})
-			const streak = computeStreak(picks)
+			// Projected aggregate — streak / goals / lives from ONE evaluateCupPicks
+			// pass over scored fixtures, so the row is internally consistent and
+			// agrees with the cells. `provisional` flags that it runs ahead of
+			// settlement (e.g. a qualifying knockout pick whose earlier ranks are
+			// still unplayed). Built from the raw picks + fixtures (tier from HOME).
+			const projectionInput = myPicks
+				.map((pk) => {
+					const fx = displayRound.fixtures.find((f) => f.id === pk.fixtureId)
+					if (!fx) return null
+					const pickedTeam: 'home' | 'away' = pk.teamId === fx.homeTeamId ? 'home' : 'away'
+					return {
+						confidenceRank: pk.confidenceRank ?? 0,
+						pickedTeam,
+						tierDifference: computeTierDifference(fx.homeTeam, fx.awayTeam, g.competition.type),
+						result: pk.result,
+						fixture: {
+							homeScore: fx.homeScore,
+							awayScore: fx.awayScore,
+							regularHomeScore: fx.regularHomeScore,
+							regularAwayScore: fx.regularAwayScore,
+							winner: fx.winner,
+							status: fx.status,
+						},
+					}
+				})
+				.filter((x): x is NonNullable<typeof x> => x != null)
+			const projection = computeCupProjection(projectionInput, startingLives)
 			return {
 				id: p.id,
 				userId: p.userId,
 				name: userNames.get(p.userId) ?? 'Player',
 				status: p.status,
-				livesRemaining: p.livesRemaining,
-				streak,
-				goals: picks.reduce((sum, pk) => sum + pk.goalsCounted, 0),
+				livesRemaining: projection.lives,
+				streak: projection.streak,
+				goals: projection.goals,
+				provisional: projection.provisional,
 				hasSubmitted: myPicks.length > 0,
 				eliminatedRoundNumber: null,
 				eliminatedRoundLabel: null,
@@ -229,7 +266,6 @@ export async function getCupStandingsData(
 		})
 
 	const competitionType = g.competition.type as 'league' | 'knockout' | 'group_knockout'
-	const startingLives = (g.modeConfig as { startingLives?: number } | null)?.startingLives ?? 3
 
 	// Win scenarios — POST-DEADLINE ONLY (pre-deadline picks are hidden; revealing
 	// who-needs-what would leak them). Built from the raw picks + fixture results;
@@ -385,6 +421,70 @@ export function computeStreak(picks: CupStandingsPick[]): number {
 		else break
 	}
 	return streak
+}
+
+/**
+ * Projected cup aggregate for a player: streak / goals / lives derived from ONE
+ * `evaluateCupPicks` pass over the player's picks on scored fixtures (so the
+ * three values are mutually consistent — unlike reading a cell-based streak
+ * alongside persisted goals/lives, which lag). Uses the same `resolveCupQualifier`
+ * + 90-minute inputs the cells use, so the row agrees with the grid cells.
+ *
+ * `provisional` is true when the projection runs ahead of settlement — i.e. the
+ * player has a pick that is still `pending` but whose fixture already has a score
+ * (e.g. a qualifying knockout pick that won't persist as a win until earlier
+ * ranks settle). When everything contributing has settled, the projected values
+ * equal the persisted ones and `provisional` is false.
+ */
+export function computeCupProjection(
+	picks: Array<{
+		confidenceRank: number
+		pickedTeam: 'home' | 'away'
+		/** tier difference from the HOME team's perspective (positive = home higher tier). */
+		tierDifference: number
+		result: string
+		fixture: {
+			homeScore: number | null
+			awayScore: number | null
+			regularHomeScore: number | null
+			regularAwayScore: number | null
+			winner: 'home' | 'away' | null
+			status: string
+		}
+	}>,
+	startingLives: number,
+): { streak: number; goals: number; lives: number; provisional: boolean } {
+	const isScored = (f: (typeof picks)[number]['fixture']) =>
+		f.status !== 'cancelled' && f.homeScore != null && f.awayScore != null
+
+	const inputs = picks
+		.filter((p) => isScored(p.fixture))
+		.sort((a, b) => a.confidenceRank - b.confidenceRank)
+		.map((p) => ({
+			confidenceRank: p.confidenceRank,
+			pickedTeam: p.pickedTeam,
+			homeScore: p.fixture.regularHomeScore ?? p.fixture.homeScore ?? 0,
+			awayScore: p.fixture.regularAwayScore ?? p.fixture.awayScore ?? 0,
+			tierDifference: p.tierDifference,
+			winner: resolveCupQualifier({
+				winner: p.fixture.winner,
+				finished: p.fixture.status === 'finished',
+				fullHomeScore: p.fixture.homeScore,
+				fullAwayScore: p.fixture.awayScore,
+			}),
+		}))
+
+	const evalResult = evaluateCupPicks(inputs, startingLives)
+	// Streak = leading consecutive run of surviving results (win / draw_success /
+	// saved_by_life) in rank order.
+	let streak = 0
+	for (const r of evalResult.pickResults) {
+		if (r.result === 'win' || r.result === 'draw_success' || r.result === 'saved_by_life') streak++
+		else break
+	}
+	const goals = evalResult.pickResults.reduce((sum, r) => sum + r.goalsCounted, 0)
+	const provisional = picks.some((p) => p.result === 'pending' && isScored(p.fixture))
+	return { streak, goals, lives: evalResult.finalLives, provisional }
 }
 
 /**

--- a/src/lib/game/winner-banner-builder.test.ts
+++ b/src/lib/game/winner-banner-builder.test.ts
@@ -120,6 +120,7 @@ describe('buildWinnerBanner', () => {
 						livesRemaining: 2,
 						streak: 5,
 						goals: 7,
+						provisional: false,
 						hasSubmitted: true,
 						eliminatedRoundNumber: null,
 						eliminatedRoundLabel: null,


### PR DESCRIPTION
## What & why

Two related cup-standings fixes Sean flagged.

**1. Lives column showed a broken `X/0` fraction.** It rendered `{remaining}/{maxLives}`, but `maxLives` = `startingLives`, which defaults to **0** (cup lives are *earned*, not capped). So it showed `0/0` (and zero heart-dots) — a denominator that's never meaningfully populated, and could even be exceeded (`4/2`) in a game that starts with lives. Cup has no maximum → render a heart glyph + count instead: **`♥ 2`**, **`♥ 0 ⚠`** for none. Fixed in the grid **and** the ladder podium.

**2. Live rows mixed projected + settled values.** `streak` was projected (from the cells) while `goals`/`lives` read the persisted columns — so a player whose knockout pick was projecting a win showed the streak tick up but goals/lives stuck at the settled value. Now all three come from **one `evaluateCupPicks` pass over scored fixtures** (`computeCupProjection`), so the row agrees with the cells, and a `provisional` flag marks values running ahead of settlement (e.g. a qualifying pick whose earlier ranks are still unplayed — the Morocco case). The grid renders provisional streak/goals/lives *italic + `*`* with a one-line legend; solid once settled. This matches how the live *detail* view already projects.

## Changes
- `computeCupProjection` — projected `{streak, goals, lives}` (consistent) + `provisional`.
- `CupStandingsPlayer.streak/goals/livesRemaining` are now the projected aggregate (equal the persisted values once settled); added `provisional: boolean`.
- `startingLives` default aligned to `0` (matches settlement) so projected == persisted.
- `LivesCell` → `♥ N`; provisional styling + legend in the grid; podium lives fixed + provisional-aware.

## Scope
Share-image layouts (`cup-standings.tsx`, `cup-live.tsx`) still use `maxLives` for their heart row — a separate follow-up, as agreed.

## Tests
- `computeCupProjection` unit: qualify-win+life is provisional; settled is not; spent-life consistency; leading-consecutive streak with a middle loss.
- `CupGrid` render (RTL): heart+count not a fraction; zero-lives `♥ ⚠` (no `0/0`); provisional `*` + legend; no legend when all settled.
- 573 unit green; typecheck, lint, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)