### PR TITLE
fix(cup): heart-count lives in share images (drop maxLives dot row)

### DIFF
--- a/src/lib/share/layouts/cup-live.tsx
+++ b/src/lib/share/layouts/cup-live.tsx
@@ -111,21 +111,28 @@ export function cupLiveLayout(data: Extract<LiveShareData, { mode: 'cup' }>): La
 							<div style={{ display: 'flex', width: '180px', fontWeight: 600, fontSize: '18px' }}>
 								{player.name}
 							</div>
-							<div style={{ display: 'flex', alignItems: 'center', gap: '3px', width: '90px' }}>
-								{Array.from({ length: cup.maxLives }).map((_, i) => (
-									<div
-										// biome-ignore lint/suspicious/noArrayIndexKey: stable index
-										key={`life-${player.id}-${i}`}
-										style={{
-											display: 'flex',
-											width: '12px',
-											height: '12px',
-											borderRadius: '6px',
-											background: i < player.livesRemaining ? '#dc2626' : 'transparent',
-											border: i < player.livesRemaining ? 'none' : '1.5px solid #e8e6e1',
-										}}
-									/>
-								))}
+							{/* Earned/uncapped lives — single red pip + count (see cup-standings). */}
+							<div style={{ display: 'flex', alignItems: 'center', gap: '5px', width: '90px' }}>
+								<div
+									style={{
+										display: 'flex',
+										width: '12px',
+										height: '12px',
+										borderRadius: '6px',
+										background: player.livesRemaining > 0 ? '#dc2626' : 'transparent',
+										border: player.livesRemaining > 0 ? 'none' : '1.5px solid #e8e6e1',
+									}}
+								/>
+								<div
+									style={{
+										display: 'flex',
+										fontWeight: 700,
+										fontSize: '15px',
+										color: player.livesRemaining > 0 ? '#dc2626' : '#9b9b9b',
+									}}
+								>
+									{player.livesRemaining}
+								</div>
 							</div>
 							<div
 								style={{

--- a/src/lib/share/layouts/cup-standings.test.tsx
+++ b/src/lib/share/layouts/cup-standings.test.tsx
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import { cupStandingsLayout } from './cup-standings'
 
@@ -89,6 +91,41 @@ describe('cupStandingsLayout', () => {
 		const { jsx, height } = cupStandingsLayout(withEliminated)
 		expect(jsx).toBeTruthy()
 		expect(height).toBeGreaterThanOrEqual(700)
+	})
+
+	it('renders lives as a numeric count, not maxLives-bounded pips', () => {
+		// Cup lives are earned/uncapped — a huge maxLives must NOT drive the render;
+		// the earned count is shown as text. Before the fix there was no count text.
+		const f = {
+			mode: 'cup' as const,
+			header: fixture.header,
+			overflowCount: 0,
+			cupData: {
+				gameId: 'g1',
+				roundId: 'r1',
+				roundNumber: 7,
+				roundLabel: 'GW7',
+				roundStatus: 'open' as const,
+				numberOfPicks: 10,
+				maxLives: 99,
+				players: [
+					{
+						id: 'p1',
+						userId: 'u1',
+						name: 'Sean',
+						status: 'alive' as const,
+						eliminatedRoundNumber: null,
+						livesRemaining: 4,
+						streak: 8,
+						goals: 12,
+						picks: [],
+						hasSubmitted: true,
+					},
+				],
+			} as never,
+		}
+		render(cupStandingsLayout(f).jsx)
+		expect(screen.getByText('4')).toBeTruthy() // the earned-lives count
 	})
 
 	it('emits overflow row when more than cap', () => {

--- a/src/lib/share/layouts/cup-standings.tsx
+++ b/src/lib/share/layouts/cup-standings.tsx
@@ -118,21 +118,30 @@ export function cupStandingsLayout(
 							<div style={{ display: 'flex', width: '180px', fontWeight: 600, fontSize: '18px' }}>
 								{player.name}
 							</div>
-							<div style={{ display: 'flex', alignItems: 'center', gap: '3px', width: '90px' }}>
-								{Array.from({ length: cup.maxLives }).map((_, i) => (
-									<div
-										// biome-ignore lint/suspicious/noArrayIndexKey: stable index
-										key={`life-${player.id}-${i}`}
-										style={{
-											display: 'flex',
-											width: '12px',
-											height: '12px',
-											borderRadius: '6px',
-											background: i < player.livesRemaining ? '#dc2626' : 'transparent',
-											border: i < player.livesRemaining ? 'none' : '1.5px solid #e8e6e1',
-										}}
-									/>
-								))}
+							{/* Cup lives are EARNED and uncapped — show a single red life pip
+							    + the count, not a maxLives-bounded row of dots (maxLives is
+							    startingLives, 0 by default → the old render showed nothing). */}
+							<div style={{ display: 'flex', alignItems: 'center', gap: '5px', width: '90px' }}>
+								<div
+									style={{
+										display: 'flex',
+										width: '12px',
+										height: '12px',
+										borderRadius: '6px',
+										background: player.livesRemaining > 0 ? '#dc2626' : 'transparent',
+										border: player.livesRemaining > 0 ? 'none' : '1.5px solid #e8e6e1',
+									}}
+								/>
+								<div
+									style={{
+										display: 'flex',
+										fontWeight: 700,
+										fontSize: '15px',
+										color: player.livesRemaining > 0 ? '#dc2626' : '#9b9b9b',
+									}}
+								>
+									{player.livesRemaining}
+								</div>
 							</div>
 							<div
 								style={{


### PR DESCRIPTION
## What & why

Follow-up to #105 for the **OG share-image** layouts (the `?share` cards). Same root issue as the interactive grid: `cup-standings.tsx` / `cup-live.tsx` rendered a row of `maxLives` life-dots, but `maxLives` = `startingLives` (0 by default — cup lives are *earned* and uncapped), so the row rendered **empty**.

Now matches the grid: a single red life pip + the **earned count** (grey `0` when none). Rendered as a **numeric count**, deliberately not a `♥` glyph — `next/og` (Satori) has no custom font loaded here, so a symbol glyph would risk tofu in the image; a number is safe in the default font.

Not marking provisional in the share image — it's a point-in-time snapshot, kept clean.

## Test
`cupStandingsLayout` now renders under jsdom and asserts the lives **count** shows as text and isn't `maxLives`-bounded (maxLives 99, livesRemaining 4 → shows "4", not 99 pips). 574 unit green; typecheck, lint, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)