### PR TITLE
fix(classic): defer unresolved knockout ties (winner-lag); grid pick+skull; share goals

### DIFF
--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -267,6 +267,269 @@ describe('lifecycle: classic-PL', () => {
 		expect(players.find((p) => p.id === gpAway)?.status).toBe('eliminated')
 	})
 
+	it('winner-lag: an unresolved knockout tie is deferred (pending), then settles when the winner lands', async () => {
+		// Regression (prod game dc857c5f, R32): a knockout tie finished level while
+		// football-data's `winner` still lagged at null. Scoring it a draw wrongly
+		// eliminated the backer, and that elimination then completed/advanced the game
+		// irreversibly. It must instead be DEFERRED — pick pending, player alive —
+		// until the winner lands, then settle correctly. The genuine loser goes out
+		// only once the result is known.
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		const home = await makeTeam({ name: 'Home', shortName: 'HOM' })
+		const away = await makeTeam({ name: 'Away', shortName: 'AWY' })
+		const r4 = await makeRound(compId, { number: 4, status: 'open' })
+		const fx = await makeFixture({ roundId: r4, homeTeamId: home, awayTeamId: away })
+		const fxPending = await makeFixture({ roundId: r4, homeTeamId: home, awayTeamId: away })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r4,
+			modeConfig: { allowRebuys: false },
+		})
+		const gpHome = await makePlayer({ gameId, userId: 'u-home' })
+		const gpAway = await makePlayer({ gameId, userId: 'u-away' })
+		// Two safe players on the still-pending fixture keep >=2 alive throughout,
+		// so the game never auto-completes (last-alive) during the test.
+		const gpSafe1 = await makePlayer({ gameId, userId: 'u-safe1' })
+		const gpSafe2 = await makePlayer({ gameId, userId: 'u-safe2' })
+		await makePick({ gameId, gamePlayerId: gpHome, roundId: r4, teamId: home, fixtureId: fx })
+		await makePick({ gameId, gamePlayerId: gpAway, roundId: r4, teamId: away, fixtureId: fx })
+		await makePick({
+			gameId,
+			gamePlayerId: gpSafe1,
+			roundId: r4,
+			teamId: home,
+			fixtureId: fxPending,
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpSafe2,
+			roundId: r4,
+			teamId: away,
+			fixtureId: fxPending,
+		})
+
+		// Winner-lag moment: finished, level score, no winner yet.
+		await finishFixture(fx, 1, 1, null)
+		await settleFixture(fx)
+		{
+			const picks = await db.query.pick.findMany({ where: eq(pick.gameId, gameId) })
+			const players = await db.query.gamePlayer.findMany({ where: eq(gamePlayer.gameId, gameId) })
+			// Deferred: both picks on the tie stay pending, both players stay alive.
+			expect(picks.find((p) => p.gamePlayerId === gpHome)?.result).toBe('pending')
+			expect(picks.find((p) => p.gamePlayerId === gpAway)?.result).toBe('pending')
+			expect(players.find((p) => p.id === gpHome)?.status).toBe('alive')
+			expect(players.find((p) => p.id === gpAway)?.status).toBe('alive')
+		}
+
+		// Correct result arrives (home advanced 2-1). Re-settle the same fixture.
+		await finishFixture(fx, 2, 1, 'home')
+		await settleFixture(fx)
+
+		const picks = await db.query.pick.findMany({ where: eq(pick.gameId, gameId) })
+		const players = await db.query.gamePlayer.findMany({ where: eq(gamePlayer.gameId, gameId) })
+		// Home backer: pick heals to a win (goals = picked team's goals) and revived.
+		expect(picks.find((p) => p.gamePlayerId === gpHome)?.result).toBe('win')
+		expect(picks.find((p) => p.gamePlayerId === gpHome)?.goalsScored).toBe(2)
+		expect(players.find((p) => p.id === gpHome)?.status).toBe('alive')
+		expect(players.find((p) => p.id === gpHome)?.eliminatedRoundId).toBeNull()
+		// Away backer genuinely lost the tie: stays a loss, stays eliminated.
+		expect(picks.find((p) => p.gamePlayerId === gpAway)?.result).toBe('loss')
+		expect(players.find((p) => p.id === gpAway)?.status).toBe('eliminated')
+	})
+
+	it('winner-only-lag: a level penalty tie settles as a win when only the winner is corrected', async () => {
+		// The shootout leaves the score level (1-1); only the `winner` field arrives
+		// late. Deferred while level+winnerless, then settles to a win (goals from the
+		// level score) once the winner lands.
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		const home = await makeTeam({ name: 'Home', shortName: 'HOM' })
+		const away = await makeTeam({ name: 'Away', shortName: 'AWY' })
+		const r4 = await makeRound(compId, { number: 4, status: 'open' })
+		const fx = await makeFixture({ roundId: r4, homeTeamId: home, awayTeamId: away })
+		const fxPending = await makeFixture({ roundId: r4, homeTeamId: home, awayTeamId: away })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r4,
+			modeConfig: { allowRebuys: false },
+		})
+		const gpHome = await makePlayer({ gameId, userId: 'u-home' })
+		const gpSafe1 = await makePlayer({ gameId, userId: 'u-safe1' })
+		const gpSafe2 = await makePlayer({ gameId, userId: 'u-safe2' })
+		await makePick({ gameId, gamePlayerId: gpHome, roundId: r4, teamId: home, fixtureId: fx })
+		await makePick({
+			gameId,
+			gamePlayerId: gpSafe1,
+			roundId: r4,
+			teamId: home,
+			fixtureId: fxPending,
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpSafe2,
+			roundId: r4,
+			teamId: away,
+			fixtureId: fxPending,
+		})
+
+		await finishFixture(fx, 1, 1, null)
+		await settleFixture(fx)
+		// Deferred: pick pending, player alive (not scored a draw).
+		expect(
+			(
+				await db.query.pick.findFirst({
+					where: and(eq(pick.gameId, gameId), eq(pick.gamePlayerId, gpHome)),
+				})
+			)?.result,
+		).toBe('pending')
+		expect(
+			(await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gpHome) }))?.status,
+		).toBe('alive')
+
+		// Only the winner arrives; score stays level at 1-1.
+		await finishFixture(fx, 1, 1, 'home')
+		await settleFixture(fx)
+
+		const homePick = await db.query.pick.findFirst({
+			where: and(eq(pick.gameId, gameId), eq(pick.gamePlayerId, gpHome)),
+		})
+		const homePlayer = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gpHome) })
+		expect(homePick?.result).toBe('win')
+		expect(homePick?.goalsScored).toBe(1)
+		expect(homePlayer?.status).toBe('alive')
+	})
+
+	it('group-stage draw still eliminates — deferral is knockout-rounds only', async () => {
+		// A group-stage (round <= 3) draw is a genuine result; deferral must NOT
+		// apply, so the backer is still eliminated after the starting round.
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		const home = await makeTeam({ name: 'Home', shortName: 'HOM' })
+		const away = await makeTeam({ name: 'Away', shortName: 'AWY' })
+		const r2 = await makeRound(compId, { number: 2, status: 'open' })
+		const fx = await makeFixture({ roundId: r2, homeTeamId: home, awayTeamId: away })
+		const fxPending = await makeFixture({ roundId: r2, homeTeamId: home, awayTeamId: away })
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r2,
+			modeConfig: { allowRebuys: false },
+		})
+		const gpDraw = await makePlayer({ gameId, userId: 'u-draw' })
+		const gpSafe1 = await makePlayer({ gameId, userId: 'u-safe1' })
+		const gpSafe2 = await makePlayer({ gameId, userId: 'u-safe2' })
+		await makePick({ gameId, gamePlayerId: gpDraw, roundId: r2, teamId: home, fixtureId: fx })
+		await makePick({
+			gameId,
+			gamePlayerId: gpSafe1,
+			roundId: r2,
+			teamId: home,
+			fixtureId: fxPending,
+		})
+		await makePick({
+			gameId,
+			gamePlayerId: gpSafe2,
+			roundId: r2,
+			teamId: away,
+			fixtureId: fxPending,
+		})
+
+		await finishFixture(fx, 1, 1, null) // genuine group draw, no winner
+		await settleFixture(fx)
+
+		const drawPick = await db.query.pick.findFirst({
+			where: and(eq(pick.gameId, gameId), eq(pick.gamePlayerId, gpDraw)),
+		})
+		const drawPlayer = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gpDraw) })
+		expect(drawPick?.result).toBe('draw')
+		expect(drawPlayer?.status).toBe('eliminated')
+	})
+
+	it('a deferred knockout tie does not complete a two-player game (no premature wrong crown)', async () => {
+		// Finding-2 regression: A's tie finishes level+winnerless while B wins. If A
+		// were scored a draw and eliminated, B (last alive) would be crowned on the
+		// fixture-derived allFinished — an irreversible wrong payout. Deferral + the
+		// pending-pick guard must keep the game active until A's tie resolves.
+		const compId = await makeCompetition({ type: 'group_knockout', dataSource: 'football_data' })
+		const home = await makeTeam({ name: 'Home', shortName: 'HOM' })
+		const away = await makeTeam({ name: 'Away', shortName: 'AWY' })
+		const win = await makeTeam({ name: 'Win', shortName: 'WIN' })
+		const lose = await makeTeam({ name: 'Lose', shortName: 'LOS' })
+		const r4 = await makeRound(compId, { number: 4, status: 'open' })
+		const fxTie = await makeFixture({ roundId: r4, homeTeamId: home, awayTeamId: away })
+		const fxB = await makeFixture({ roundId: r4, homeTeamId: win, awayTeamId: lose })
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r4,
+			modeConfig: { allowRebuys: false },
+		})
+		const gpA = await makePlayer({ gameId, userId: 'u-a' })
+		const gpB = await makePlayer({ gameId, userId: 'u-b' })
+		await makePick({ gameId, gamePlayerId: gpA, roundId: r4, teamId: home, fixtureId: fxTie })
+		await makePick({ gameId, gamePlayerId: gpB, roundId: r4, teamId: win, fixtureId: fxB })
+
+		// B wins outright; A's tie is level with no winner yet.
+		await finishFixture(fxB, 3, 0, 'home')
+		await settleFixture(fxB)
+		await finishFixture(fxTie, 1, 1, null)
+		await settleFixture(fxTie)
+
+		// A's tie is unresolved → game stays active, A stays alive, B not crowned.
+		const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+		expect(g?.status).toBe('active')
+		const players = await db.query.gamePlayer.findMany({ where: eq(gamePlayer.gameId, gameId) })
+		expect(players.find((p) => p.id === gpA)?.status).toBe('alive')
+		expect(players.find((p) => p.id === gpB)?.status).toBe('alive')
+	})
+
+	it('re-settling a finished fixture does not re-eliminate a reinstated player', async () => {
+		// Guards finding-1: settleFixture skips already-settled picks, so a player
+		// reinstated after a loss (rebuy / admin) is NOT silently re-eliminated when a
+		// reconcile sweep re-runs settleFixture on the finished fixture.
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const a = await makeTeam({ name: 'A', shortName: 'A' })
+		const b = await makeTeam({ name: 'B', shortName: 'B' })
+		const r2 = await makeRound(compId, { number: 2, status: 'open' })
+		const fx = await makeFixture({ roundId: r2, homeTeamId: a, awayTeamId: b })
+		const fxPending = await makeFixture({ roundId: r2, homeTeamId: a, awayTeamId: b })
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r2,
+			modeConfig: { allowRebuys: true },
+		})
+		const gpReinstated = await makePlayer({ gameId, userId: 'u-re' })
+		// Two safe players keep >=2 alive so eliminating gpReinstated doesn't complete.
+		const gpSafe1 = await makePlayer({ gameId, userId: 'u-safe1' })
+		const gpSafe2 = await makePlayer({ gameId, userId: 'u-safe2' })
+		await makePick({ gameId, gamePlayerId: gpReinstated, roundId: r2, teamId: a, fixtureId: fx })
+		await makePick({ gameId, gamePlayerId: gpSafe1, roundId: r2, teamId: a, fixtureId: fxPending })
+		await makePick({ gameId, gamePlayerId: gpSafe2, roundId: r2, teamId: b, fixtureId: fxPending })
+
+		// A loses 0-2 → gpReinstated (picked A) eliminated.
+		await finishFixture(fx, 0, 2)
+		await settleFixture(fx)
+		expect(
+			(await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gpReinstated) }))?.status,
+		).toBe('eliminated')
+
+		// Reinstate (as a rebuy / admin make-pick would): alive again, loss pick persists.
+		await db
+			.update(gamePlayer)
+			.set({ status: 'alive', eliminatedRoundId: null, eliminatedReason: null })
+			.where(eq(gamePlayer.id, gpReinstated))
+
+		// Reconcile-style re-run of settleFixture on the same finished fixture.
+		await settleFixture(fx)
+
+		expect(
+			(await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gpReinstated) }))?.status,
+		).toBe('alive')
+	})
+
 	it('last player alive is crowned winner without their own pick winning', async () => {
 		// The doomed player's pick loses → eliminated → one alive. The survivor's
 		// pick is on a still-pending fixture, so the crown comes purely from being
@@ -336,6 +599,41 @@ describe('lifecycle: classic-PL', () => {
 		const grid = await getProgressGridData(gameId, 'u-win')
 		expect(grid?.players.find((p) => p.id === gpWin)?.goals).toBe(3)
 		expect(grid?.players.find((p) => p.id === gpLose)?.goals).toBe(0)
+	})
+
+	it('progress grid keeps the eliminating pick visible with a skull marker (not a bare skull)', async () => {
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const a = await makeTeam({ name: 'A', shortName: 'A' })
+		const b = await makeTeam({ name: 'B', shortName: 'B' })
+		const r2 = await makeRound(compId, { number: 2, status: 'open' })
+		const fx = await makeFixture({ roundId: r2, homeTeamId: a, awayTeamId: b })
+		const fxSafe = await makeFixture({ roundId: r2, homeTeamId: a, awayTeamId: b })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r2,
+			modeConfig: { allowRebuys: false },
+		})
+		const gpOut = await makePlayer({ gameId, userId: 'u-out' })
+		// Two safe players keep >=2 alive so the game doesn't auto-complete.
+		const gpSafe1 = await makePlayer({ gameId, userId: 'u-safe1' })
+		const gpSafe2 = await makePlayer({ gameId, userId: 'u-safe2' })
+		await makePick({ gameId, gamePlayerId: gpOut, roundId: r2, teamId: a, fixtureId: fx })
+		await makePick({ gameId, gamePlayerId: gpSafe1, roundId: r2, teamId: a, fixtureId: fxSafe })
+		await makePick({ gameId, gamePlayerId: gpSafe2, roundId: r2, teamId: b, fixtureId: fxSafe })
+
+		// A loses 0-2 → gpOut (picked A) is eliminated in round 2.
+		await finishFixture(fx, 0, 2)
+		await settleFixture(fx)
+
+		const grid = await getProgressGridData(gameId, 'u-out')
+		const cell = grid?.players.find((p) => p.id === gpOut)?.cellsByRoundId[r2]
+		// The cell shows the pick + result, not a bare skull — plus the marker flag.
+		expect(cell?.result).not.toBe('skull')
+		expect(cell?.result).toBe('loss')
+		expect(cell?.teamShortName).toBe('A')
+		expect(cell?.eliminatedHere).toBe(true)
 	})
 })
 

