### PR TITLE
Archived competition status honoured across game creation, sync, and sweeps

### DIFF
--- a/src/app/api/cron/daily-sync/route.test.ts
+++ b/src/app/api/cron/daily-sync/route.test.ts
@@ -37,9 +37,14 @@ vi.mock('@/lib/game/round-lifecycle', () => ({
 	openRoundForGame: vi.fn().mockResolvedValue(undefined),
 }))
 
+vi.mock('@/lib/game/reconcile', () => ({
+	reconcileAllActiveGames: vi.fn().mockResolvedValue({ checked: 0, settled: 0, advanced: 0 }),
+}))
+
 import { db } from '@/lib/db'
 import { syncCompetition } from '@/lib/game/bootstrap-competitions'
 import { processDeadlineLock } from '@/lib/game/no-pick-handler'
+import { openRoundForGame } from '@/lib/game/round-lifecycle'
 import { POST } from './route'
 
 describe('daily-sync route', () => {
@@ -179,6 +184,37 @@ describe('daily-sync route', () => {
 			}),
 		)
 		expect(processDeadlineLock).not.toHaveBeenCalled()
+	})
+
+	it('does not open upcoming rounds for games on an archived competition', async () => {
+		vi.mocked(db.query.competition.findMany).mockResolvedValue([] as never)
+		vi.mocked(db.query.game.findMany).mockResolvedValue([
+			{
+				id: 'g-archived',
+				status: 'active',
+				competition: { id: 'c-old', status: 'archived' },
+				currentRound: { id: 'r-old', status: 'upcoming' },
+			},
+			{
+				id: 'g-live',
+				status: 'active',
+				competition: { id: 'c-new', status: 'active' },
+				currentRound: { id: 'r-new', status: 'upcoming' },
+			},
+		] as never)
+
+		const res = await POST(
+			new Request('http://x', {
+				method: 'POST',
+				headers: { authorization: 'Bearer test-secret' },
+			}),
+		)
+
+		expect(res.status).toBe(200)
+		expect(openRoundForGame).toHaveBeenCalledTimes(1)
+		expect(openRoundForGame).toHaveBeenCalledWith('r-new')
+		const body = (await res.json()) as { reconciledRoundIds: string[] }
+		expect(body.reconciledRoundIds).toEqual(['r-new'])
 	})
 
 	it('invokes processDeadlineLock once with all transitioned round ids across competitions', async () => {

--- a/src/app/api/cron/daily-sync/route.ts
+++ b/src/app/api/cron/daily-sync/route.ts
@@ -85,10 +85,13 @@ export async function POST(request: Request) {
 		// the round as open.
 		const activeGames = await db.query.game.findMany({
 			where: eq(game.status, 'active'),
-			with: { currentRound: true },
+			with: { currentRound: true, competition: true },
 		})
 		const reconciledRoundIds: string[] = []
 		for (const g of activeGames) {
+			// Never mutate an archived competition's rounds — its data is frozen
+			// history even if a game row somehow still points at it.
+			if (g.competition?.status === 'archived') continue
 			if (g.currentRound && g.currentRound.status === 'upcoming') {
 				await openRoundForGame(g.currentRound.id)
 				reconciledRoundIds.push(g.currentRound.id)

--- a/src/app/api/cron/poll-scores/route.test.ts
+++ b/src/app/api/cron/poll-scores/route.test.ts
@@ -90,6 +90,20 @@ describe('poll-scores short-circuit', () => {
 		expect(body).toEqual({ updated: 0, reason: 'no-active-rounds' })
 	})
 
+	it('never polls a game whose competition is archived', async () => {
+		vi.mocked(db.query.game.findMany).mockResolvedValue([
+			{
+				currentRoundId: 'r1',
+				competition: { externalId: 'PL', dataSource: 'football_data', status: 'archived' },
+			},
+		] as never)
+		const res = await POST(authedRequest())
+		const body = await res.json()
+		expect(body).toEqual({ updated: 0, reason: 'no-active-rounds' })
+		expect(fetchLiveScoresMock).not.toHaveBeenCalled()
+		expect(enqueuePollScores).not.toHaveBeenCalled()
+	})
+
 	it('short-circuits when no fixtures are in their live window', async () => {
 		vi.mocked(db.query.game.findMany).mockResolvedValue([
 			{

--- a/src/app/api/cron/poll-scores/route.ts
+++ b/src/app/api/cron/poll-scores/route.ts
@@ -40,9 +40,12 @@ async function pollScores(apiKey: string): Promise<NextResponse> {
 
 	// A game is dispatchable if it has a current round AND its competition
 	// maps to a football-data.org code. Any later gating (live-window,
-	// dispatch loop) must agree on this set.
+	// dispatch loop) must agree on this set. Archived competitions are frozen
+	// history — never poll, write scores, or re-sync them, even if an active
+	// game row somehow still points at one.
 	const dispatchableGames = activeGames.flatMap((g) => {
 		if (!g.currentRoundId) return []
+		if (g.competition.status === 'archived') return []
 		const code = resolveFootballDataCode(g.competition)
 		if (!code) return []
 		return [{ id: g.id, currentRoundId: g.currentRoundId, code }]
@@ -80,6 +83,9 @@ async function pollScores(apiKey: string): Promise<NextResponse> {
 	// trigger a bracket re-sync after a knockout fixture finishes.
 	const compByCode = new Map<string, { id: string; type: string }>()
 	for (const g of activeGames) {
+		// Same archived exclusion as dispatchableGames — an archived competition
+		// sharing an external code must never shadow the active one here.
+		if (g.competition.status === 'archived') continue
 		const code = resolveFootballDataCode(g.competition)
 		if (code) compByCode.set(code, { id: g.competition.id, type: g.competition.type })
 	}

--- a/src/app/api/games/route.test.ts
+++ b/src/app/api/games/route.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/auth-helpers', () => ({
+	requireSession: vi.fn().mockResolvedValue({ user: { id: 'creator' } }),
+}))
+
+vi.mock('@/lib/game/round-lifecycle', () => ({
+	openRoundForGame: vi.fn().mockResolvedValue(undefined),
+}))
+
+const { dbMock, insertReturning } = vi.hoisted(() => {
+	const insertReturning = vi.fn().mockResolvedValue([{ id: 'new-game' }])
+	// db.insert(...).values(...) is awaited directly for gamePlayer/payment rows
+	// and chained with .returning() for the game row — mirror drizzle's thenable
+	// builder shape.
+	const insertValues = vi.fn(() => {
+		const thenable = Promise.resolve(undefined) as Promise<undefined> & {
+			returning: typeof insertReturning
+		}
+		thenable.returning = insertReturning
+		return thenable
+	})
+	return {
+		insertReturning,
+		dbMock: {
+			query: {
+				competition: { findFirst: vi.fn() },
+				round: { findMany: vi.fn() },
+				team: { findMany: vi.fn() },
+			},
+			insert: vi.fn(() => ({ values: insertValues })),
+		},
+	}
+})
+
+vi.mock('@/lib/db', () => ({ db: dbMock }))
+
+import { openRoundForGame } from '@/lib/game/round-lifecycle'
+import { POST } from './route'
+
+const req = (body: unknown) =>
+	new Request('http://localhost/api/games', {
+		method: 'POST',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify(body),
+	})
+
+const createBody = { name: 'GW1 survivors', competitionId: 'c1', gameMode: 'classic' }
+
+describe('POST /api/games', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		insertReturning.mockResolvedValue([{ id: 'new-game' }])
+		dbMock.query.competition.findFirst.mockResolvedValue({
+			id: 'c1',
+			type: 'league',
+			status: 'active',
+		} as never)
+		dbMock.query.round.findMany.mockResolvedValue([
+			{
+				id: 'r1',
+				number: 1,
+				status: 'upcoming',
+				deadline: new Date(Date.now() + 24 * 60 * 60 * 1000),
+			},
+		] as never)
+	})
+
+	it('404s when the competition does not exist', async () => {
+		dbMock.query.competition.findFirst.mockResolvedValue(undefined as never)
+		const res = await POST(req(createBody))
+		expect(res.status).toBe(404)
+	})
+
+	it('rejects an archived competition with 400 and creates nothing', async () => {
+		dbMock.query.competition.findFirst.mockResolvedValue({
+			id: 'c1',
+			type: 'league',
+			status: 'archived',
+		} as never)
+
+		const res = await POST(req(createBody))
+
+		expect(res.status).toBe(400)
+		expect((await res.json()).error).toBe('competition-archived')
+		expect(dbMock.insert).not.toHaveBeenCalled()
+		expect(openRoundForGame).not.toHaveBeenCalled()
+	})
+
+	it('creates a game on an active competition and opens its first round', async () => {
+		const res = await POST(req(createBody))
+
+		expect(res.status).toBe(201)
+		expect((await res.json()).id).toBe('new-game')
+		expect(openRoundForGame).toHaveBeenCalledWith('r1')
+	})
+})

--- a/src/app/api/games/route.ts
+++ b/src/app/api/games/route.ts
@@ -58,6 +58,20 @@ export async function POST(request: Request) {
 		return NextResponse.json({ error: 'Competition not found' }, { status: 404 })
 	}
 
+	// Archived competitions (finished seasons/tournaments kept for history) are
+	// excluded from the creation listing, but reject at the API boundary too so
+	// a stale client or crafted request can't attach a new game to a dead season.
+	if (comp.status === 'archived') {
+		return NextResponse.json(
+			{
+				error: 'competition-archived',
+				message:
+					'This competition has finished and is archived. New games cannot be created on it.',
+			},
+			{ status: 400 },
+		)
+	}
+
 	// Cup mode is designed for cup competitions (knockout / group_knockout —
 	// e.g. World Cup, FA Cup, League Cup). It's not appropriate for league
 	// competitions like the PL where the format doesn't match. Reject at the

--- a/src/lib/game/apply-pot-assignments.test.ts
+++ b/src/lib/game/apply-pot-assignments.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const { dbMock } = vi.hoisted(() => ({
 	dbMock: {
 		query: {
+			competition: { findFirst: vi.fn() },
 			round: { findMany: vi.fn() },
 			team: { findMany: vi.fn() },
 		},
@@ -16,7 +17,23 @@ vi.mock('@/lib/db', () => ({ db: dbMock }))
 import { applyPotAssignments } from './bootstrap-competitions'
 
 describe('applyPotAssignments', () => {
-	beforeEach(() => vi.clearAllMocks())
+	beforeEach(() => {
+		vi.clearAllMocks()
+		dbMock.query.competition.findFirst.mockResolvedValue({ id: 'c1', status: 'active' } as never)
+	})
+
+	it('is a no-op for an archived competition (team pot tags stay untouched)', async () => {
+		dbMock.query.competition.findFirst.mockResolvedValue({
+			id: 'c1',
+			status: 'archived',
+		} as never)
+
+		const result = await applyPotAssignments('c1')
+
+		expect(result).toEqual({ matched: 0, unmatched: [] })
+		expect(dbMock.query.round.findMany).not.toHaveBeenCalled()
+		expect(dbMock.update).not.toHaveBeenCalled()
+	})
 
 	it('returns matched=0, unmatched=[] when no fixtures/teams in competition', async () => {
 		dbMock.query.round.findMany.mockResolvedValue([] as never)

--- a/src/lib/game/bootstrap-competitions.test.ts
+++ b/src/lib/game/bootstrap-competitions.test.ts
@@ -1,3 +1,4 @@
+import { PgDialect } from 'drizzle-orm/pg-core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
@@ -28,7 +29,10 @@ const {
 	}))
 	const selectWhere = vi.fn().mockResolvedValue([])
 	const selectFn = vi.fn(() => ({
-		from: () => ({ where: selectWhere }),
+		from: () => ({
+			innerJoin: () => ({ innerJoin: () => ({ where: selectWhere }) }),
+			where: selectWhere,
+		}),
 	}))
 	return {
 		dbQueryCompetitionFindFirst: vi.fn(),
@@ -595,5 +599,61 @@ describe('scheduleUpcomingFixturePolls', () => {
 
 		await expect(scheduleUpcomingFixturePolls()).resolves.toBeUndefined()
 		expect(enqueuePollScoresAtMock).toHaveBeenCalledTimes(2)
+	})
+
+	it('restricts the fixture query to active competitions so archived ones never get polls', async () => {
+		dbSelectWhere.mockResolvedValue([])
+
+		await scheduleUpcomingFixturePolls()
+
+		const condition = dbSelectWhere.mock.calls[0][0]
+		const { sql: rendered, params } = new PgDialect().sqlToQuery(condition as never)
+		expect(rendered).toContain('"competition"."status"')
+		expect(params).toContain('active')
+	})
+})
+
+describe('archived competition immutability', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('syncCompetition is a no-op for an archived competition (nothing fetched or written)', async () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+		const summary = await syncCompetition(
+			{
+				id: 'comp-old',
+				name: 'Premier League 2025/26',
+				dataSource: 'fpl',
+				externalId: null,
+				status: 'archived',
+			} as never,
+			{ footballDataApiKey: 'fd-key' },
+		)
+
+		expect(summary).toEqual({
+			rounds: 0,
+			fixtures: 0,
+			deadlinePassedRoundIds: [],
+			settledFixtureIds: [],
+		})
+		expect(fplFetchTeams).not.toHaveBeenCalled()
+		expect(fdFetchTeams).not.toHaveBeenCalled()
+		expect(dbInsertFn).not.toHaveBeenCalled()
+		expect(dbUpdateFn).not.toHaveBeenCalled()
+		expect(warn).toHaveBeenCalledWith(expect.stringContaining('archived'))
+		warn.mockRestore()
+	})
+
+	it('mergeFootballDataIds is a no-op for an archived competition', async () => {
+		await mergeFootballDataIds(
+			{ id: 'comp-old', dataSource: 'fpl', externalId: null, status: 'archived' } as never,
+			'fd-key',
+		)
+
+		expect(fdFetchTeams).not.toHaveBeenCalled()
+		expect(fdFetchRounds).not.toHaveBeenCalled()
+		expect(dbUpdateFn).not.toHaveBeenCalled()
 	})
 })

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -98,10 +98,20 @@ const PRE_SCHEDULE_LOOKAHEAD_MS = 2 * 24 * 60 * 60 * 1000
 export async function scheduleUpcomingFixturePolls(): Promise<void> {
 	const now = new Date()
 	const lookahead = new Date(now.getTime() + PRE_SCHEDULE_LOOKAHEAD_MS)
+	// Join up to the competition so archived competitions never get polls
+	// enqueued — their fixtures are history, not upcoming matches.
 	const upcoming = await db
 		.select({ id: fixture.id, kickoff: fixture.kickoff })
 		.from(fixture)
-		.where(and(gt(fixture.kickoff, now), lt(fixture.kickoff, lookahead)))
+		.innerJoin(round, eq(fixture.roundId, round.id))
+		.innerJoin(competition, eq(round.competitionId, competition.id))
+		.where(
+			and(
+				gt(fixture.kickoff, now),
+				lt(fixture.kickoff, lookahead),
+				eq(competition.status, 'active'),
+			),
+		)
 
 	for (const f of upcoming) {
 		if (!f.kickoff) continue
@@ -160,6 +170,9 @@ function fdTlaForFplShortName(fplShortName: string): string {
  * Idempotent: re-running this on already-merged data is a no-op.
  */
 export async function mergeFootballDataIds(comp: CompetitionRow, apiKey: string): Promise<void> {
+	// Same immutability rule as syncCompetition: never touch an archived
+	// competition's team/fixture external ids.
+	if (comp.status === 'archived') return
 	if (!comp.externalId && comp.dataSource !== 'fpl') return // PL is the only fpl source today
 	const fdCode = comp.externalId ?? 'PL'
 	const fdAdapter = new FootballDataAdapter(fdCode, apiKey)
@@ -274,6 +287,15 @@ export async function syncCompetition(
 	deadlinePassedRoundIds: string[]
 	settledFixtureIds: string[]
 }> {
+	// Archived competitions are immutable — their rounds, fixtures, and external
+	// ids must never change again. The daily-sync loop only enumerates active
+	// competitions, but this guard is the structural backstop for every other
+	// path that reaches here (stale QStash sync_competition jobs, the hardcoded
+	// bootstrap lookups, future callers).
+	if (comp.status === 'archived') {
+		console.warn(`[syncCompetition] skipping archived competition ${comp.id} (${comp.name})`)
+		return { rounds: 0, fixtures: 0, deadlinePassedRoundIds: [], settledFixtureIds: [] }
+	}
 	const adapter = adapterFor(comp, opts)
 	if (!adapter) return { rounds: 0, fixtures: 0, deadlinePassedRoundIds: [], settledFixtureIds: [] }
 
@@ -575,6 +597,12 @@ async function seedProvisionalKnockoutTies(
 export async function applyPotAssignments(
 	competitionId: string,
 ): Promise<{ matched: number; unmatched: string[] }> {
+	// Pot tags land on team rows via external_ids — a sync-owned mutation, so
+	// the archived-competition immutability rule applies here too.
+	const comp = await db.query.competition.findFirst({
+		where: eq(competition.id, competitionId),
+	})
+	if (!comp || comp.status === 'archived') return { matched: 0, unmatched: [] }
 	const rounds = await db.query.round.findMany({
 		where: eq(round.competitionId, competitionId),
 		with: { fixtures: true },

--- a/src/lib/game/reconcile.test.ts
+++ b/src/lib/game/reconcile.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { dbMock, advanceGameIfReadyMock, sweepGameSettlementMock } = vi.hoisted(() => ({
+	dbMock: { query: { game: { findFirst: vi.fn() } } },
+	advanceGameIfReadyMock: vi.fn(),
+	sweepGameSettlementMock: vi.fn(),
+}))
+
+vi.mock('@/lib/db', () => ({ db: dbMock }))
+vi.mock('@/lib/game/process-round', () => ({ advanceGameIfReady: advanceGameIfReadyMock }))
+vi.mock('@/lib/game/settle', () => ({ sweepGameSettlement: sweepGameSettlementMock }))
+
+import { reconcileGameState } from './reconcile'
+
+describe('reconcileGameState', () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it('no-ops on an active game whose competition is archived — no settle, no advance', async () => {
+		dbMock.query.game.findFirst.mockResolvedValue({
+			id: 'g1',
+			status: 'active',
+			currentRoundId: 'r1',
+			competition: { id: 'c1', status: 'archived' },
+			currentRound: { id: 'r1', status: 'completed', fixtures: [] },
+		} as never)
+
+		const result = await reconcileGameState('g1')
+
+		expect(result).toEqual({ ok: true, action: 'noop', reason: 'competition-archived' })
+		expect(advanceGameIfReadyMock).not.toHaveBeenCalled()
+		expect(sweepGameSettlementMock).not.toHaveBeenCalled()
+	})
+
+	it('leaves a completed game on an archived competition untouched (history intact)', async () => {
+		dbMock.query.game.findFirst.mockResolvedValue({
+			id: 'g1',
+			status: 'completed',
+			currentRoundId: 'r1',
+			competition: { id: 'c1', status: 'archived' },
+			currentRound: { id: 'r1', status: 'completed', fixtures: [] },
+		} as never)
+
+		const result = await reconcileGameState('g1')
+
+		expect(result).toEqual({ ok: true, action: 'noop', reason: 'game-not-active' })
+		expect(advanceGameIfReadyMock).not.toHaveBeenCalled()
+		expect(sweepGameSettlementMock).not.toHaveBeenCalled()
+	})
+
+	it('still reconciles an active game on an active competition', async () => {
+		dbMock.query.game.findFirst.mockResolvedValue({
+			id: 'g1',
+			status: 'active',
+			currentRoundId: 'r1',
+			competition: { id: 'c1', status: 'active' },
+			currentRound: { id: 'r1', status: 'open', fixtures: [] },
+		} as never)
+		sweepGameSettlementMock.mockResolvedValue([
+			{ classicSettled: 2, turboSettled: 0, cupGamesReevaluated: 0 },
+		])
+
+		const result = await reconcileGameState('g1')
+
+		expect(result).toEqual({ ok: true, action: 'settled', fixturesSettled: 2 })
+	})
+})

--- a/src/lib/game/reconcile.ts
+++ b/src/lib/game/reconcile.ts
@@ -28,6 +28,7 @@ export async function reconcileGameState(gameId: string): Promise<ReconcileResul
 	const g = await db.query.game.findFirst({
 		where: eq(game.id, gameId),
 		with: {
+			competition: true,
 			currentRound: {
 				with: { fixtures: true },
 			},
@@ -35,6 +36,12 @@ export async function reconcileGameState(gameId: string): Promise<ReconcileResul
 	})
 	if (!g) return { ok: false, error: 'game-not-found' }
 	if (g.status !== 'active') return { ok: true, action: 'noop', reason: 'game-not-active' }
+	// Archived competitions are immutable history — reconcile must not settle,
+	// advance, or open rounds on one. Guarding here covers every recovery
+	// surface at once (page SSR, live API, daily-sync sweep, manual cron).
+	if (g.competition?.status === 'archived') {
+		return { ok: true, action: 'noop', reason: 'competition-archived' }
+	}
 	if (!g.currentRoundId || !g.currentRound) {
 		return { ok: true, action: 'noop', reason: 'no-current-round' }
 	}

--- a/src/lib/schema/competition.ts
+++ b/src/lib/schema/competition.ts
@@ -48,7 +48,14 @@ export const competition = pgTable('competition', {
 	dataSource: competitionDataSourceEnum('data_source').notNull(),
 	externalId: varchar('external_id', { length: 100 }),
 	season: varchar('season', { length: 20 }),
-	status: varchar('status', { length: 20 }).notNull().default('active'),
+	// Lifecycle: 'active' → offered at game creation, synced daily, polled live.
+	// 'archived' → a finished season/tournament kept for history: hidden from
+	// game creation, skipped by every sync/reconcile/poll surface, and never
+	// mutated again. Completed games on it keep rendering unchanged.
+	status: varchar('status', { length: 20 })
+		.$type<'active' | 'archived'>()
+		.notNull()
+		.default('active'),
 	createdAt: timestamp('created_at').defaultNow().notNull(),
 })
 


### PR DESCRIPTION
Closes #114

## What

Competitions gain an `archived` lifecycle state (typed `'active' | 'archived'` on the existing varchar — no migration) that is honoured at every surface that enumerates or mutates competition data:

- **Game creation** — the listing already excluded non-active competitions (`getActiveCompetitions`); the `POST /api/games` boundary now rejects archived ones with 400 `competition-archived`, so a stale client or crafted request can't attach a game to a dead season.
- **Sync paths** — `syncCompetition`, `mergeFootballDataIds`, and `applyPotAssignments` all no-op on archived competitions. The daily-sync loop already enumerated only active competitions; these guards are the structural backstop for every other caller (stale QStash `sync_competition` jobs — a failure mode this project has hit before, the hardcoded bootstrap lookups, future callers).
- **Fixture-poll scheduling** — `scheduleUpcomingFixturePolls` now joins fixture → round → competition and only enqueues kickoff triggers for active competitions' fixtures.
- **Reconcile sweeps** — `reconcileGameState` no-ops when the game's competition is archived; one guard at the choke point covers all four recovery surfaces (page SSR, live API, daily-sync sweep, manual process-rounds). The daily-sync upcoming-round heal loop likewise never opens an archived competition's round.
- **Live polling** (self-review finding) — `poll-scores` excludes games on archived competitions from its dispatchable set, so scores can never be written onto an archived comp's fixtures and no poll chain can be kept alive by one.
- **Completed games on an archived competition render unchanged** — nothing in the render path consults `competition.status`; the only page query that filters on it is the create-game listing. The reconcile guard means page-SSR recovery is a guaranteed no-op.

## Coverage

At the seams the ticket named, plus the surfaces the guards touch:

- Bootstrap unit seam: `syncCompetition` / `mergeFootballDataIds` archived no-ops; poll query restricted to active competitions; `applyPotAssignments` archived no-op.
- Game-creation API seam: new `src/app/api/games/route.test.ts` (404 unknown, 400 archived + nothing created, 201 happy path proving the guard doesn't over-reject).
- `reconcileGameState` guard, daily-sync heal-loop skip, and poll-scores exclusion each have route/unit tests.

`just test` (612 passed), `just typecheck`, `just lint` (2 pre-existing warnings in `team-badge.tsx`, untouched), `just smoke` against local Postgres (50 passed), `just build` — all green.

## Self-review notes (findings I disagreed with, and why)

- **Nothing writes `status='archived'` yet** — deliberate: this ticket makes the state *honoured*; the writers (season-rollover auto-archive, the 2025/26 restore-and-archive script) are separate children of #112.
- **`status` stays varchar rather than a `pgEnum`** (divergence from the other status columns in the schema file) — declined to avoid a data migration on an existing column for a two-value state; the `$type` union gives compile-time safety. Worth revisiting if a third lifecycle state ever lands.
- **Shared `isArchived(comp)` helper for the repeated predicate** — declined: half the sites are SQL where-clauses that can't share a TS predicate, and the defence-in-depth guards are meant to read locally as a single typed equality.
- **`applyPotAssignments` re-fetches the competition though callers hold the row** — kept the id-based signature: it protects future id-only callers (the `sync_competition` QStash job pattern) and one extra query per daily sync is negligible.
- **`PgDialect().sqlToQuery` assertion tests rendered SQL** — acknowledged as white-box; it is the only way to assert the poll-query exclusion at the mocked-db unit seam the ticket scoped coverage to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)