--- a/src/app/api/cron/poll-scores/route.ts
+++ b/src/app/api/cron/poll-scores/route.ts
@@ -106,7 +106,15 @@ async function pollScores(apiKey: string): Promise<NextResponse> {
 				// football-data-bootstrapped competitions (e.g., WC), external_ids.football_data
 				// equals external_id by construction.
 				const [existing] = await db
-					.select({ id: fixture.id, status: fixture.status })
+					.select({
+						id: fixture.id,
+						status: fixture.status,
+						winner: fixture.winner,
+						homeScore: fixture.homeScore,
+						awayScore: fixture.awayScore,
+						regularHomeScore: fixture.regularHomeScore,
+						regularAwayScore: fixture.regularAwayScore,
+					})
 					.from(fixture)
 					.where(sql`${fixture.externalIds}->>'football_data' = ${score.externalId}`)
 				if (!existing) continue
@@ -130,6 +138,20 @@ async function pollScores(apiKey: string): Promise<NextResponse> {
 				const nowTerminal = score.status === 'finished' || score.status === 'cancelled'
 				if (!wasTerminal && nowTerminal) {
 					transitionedFixtureIds.push(existing.id)
+				} else if (wasTerminal && nowTerminal) {
+					// Winner-lag / late correction: football-data can report a knockout
+					// tie's winner (or a corrected/regulation score) a poll or two after the
+					// fixture first flips to finished. Re-fire settlement so a classic pick
+					// deferred as an unresolved tie settles the moment the winner lands, and
+					// cup regulation-score corrections re-evaluate. settleFixture only
+					// settles pending picks, so a no-change re-fire is a no-op.
+					const resultChanged =
+						(existing.winner ?? null) !== (score.winner ?? null) ||
+						existing.homeScore !== score.homeScore ||
+						existing.awayScore !== score.awayScore ||
+						existing.regularHomeScore !== (score.regularHomeScore ?? null) ||
+						existing.regularAwayScore !== (score.regularAwayScore ?? null)
+					if (resultChanged) transitionedFixtureIds.push(existing.id)
 				}
 				totalUpdated++
 			}

--- a/src/components/standings/progress-grid.tsx
+++ b/src/components/standings/progress-grid.tsx
@@ -64,6 +64,15 @@ export interface GridCell {
 	homeAway?: 'H' | 'A'
 	score?: string
 	isAuto?: boolean
+	/**
+	 * True on the cell for the round in which this player was eliminated, when a
+	 * real pick exists for that round. The pick + result render as normal and a
+	 * skull marker is overlaid — so a pick that actually won (but the player was
+	 * still eliminated) stays visible rather than being replaced by a bare skull.
+	 * The bare `result: 'skull'` cell is kept only for elimination rounds with no
+	 * pick (e.g. a no-pick elimination).
+	 */
+	eliminatedHere?: boolean
 }
 
 export interface GridPlayer {
@@ -586,6 +595,11 @@ function GridCellView({
 					)}
 				>
 					<span>{pickedLabel}</span>
+					{cell.eliminatedHere && (
+						<span className="absolute -bottom-1.5 -right-1 text-xs leading-none drop-shadow">
+							💀
+						</span>
+					)}
 					{showOpponents && opponentLabel && (
 						<span className="text-[0.55rem] font-normal opacity-80">{opponentLabel}</span>
 					)}

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -950,7 +950,11 @@ export async function getProgressGridData(
 		for (const r of rounds) {
 			const thePick = gameData.picks.find((pk) => pk.gamePlayerId === p.id && pk.roundId === r.id)
 
-			if (p.status === 'eliminated' && p.eliminatedRoundId === r.id) {
+			// Elimination round with NO pick (e.g. a no-pick elimination) → bare
+			// skull. With a pick, fall through and render the pick + result as
+			// normal, flagged `eliminatedHere` so a skull marker is overlaid — a
+			// pick that actually won stays visible instead of being hidden.
+			if (p.status === 'eliminated' && p.eliminatedRoundId === r.id && !thePick) {
 				cellsByRoundId[r.id] = { result: 'skull' }
 				continue
 			}
@@ -1027,6 +1031,8 @@ export async function getProgressGridData(
 				homeAway,
 				score,
 				isAuto: thePick.isAuto,
+				eliminatedHere:
+					p.status === 'eliminated' && p.eliminatedRoundId === r.id ? true : undefined,
 			}
 		}
 

--- a/src/lib/game/settle.ts
+++ b/src/lib/game/settle.ts
@@ -175,6 +175,23 @@ async function settleClassicPickRow(
 	// boundary so we coalesce defensively.
 	const homeScore = fx.homeScore ?? 0
 	const awayScore = fx.awayScore ?? 0
+
+	// Unresolved knockout tie → leave the pick PENDING (don't score it a draw).
+	// A knockout match can't end level: if a knockout-round fixture is finished
+	// level with no `winner` reported yet, that's football-data's winner-lag, not
+	// a draw. Scoring it a draw here would wrongly eliminate the backer (whose team
+	// may have advanced on penalties) — and once that elimination completes or
+	// advances the game it can't be undone. Deferring keeps the player alive until
+	// the winner (or a decisive full-time score) lands, at which point the pick
+	// settles correctly via the poll re-fire / recovery sweeps. Group-stage and
+	// league draws are genuine results and are unaffected.
+	const isKnockoutRound =
+		fx.round.competition.type === 'knockout' ||
+		(fx.round.competition.type === 'group_knockout' && wcRoundStage(fx.round.number) === 'knockout')
+	if (isKnockoutRound && fx.winner == null && homeScore === awayScore) {
+		return false
+	}
+
 	const result = determinePickResult({
 		pickedTeamId: p.teamId,
 		homeTeamId: fx.homeTeam.id,
@@ -443,13 +460,29 @@ async function checkAndMaybeCompleteOrAdvance(
 				f.status === 'cancelled',
 		)
 
+	// A classic round with a still-pending pick is NOT fully settled even when
+	// every fixture is terminal: a knockout tie can be `finished` while its pick
+	// is deliberately left pending until the winner resolves (see
+	// settleClassicPickRow). Crowning / advancing on the fixture-only `allFinished`
+	// would decide the game on an unresolved tie. Mirror the turbo/cup invariant —
+	// gate the "round done" verdict on there being no pending picks too. (last-alive
+	// / mass-extinction still fire on alive count inside checkClassicCompletion; the
+	// deferred player stays alive, so those counts stay correct.)
+	let classicRoundSettled = allFinished
+	if (g.gameMode === 'classic' && allFinished) {
+		const roundPicks = await db.query.pick.findMany({
+			where: and(eq(pick.gameId, gameId), eq(pick.roundId, roundId)),
+		})
+		if (roundPicks.some((p) => p.result === 'pending')) classicRoundSettled = false
+	}
+
 	// Per-mode completion check. Classic + cup check after every pick
 	// settlement (game can complete mid-gameweek). Turbo only checks once
 	// the round is fully settled.
 	if (g.gameMode === 'classic') {
 		// WC auto-elim runs after the round is fully settled (it needs the
 		// full set of remaining-round candidates).
-		if (allFinished && g.competition.type === 'group_knockout') {
+		if (classicRoundSettled && g.competition.type === 'group_knockout') {
 			await runWcClassicAutoElims(gameId, roundId)
 		}
 		const completion = await checkClassicCompletion(
@@ -457,7 +490,7 @@ async function checkAndMaybeCompleteOrAdvance(
 			g.competitionId,
 			roundId,
 			roundNumber,
-			allFinished,
+			classicRoundSettled,
 		)
 		if (completion.completed) {
 			await applyAutoCompletion(gameId, completion.winnerPlayerIds)
@@ -504,8 +537,10 @@ async function checkAndMaybeCompleteOrAdvance(
 	}
 
 	// Game still active — if the round is fully settled, mark it complete +
-	// advance the game. Classic + cup path only; turbo handled above.
-	if (allFinished) {
+	// advance the game. Classic-only path here (cup + turbo returned above), so
+	// use the pending-aware `classicRoundSettled` — never advance past a deferred,
+	// still-unresolved knockout tie.
+	if (classicRoundSettled) {
 		await db.update(round).set({ status: 'completed' }).where(eq(round.id, roundId))
 		result.roundsCompleted.push(roundId)
 		const advanced = await advanceGameToNextRound(gameId, g.competitionId, roundNumber)

--- a/src/lib/share/layouts/classic-standings.test.ts
+++ b/src/lib/share/layouts/classic-standings.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import type { StandingsShareData } from '../data'
+import { classicStandingsLayout } from './classic-standings'
+
+/**
+ * The share image must carry the classic tiebreaker (total goals) and the
+ * per-cell scoreline, matching the on-site grid + the turbo share image.
+ * The layout returns a @vercel/og React element tree (plain objects), so we
+ * serialise it and assert the values are present in the rendered output.
+ */
+function makeData(): Extract<StandingsShareData, { mode: 'classic' }> {
+	return {
+		mode: 'classic',
+		flat: false,
+		header: {
+			gameName: 'G',
+			gameMode: 'classic',
+			competitionName: 'World Cup',
+			pot: '0.00',
+			potTotal: '0.00',
+			generatedAt: new Date('2020-05-01T00:00:00Z'),
+		},
+		classicGrid: {
+			aliveCount: 1,
+			eliminatedCount: 0,
+			pot: '0.00',
+			rounds: [{ id: 'r1', number: 4, name: 'Round of 32', label: 'R32' }],
+			players: [
+				{
+					id: 'p1',
+					name: 'Zed',
+					status: 'alive',
+					eliminatedRoundNumber: undefined,
+					eliminatedRoundLabel: undefined,
+					goals: 42,
+					cellsByRoundId: {
+						r1: {
+							result: 'win',
+							teamShortName: 'POR',
+							opponentShortName: 'CRO',
+							homeAway: 'H',
+							score: '2-1',
+						},
+					},
+				},
+			],
+		},
+	} as unknown as Extract<StandingsShareData, { mode: 'classic' }>
+}
+
+describe('classicStandingsLayout', () => {
+	it('renders a Gls column header', () => {
+		const { jsx } = classicStandingsLayout(makeData())
+		expect(JSON.stringify(jsx)).toContain('Gls')
+	})
+
+	it("renders each player's total goals (the tiebreaker)", () => {
+		const { jsx } = classicStandingsLayout(makeData())
+		expect(JSON.stringify(jsx)).toContain('42')
+	})
+
+	it('renders the per-cell scoreline', () => {
+		const { jsx } = classicStandingsLayout(makeData())
+		expect(JSON.stringify(jsx)).toContain('2-1')
+	})
+
+	it('marks the elimination-round pick with a skull but keeps the pick + result visible', () => {
+		const data = makeData()
+		// The player was eliminated on this round but their pick actually WON
+		// (the Mark Edworthy case). The cell must still show the team and a skull.
+		data.classicGrid.players[0].status = 'eliminated'
+		data.classicGrid.players[0].cellsByRoundId.r1.eliminatedHere = true
+		const s = JSON.stringify(classicStandingsLayout(data).jsx)
+		expect(s).toContain('POR') // pick still shown
+		expect(s).toContain('💀') // elimination marker
+	})
+})

--- a/src/lib/share/layouts/classic-standings.tsx
+++ b/src/lib/share/layouts/classic-standings.tsx
@@ -129,6 +129,7 @@ export function classicStandingsLayout(
 							</div>
 						))}
 					</div>
+					<div style={{ display: 'flex', width: '60px', justifyContent: 'center' }}>Gls</div>
 					<div style={{ display: 'flex', width: '100px', justifyContent: 'flex-end' }}>Status</div>
 				</div>
 				{visible.map((player) => (
@@ -241,8 +242,8 @@ export function classicStandingsLayout(
 								const bg = RESULT_COLOUR[cell.result] ?? '#888'
 								const teamAccent = cell.teamShortName ? getTeamColour(cell.teamShortName) : bg
 								const opponentLabel = cell.opponentShortName
-									? `${cell.homeAway === 'A' ? '@' : 'v'}${cell.opponentShortName}`
-									: null
+									? `${cell.homeAway === 'A' ? '@' : 'v'}${cell.opponentShortName}${cell.score ? ` ${cell.score}` : ''}`
+									: (cell.score ?? null)
 								return (
 									<div
 										key={r.id}
@@ -258,8 +259,22 @@ export function classicStandingsLayout(
 											borderRadius: '6px',
 											padding: '6px 4px',
 											borderLeft: `4px solid ${teamAccent}`,
+											position: 'relative',
 										}}
 									>
+										{cell.eliminatedHere && (
+											<div
+												style={{
+													display: 'flex',
+													position: 'absolute',
+													top: '-8px',
+													right: '-4px',
+													fontSize: '16px',
+												}}
+											>
+												💀
+											</div>
+										)}
 										<div style={{ display: 'flex', fontSize: '16px' }}>
 											{cell.teamShortName ?? '?'}
 										</div>
@@ -279,6 +294,19 @@ export function classicStandingsLayout(
 									</div>
 								)
 							})}
+						</div>
+						<div
+							style={{
+								display: 'flex',
+								width: '60px',
+								justifyContent: 'center',
+								alignItems: 'center',
+								fontSize: '16px',
+								fontWeight: 700,
+								color: '#1a1a1a',
+							}}
+						>
+							{player.goals || '—'}
 						</div>
 						<div
 							style={{


### PR DESCRIPTION
## Problem

In the live **World Cup LPS** classic game, a player who backed **Portugal** — who won their Round of 32 tie **2-1** — was **eliminated**. Root cause: a knockout tie decided in ET/penalties is scored a **draw** whenever football-data's `score.winner` lags the `finished` status (level full-time, `winner=null`). Classic then:

1. scored the tie a draw → eliminated the backer, and
2. **never re-settled** the frozen pick (guard skips non-pending picks), so it stayed wrong even after the real result landed.

Worse, that wrongful elimination could **auto-complete or advance** the game — crowning the wrong player / paying out the wrong pot, irreversibly. Cup mode already defends against winner-lag; classic didn't.

The prod record for the affected player was healed separately (draw→win, revived); this PR prevents recurrence.

## Fix — don't create the wound

Instead of re-settling and trying to *undo* a wrongful elimination (which is unreachable once the game completes/advances), a knockout-round fixture that finishes **level with no winner yet** is treated as **unresolved, not a draw**:

- **Defer** it — leave the pick `pending`, player stays **alive** — until the winner (or a decisive score) lands, then it settles correctly the first time. Group-stage and league draws are genuine results and are unaffected.
- **Round completion/advancement** now also requires no pending picks (mirrors the turbo/cup invariant), so a game can't crown or advance past an unresolved tie.
- **`poll-scores`** re-fires settlement when an already-terminal fixture's winner/score (incl. the regulation score) is corrected, so a deferred pick settles promptly.

## Also in this PR (same incident report)

- **Results grid** — the elimination-round cell now shows the actual **pick + result with a skull marker** instead of a bare 💀, so a winning-but-eliminated pick stays visible (on-site grid + share image).
- **Classic share image** — adds the **goals tiebreaker column + per-cell scores**, matching the on-site grid and the turbo share image.

## Tests

New smoke scenarios (RED-verified against the old code): deferral of an unresolved tie, winner-only lag (level penalty tie), group-stage draws still eliminating, **no premature wrong crown** in a two-player endgame, a reinstated player not being re-eliminated, and the grid showing pick+skull. Full gate green: tsc, 48 smoke, 568 unit, lint, production build.

## Review note

The initial approach (re-settle + self-heal) was caught by an adversarial code review to have serious holes (re-eliminating rebought players; wrong-crown unreachable after completion/advancement). This PR is the reworked deferral approach that resolves those at the root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)