### PR TITLE
Season-safe sync identity: competition-scoped fixture upserts + payload-driven team resolution

### DIFF
--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -2592,6 +2592,17 @@ describe('lifecycle: PL season rollover sync identity', () => {
 		expect(teams.find((t) => t.name === 'Holt FC')?.badgeUrl).toBe(fdCrest('HOL'))
 		expect(teams.find((t) => t.name === 'Isley FC')?.badgeUrl).toBe(fdCrest('ISL'))
 
+		// A later daily sync (without its merge step — the merge is exactly what
+		// fails loudly on a new-season tla gap) must not stomp the crest with
+		// the 404ing FPL badge URL.
+		await syncSecondSeason()
+		const teamsAfterResync = await db.select().from(teamTable)
+		for (const name of ['Grove FC', 'Holt FC', 'Isley FC']) {
+			const club = S2_CLUBS.find((c) => c.name === name)
+			if (!club) throw new Error(`unknown club ${name}`)
+			expect(teamsAfterResync.find((t) => t.name === name)?.badgeUrl).toBe(fdCrest(club.short_name))
+		}
+
 		// Relegated clubs' rows are untouched by the whole second-season run —
 		// stale external ids and all.
 		for (const name of ['Dorne FC', 'Elm FC', 'Fern FC']) {

--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -17,10 +17,10 @@
  * Adding a new competition? Add a scenario for each supported mode here.
  * See `docs/superpowers/specs/2026-05-12-per-fixture-settlement-and-live-projection-design.md`.
  */
-import { and, eq } from 'drizzle-orm'
+import { and, eq, inArray } from 'drizzle-orm'
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { db } from '@/lib/db'
-import { syncCompetition } from '@/lib/game/bootstrap-competitions'
+import { mergeFootballDataIds, syncCompetition } from '@/lib/game/bootstrap-competitions'
 import { getCupLadderData, getCupStandingsData } from '@/lib/game/cup-standings-queries'
 import {
 	getLivePayload,
@@ -2306,5 +2306,298 @@ describe('lifecycle: WC knockout bracket self-heal', () => {
 		expect(
 			[tla(bound537377?.homeTeamId ?? null), tla(bound537377?.awayTeamId ?? null)].sort(),
 		).toEqual(['W4', 'W5'].sort())
+	})
+})
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* PL season rollover — season-safe sync identity                          */
+/* ────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Runs the REAL syncCompetition + mergeFootballDataIds against Postgres,
+ * proving a second-season sync is structurally unable to touch the first
+ * season's rows (the 2026/27 silent-corruption incident):
+ *   - FPL fixture ids restart every season (1..380) — the upsert must only
+ *     ever find rows inside the competition being synced.
+ *   - FPL team ids restart too and get reassigned across clubs, so team
+ *     resolution must go through the current payload, never per-season ids
+ *     stored on team rows from an earlier season.
+ *   - Promoted clubs are new rows whose badge comes from the football-data
+ *     crest (the FPL badge CDN 404s for newly promoted clubs); relegated
+ *     clubs' rows are left dormant.
+ *
+ * The first-season competition deliberately stays ACTIVE — the scoping must
+ * hold structurally, not by leaning on the archived-status guard.
+ */
+describe('lifecycle: PL season rollover sync identity', () => {
+	// Season 1 clubs, FPL ids assigned alphabetically. Dorne/Elm/Fern are
+	// relegated after season 1; Grove/Holt/Isley come up. FPL then reassigns
+	// ids alphabetically again, so ids 4-6 point at DIFFERENT clubs in season
+	// 2 — the stale-id trap.
+	const S1_CLUBS = [
+		{ id: 1, name: 'Alder FC', short_name: 'ALD', code: 11, fdId: 101 },
+		{ id: 2, name: 'Birch FC', short_name: 'BIR', code: 12, fdId: 102 },
+		{ id: 3, name: 'Cedar FC', short_name: 'CED', code: 13, fdId: 103 },
+		{ id: 4, name: 'Dorne FC', short_name: 'DOR', code: 14, fdId: 104 },
+		{ id: 5, name: 'Elm FC', short_name: 'ELM', code: 15, fdId: 105 },
+		{ id: 6, name: 'Fern FC', short_name: 'FER', code: 16, fdId: 106 },
+	]
+	const S2_CLUBS = [
+		{ id: 1, name: 'Alder FC', short_name: 'ALD', code: 11, fdId: 101 },
+		{ id: 2, name: 'Birch FC', short_name: 'BIR', code: 12, fdId: 102 },
+		{ id: 3, name: 'Cedar FC', short_name: 'CED', code: 13, fdId: 103 },
+		{ id: 4, name: 'Grove FC', short_name: 'GRO', code: 24, fdId: 107 },
+		{ id: 5, name: 'Holt FC', short_name: 'HOL', code: 25, fdId: 108 },
+		{ id: 6, name: 'Isley FC', short_name: 'ISL', code: 26, fdId: 109 },
+	]
+
+	// Season 1: one finished gameweek, fixture ids 1-3, with final scores.
+	const S1_FPL = {
+		bootstrap: {
+			teams: S1_CLUBS.map(({ fdId: _fdId, ...t }) => t),
+			events: [
+				{ id: 1, name: 'Gameweek 1', deadline_time: '2025-08-15T17:30:00Z', finished: true },
+			],
+		},
+		fixtures: [
+			{ id: 1, event: 1, team_h: 1, team_a: 2, kickoff_time: '2025-08-16T14:00:00Z', h: 2, a: 0 },
+			{ id: 2, event: 1, team_h: 3, team_a: 4, kickoff_time: '2025-08-16T16:30:00Z', h: 1, a: 1 },
+			{ id: 3, event: 1, team_h: 5, team_a: 6, kickoff_time: '2025-08-17T13:00:00Z', h: 0, a: 3 },
+		].map((f) => ({
+			id: f.id,
+			event: f.event,
+			team_h: f.team_h,
+			team_a: f.team_a,
+			kickoff_time: f.kickoff_time,
+			started: true,
+			finished: true,
+			finished_provisional: true,
+			team_h_score: f.h,
+			team_a_score: f.a,
+		})),
+	}
+
+	// Season 2: fixture ids RESTART at 1, scheduled, no scores. Payload team
+	// id 4 is now the promoted Grove FC (was Dorne FC in season 1).
+	const S2_FPL = {
+		bootstrap: {
+			teams: S2_CLUBS.map(({ fdId: _fdId, ...t }) => t),
+			events: [
+				{ id: 1, name: 'Gameweek 1', deadline_time: '2026-08-21T17:30:00Z', finished: false },
+			],
+		},
+		fixtures: [
+			{ id: 1, event: 1, team_h: 1, team_a: 4, kickoff_time: '2026-08-22T14:00:00Z' },
+			{ id: 2, event: 1, team_h: 2, team_a: 5, kickoff_time: '2026-08-22T16:30:00Z' },
+			{ id: 3, event: 1, team_h: 3, team_a: 6, kickoff_time: '2026-08-23T13:00:00Z' },
+		].map((f) => ({
+			id: f.id,
+			event: f.event,
+			team_h: f.team_h,
+			team_a: f.team_a,
+			kickoff_time: f.kickoff_time,
+			started: false,
+			finished: false,
+			finished_provisional: false,
+			team_h_score: null,
+			team_a_score: null,
+		})),
+	}
+
+	const fdCrest = (tla: string) => `https://crests.example/${tla.toLowerCase()}.png`
+	const fdTeam = (club: (typeof S1_CLUBS)[number]) => ({
+		id: club.fdId,
+		name: club.name,
+		tla: club.short_name,
+		crest: fdCrest(club.short_name),
+	})
+	const clubByFplId = (clubs: typeof S1_CLUBS, id: number) => {
+		const club = clubs.find((c) => c.id === id)
+		if (!club) throw new Error(`no club with fpl id ${id}`)
+		return club
+	}
+
+	// football-data mirror of each season, for the merge step. fd match ids
+	// are globally unique across seasons (unlike FPL's).
+	const S1_FD_MATCHES = S1_FPL.fixtures.map((f, i) => ({
+		id: 9001 + i,
+		matchday: 1,
+		homeTeam: fdTeam(clubByFplId(S1_CLUBS, f.team_h)),
+		awayTeam: fdTeam(clubByFplId(S1_CLUBS, f.team_a)),
+		utcDate: f.kickoff_time,
+		status: 'FINISHED',
+		score: { fullTime: { home: f.team_h_score, away: f.team_a_score } },
+	}))
+	const S2_FD_MATCHES = S2_FPL.fixtures.map((f, i) => ({
+		id: 9101 + i,
+		matchday: 1,
+		homeTeam: fdTeam(clubByFplId(S2_CLUBS, f.team_h)),
+		awayTeam: fdTeam(clubByFplId(S2_CLUBS, f.team_a)),
+		utcDate: f.kickoff_time,
+		status: 'TIMED',
+		score: { fullTime: { home: null, away: null } },
+	}))
+
+	function mockFdFetch(matches: unknown[]) {
+		vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+			const s = typeof url === 'string' ? url : url.toString()
+			if (s.includes('/standings'))
+				return Promise.resolve(new Response(JSON.stringify({ standings: [] })))
+			return Promise.resolve(new Response(JSON.stringify({ matches })))
+		})
+	}
+
+	async function makeSeasonComp(name: string): Promise<typeof competition.$inferSelect> {
+		const [c] = await db
+			.insert(competition)
+			.values({ name, type: 'league', dataSource: 'fpl', status: 'active' })
+			.returning()
+		return c
+	}
+
+	/** Sync + merge season 1, snapshot its rows, then sync + merge season 2. */
+	async function runRollover() {
+		const c1 = await makeSeasonComp('Smoke PL 2025/26')
+		await syncCompetition(c1, { fplData: S1_FPL })
+		mockFdFetch(S1_FD_MATCHES)
+		await mergeFootballDataIds(c1, 'test-key')
+
+		const s1Rounds = await db
+			.select()
+			.from(roundTable)
+			.where(eq(roundTable.competitionId, c1.id))
+			.orderBy(roundTable.number)
+		const s1Fixtures = await db
+			.select()
+			.from(fixtureTable)
+			.where(
+				inArray(
+					fixtureTable.roundId,
+					s1Rounds.map((r) => r.id),
+				),
+			)
+			.orderBy(fixtureTable.externalId)
+		const s1Teams = await db.select().from(teamTable).orderBy(teamTable.name)
+
+		const c2 = await makeSeasonComp('Smoke PL 2026/27')
+		const syncSecondSeason = async () => {
+			await syncCompetition(c2, { fplData: S2_FPL })
+		}
+		const mergeSecondSeason = async () => {
+			mockFdFetch(S2_FD_MATCHES)
+			await mergeFootballDataIds(c2, 'test-key')
+		}
+		return { c1, c2, s1Rounds, s1Fixtures, s1Teams, syncSecondSeason, mergeSecondSeason }
+	}
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('leaves the first season’s fixture and round rows byte-for-byte untouched', async () => {
+		const { c1, s1Rounds, s1Fixtures, syncSecondSeason, mergeSecondSeason } = await runRollover()
+		await syncSecondSeason()
+		await mergeSecondSeason()
+
+		const roundsAfter = await db
+			.select()
+			.from(roundTable)
+			.where(eq(roundTable.competitionId, c1.id))
+			.orderBy(roundTable.number)
+		const fixturesAfter = await db
+			.select()
+			.from(fixtureTable)
+			.where(
+				inArray(
+					fixtureTable.roundId,
+					roundsAfter.map((r) => r.id),
+				),
+			)
+			.orderBy(fixtureTable.externalId)
+		expect(roundsAfter).toEqual(s1Rounds)
+		expect(fixturesAfter).toEqual(s1Fixtures)
+	})
+
+	it('cannot collide restarted external ids — the upsert only finds in-competition rows', async () => {
+		const { c1, c2, syncSecondSeason } = await runRollover()
+		await syncSecondSeason()
+
+		// Both seasons hold fixtures with external ids 1-3, on distinct rows.
+		for (const comp of [c1, c2]) {
+			const rounds = await db.select().from(roundTable).where(eq(roundTable.competitionId, comp.id))
+			const fixtures = await db
+				.select()
+				.from(fixtureTable)
+				.where(
+					inArray(
+						fixtureTable.roundId,
+						rounds.map((r) => r.id),
+					),
+				)
+			expect(fixtures.map((f) => f.externalId).sort()).toEqual(['1', '2', '3'])
+		}
+	})
+
+	it('attaches new-season fixtures to the correct club rows via the payload, not stale team ids', async () => {
+		const { c2, s1Teams, syncSecondSeason } = await runRollover()
+		await syncSecondSeason()
+
+		const teams = await db.select().from(teamTable)
+		const byName = (name: string) => {
+			const t = teams.find((row) => row.name === name)
+			if (!t) throw new Error(`missing team row: ${name}`)
+			return t
+		}
+		const [r2] = await db.select().from(roundTable).where(eq(roundTable.competitionId, c2.id))
+		const fixtures = await db.select().from(fixtureTable).where(eq(fixtureTable.roundId, r2.id))
+		const byExternalId = (id: string) => {
+			const f = fixtures.find((row) => row.externalId === id)
+			if (!f) throw new Error(`missing season-2 fixture ${id}`)
+			return f
+		}
+
+		// Payload id 4 is Grove FC this season. A stale-id lookup would resolve
+		// it to Dorne FC (relegated, still holding fpl id 4 from season 1).
+		expect(byExternalId('1').homeTeamId).toBe(byName('Alder FC').id)
+		expect(byExternalId('1').awayTeamId).toBe(byName('Grove FC').id)
+		expect(byExternalId('1').awayTeamId).not.toBe(byName('Dorne FC').id)
+		expect(byExternalId('2').awayTeamId).toBe(byName('Holt FC').id)
+		expect(byExternalId('3').awayTeamId).toBe(byName('Isley FC').id)
+
+		// Promoted clubs are NEW rows — no season-1 row was renamed or reused.
+		const s1Ids = new Set(s1Teams.map((t) => t.id))
+		for (const name of ['Grove FC', 'Holt FC', 'Isley FC']) {
+			expect(s1Ids.has(byName(name).id)).toBe(false)
+		}
+	})
+
+	it('creates promoted clubs with football-data crest badges and leaves relegated rows dormant', async () => {
+		const { s1Teams, syncSecondSeason, mergeSecondSeason } = await runRollover()
+		await syncSecondSeason()
+
+		// After the sync (before the fd merge) a promoted club must NOT carry
+		// the FPL badge CDN URL — it 404s for newly promoted clubs. It stays
+		// empty until the merge lands the crest, so the UI colour fallback
+		// applies rather than a broken image.
+		const teamsAfterSync = await db.select().from(teamTable)
+		for (const name of ['Grove FC', 'Holt FC', 'Isley FC']) {
+			const t = teamsAfterSync.find((row) => row.name === name)
+			expect(t?.badgeUrl ?? null).toBeNull()
+		}
+
+		await mergeSecondSeason()
+
+		const teams = await db.select().from(teamTable)
+		expect(teams.find((t) => t.name === 'Grove FC')?.badgeUrl).toBe(fdCrest('GRO'))
+		expect(teams.find((t) => t.name === 'Holt FC')?.badgeUrl).toBe(fdCrest('HOL'))
+		expect(teams.find((t) => t.name === 'Isley FC')?.badgeUrl).toBe(fdCrest('ISL'))
+
+		// Relegated clubs' rows are untouched by the whole second-season run —
+		// stale external ids and all.
+		for (const name of ['Dorne FC', 'Elm FC', 'Fern FC']) {
+			const before = s1Teams.find((t) => t.name === name)
+			const after = teams.find((t) => t.name === name)
+			expect(after).toEqual(before)
+		}
 	})
 })

--- a/src/app/api/cron/poll-scores/route.test.ts
+++ b/src/app/api/cron/poll-scores/route.test.ts
@@ -1,3 +1,4 @@
+import { PgDialect } from 'drizzle-orm/pg-core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/lib/db', () => ({
@@ -130,7 +131,8 @@ describe('poll-scores short-circuit', () => {
 			},
 		] as never)
 		// Two distinct select() calls: (a) the up-front fixturesInRounds
-		// snapshot, then (b) per-score row lookups inside the inner loop.
+		// snapshot, then (b) per-score row lookups inside the inner loop
+		// (competition-scoped, hence the round join).
 		// Mock the snapshot's response first, then the per-score lookup
 		// finds the existing fixture id by ext_id.
 		const selectMock = vi
@@ -142,7 +144,9 @@ describe('poll-scores short-circuit', () => {
 			})
 			.mockReturnValue({
 				from: () => ({
-					where: () => Promise.resolve([{ id: 'f1', status: 'live' }]),
+					innerJoin: () => ({
+						where: () => Promise.resolve([{ id: 'f1', status: 'live' }]),
+					}),
 				}),
 			})
 		vi.mocked(db.select).mockImplementation(selectMock as never)
@@ -212,8 +216,9 @@ describe('poll-scores short-circuit', () => {
 			},
 		] as never)
 		// First select(): fixturesInRounds snapshot. Subsequent select()s:
-		// per-score existing-fixture lookups; both return a live row so the
-		// transition non-finished → finished triggers settleFixture.
+		// per-score existing-fixture lookups (competition-scoped via the round
+		// join); both return a live row so the transition non-finished →
+		// finished triggers settleFixture.
 		const selectMock = vi
 			.fn()
 			.mockReturnValueOnce({
@@ -224,7 +229,9 @@ describe('poll-scores short-circuit', () => {
 			})
 			.mockReturnValue({
 				from: () => ({
-					where: () => Promise.resolve([{ id: 'fx-1-internal', status: 'live' }]),
+					innerJoin: () => ({
+						where: () => Promise.resolve([{ id: 'fx-1-internal', status: 'live' }]),
+					}),
 				}),
 			})
 		vi.mocked(db.select).mockImplementation(selectMock as never)
@@ -241,6 +248,51 @@ describe('poll-scores short-circuit', () => {
 
 		expect(settleFixtureMock).toHaveBeenCalledTimes(1)
 		expect(settleFixtureMock).toHaveBeenCalledWith('fx-1-internal')
+	})
+
+	it("scopes score-write matching to the polled round's competition", async () => {
+		// Same identity family as the sync upsert scoping: external ids are
+		// unique only within (competition, data source), so a score fetched for
+		// one competition must never match another competition's fixture row.
+		vi.mocked(db.query.game.findMany).mockResolvedValue([
+			{
+				currentRoundId: 'r1',
+				competition: { id: 'comp-pl', externalId: 'PL', dataSource: 'football_data' },
+			},
+		] as never)
+		const perScoreWhere = vi.fn().mockResolvedValue([{ id: 'f1', status: 'live' }])
+		const selectMock = vi
+			.fn()
+			.mockReturnValueOnce({
+				from: () => ({
+					where: () => Promise.resolve([{ id: 'f1', kickoff: new Date(), roundId: 'r1' }]),
+				}),
+			})
+			.mockReturnValue({
+				from: () => ({ innerJoin: () => ({ where: perScoreWhere }) }),
+			})
+		vi.mocked(db.select).mockImplementation(selectMock as never)
+		vi.mocked(hasActiveFixture).mockReturnValue(true)
+		vi.mocked(db.query.round.findFirst).mockResolvedValue({
+			id: 'r1',
+			number: 5,
+			competitionId: 'comp-pl',
+		} as never)
+		fetchLiveScoresMock.mockResolvedValue([
+			{ externalId: 'm1', homeScore: 1, awayScore: 0, status: 'live' },
+		])
+		const whereMock = vi.fn().mockResolvedValue(undefined)
+		const setMock = vi.fn(() => ({ where: whereMock }))
+		vi.mocked(db.update).mockReturnValue({ set: setMock } as never)
+
+		await POST(authedRequest())
+
+		expect(perScoreWhere).toHaveBeenCalledTimes(1)
+		const condition = perScoreWhere.mock.calls[0][0]
+		const { sql: rendered, params } = new PgDialect().sqlToQuery(condition as never)
+		expect(rendered).toContain('"round"."competition_id"')
+		expect(params).toContain('comp-pl')
+		expect(params).toContain('m1')
 	})
 
 	it('constructs one adapter per distinct competition code', async () => {

--- a/src/app/api/cron/poll-scores/route.ts
+++ b/src/app/api/cron/poll-scores/route.ts
@@ -1,4 +1,4 @@
-import { eq, inArray, sql } from 'drizzle-orm'
+import { and, eq, inArray, sql } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import { serializeError } from '@/lib/cron/serialize-error'
 import { FootballDataAdapter, resolveFootballDataCode } from '@/lib/data/football-data'
@@ -111,6 +111,12 @@ async function pollScores(apiKey: string): Promise<NextResponse> {
 				// populates external_ids.football_data on FPL fixtures. For
 				// football-data-bootstrapped competitions (e.g., WC), external_ids.football_data
 				// equals external_id by construction.
+				//
+				// Scoped to the polled round's competition — external ids are unique
+				// only within (competition, data source), the same identity rule as
+				// the sync fixture upsert. Competition-level (not round-level)
+				// because a rescheduled fixture can sit under a different round in
+				// our DB than the football-data matchday the score arrived from.
 				const [existing] = await db
 					.select({
 						id: fixture.id,
@@ -122,7 +128,13 @@ async function pollScores(apiKey: string): Promise<NextResponse> {
 						regularAwayScore: fixture.regularAwayScore,
 					})
 					.from(fixture)
-					.where(sql`${fixture.externalIds}->>'football_data' = ${score.externalId}`)
+					.innerJoin(round, eq(fixture.roundId, round.id))
+					.where(
+						and(
+							eq(round.competitionId, roundData.competitionId),
+							sql`${fixture.externalIds}->>'football_data' = ${score.externalId}`,
+						),
+					)
 				if (!existing) continue
 
 				await db

--- a/src/lib/game/bootstrap-competitions.test.ts
+++ b/src/lib/game/bootstrap-competitions.test.ts
@@ -263,6 +263,38 @@ describe('syncCompetition team upsert (payload-driven identity)', () => {
 		])
 	})
 
+	it('never overwrites an existing badge with the FPL CDN URL on re-sync', async () => {
+		// After mergeFootballDataIds lands the football-data crest, a later
+		// daily sync must not stomp it with the constructed FPL badge URL —
+		// that URL 404s for promoted clubs, and the merge that would re-fix it
+		// is exactly the step that fails loudly on a new-season tla gap.
+		fplFetchTeams.mockResolvedValue([
+			{
+				externalId: '4',
+				name: 'Grove FC',
+				shortName: 'GRO',
+				badgeUrl: 'https://resources.premierleague.com/premierleague/badges/rb/t24.svg',
+			},
+		])
+		fplFetchRounds.mockResolvedValue([])
+		dbQueryTeamFindFirst.mockResolvedValue({
+			id: 'team-grove-uuid',
+			name: 'Grove FC',
+			badgeUrl: 'https://crests.football-data.org/grove.png',
+			externalIds: { fpl: '4', football_data: '107' },
+		})
+
+		await syncCompetition(
+			{ id: 'comp-1', dataSource: 'fpl', externalId: null, season: '2026/27' } as never,
+			{ footballDataApiKey: 'fd-key' },
+		)
+
+		const teamUpdate = dbUpdateSet.mock.calls
+			.map((c) => c[0] as { badgeUrl?: string | null })
+			.find((p) => 'badgeUrl' in p)
+		expect(teamUpdate?.badgeUrl).toBe('https://crests.football-data.org/grove.png')
+	})
+
 	it('re-links an existing club to its new payload id by name, not by stored external id', async () => {
 		// Grove FC existed before under fpl:9; this season the payload hands it
 		// id 4. The row must be found by NAME and its fpl id overwritten.

--- a/src/lib/game/bootstrap-competitions.test.ts
+++ b/src/lib/game/bootstrap-competitions.test.ts
@@ -150,8 +150,11 @@ describe('syncCompetition league-position persistence', () => {
 		fdFetchStandings.mockResolvedValue([])
 	})
 
-	it('persists league_position for each standings row scoped by external id', async () => {
-		fplFetchTeams.mockResolvedValue([])
+	it('persists league_position for each standings row resolved through the current payload', async () => {
+		fplFetchTeams.mockResolvedValue([
+			{ externalId: '1', name: 'Alder FC', shortName: 'ALD', badgeUrl: 'ald.svg' },
+			{ externalId: '2', name: 'Birch FC', shortName: 'BIR', badgeUrl: 'bir.svg' },
+		])
 		fplFetchRounds.mockResolvedValue([])
 		fplFetchStandings.mockResolvedValue([
 			{
@@ -173,11 +176,10 @@ describe('syncCompetition league-position persistence', () => {
 				points: 20,
 			},
 		])
-		dbQueryTeamFindMany.mockResolvedValue([
-			{ id: 'team-1-uuid', externalIds: { fpl: '1' } },
-			{ id: 'team-2-uuid', externalIds: { fpl: '2' } },
-			{ id: 'team-other-uuid', externalIds: { football_data: '99' } },
-		])
+		// Payload teams resolve to existing club rows by name.
+		dbQueryTeamFindFirst
+			.mockResolvedValueOnce({ id: 'team-1-uuid', name: 'Alder FC', externalIds: { fpl: '1' } })
+			.mockResolvedValueOnce({ id: 'team-2-uuid', name: 'Birch FC', externalIds: { fpl: '2' } })
 
 		await syncCompetition(
 			{ id: 'comp-1', dataSource: 'fpl', externalId: null, season: '2025/26' } as never,
@@ -197,7 +199,10 @@ describe('syncCompetition league-position persistence', () => {
 		)
 	})
 
-	it('ignores standings rows whose teamExternalId is not in the competition data source', async () => {
+	it('ignores standings rows whose team is absent from the current payload, even when a stale team row holds that id', async () => {
+		// The payload has no team '999' — but a dormant (relegated) team row
+		// still carries fpl:999 from an earlier season. Resolution must go
+		// through the payload, so the stale row must NOT receive a position.
 		fplFetchTeams.mockResolvedValue([])
 		fplFetchRounds.mockResolvedValue([])
 		fplFetchStandings.mockResolvedValue([
@@ -211,10 +216,7 @@ describe('syncCompetition league-position persistence', () => {
 				points: 0,
 			},
 		])
-		dbQueryTeamFindMany.mockResolvedValue([
-			// Team with different data source key — must not match.
-			{ id: 'team-fd-uuid', externalIds: { football_data: '999' } },
-		])
+		dbQueryTeamFindMany.mockResolvedValue([{ id: 'team-stale-uuid', externalIds: { fpl: '999' } }])
 
 		await syncCompetition(
 			{ id: 'comp-1', dataSource: 'fpl', externalId: null, season: '2025/26' } as never,
@@ -225,6 +227,65 @@ describe('syncCompetition league-position persistence', () => {
 			.map((call) => call[0])
 			.filter((payload) => 'leaguePosition' in payload)
 		expect(positionSets).toHaveLength(0)
+	})
+})
+
+describe('syncCompetition team upsert (payload-driven identity)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		dbQueryTeamFindMany.mockResolvedValue([])
+		dbQueryRoundFindMany.mockResolvedValue([])
+		dbQueryPlannedPickFindMany.mockResolvedValue([])
+	})
+
+	it('inserts an unseen (promoted) club without the FPL badge URL — the FPL CDN 404s for it', async () => {
+		fplFetchTeams.mockResolvedValue([
+			{
+				externalId: '4',
+				name: 'Grove FC',
+				shortName: 'GRO',
+				badgeUrl: 'https://resources.premierleague.com/premierleague/badges/rb/t24.svg',
+			},
+		])
+		fplFetchRounds.mockResolvedValue([])
+		dbQueryTeamFindFirst.mockResolvedValue(undefined) // never seen this club
+
+		await syncCompetition(
+			{ id: 'comp-1', dataSource: 'fpl', externalId: null, season: '2026/27' } as never,
+			{ footballDataApiKey: 'fd-key' },
+		)
+
+		const insertedValues = dbInsertFn.mock.results
+			.map((r) => (r.value as { values: ReturnType<typeof vi.fn> }).values.mock.calls[0]?.[0])
+			.filter((v): v is Record<string, unknown> => v != null && 'name' in (v as object))
+		expect(insertedValues).toEqual([
+			expect.objectContaining({ name: 'Grove FC', shortName: 'GRO', badgeUrl: null }),
+		])
+	})
+
+	it('re-links an existing club to its new payload id by name, not by stored external id', async () => {
+		// Grove FC existed before under fpl:9; this season the payload hands it
+		// id 4. The row must be found by NAME and its fpl id overwritten.
+		fplFetchTeams.mockResolvedValue([
+			{ externalId: '4', name: 'Grove FC', shortName: 'GRO', badgeUrl: 'gro.svg' },
+		])
+		fplFetchRounds.mockResolvedValue([])
+		dbQueryTeamFindFirst.mockResolvedValue({
+			id: 'team-grove-uuid',
+			name: 'Grove FC',
+			badgeUrl: 'gro.svg',
+			externalIds: { fpl: '9', football_data: '107' },
+		})
+
+		await syncCompetition(
+			{ id: 'comp-1', dataSource: 'fpl', externalId: null, season: '2026/27' } as never,
+			{ footballDataApiKey: 'fd-key' },
+		)
+
+		const teamUpdate = dbUpdateSet.mock.calls
+			.map((c) => c[0] as { externalIds?: Record<string, string> })
+			.find((p) => p.externalIds?.fpl != null)
+		expect(teamUpdate?.externalIds).toEqual({ fpl: '4', football_data: '107' })
 	})
 })
 

--- a/src/lib/game/bootstrap-competitions.test.ts
+++ b/src/lib/game/bootstrap-competitions.test.ts
@@ -531,6 +531,114 @@ describe('mergeFootballDataIds', () => {
 		})
 	})
 
+	it('never touches a team row outside this competition, even on a tla collision', async () => {
+		// A WC country row shares the 3-letter code of a club in the fd payload.
+		// It is not referenced by any of this competition's fixtures, so the
+		// merge must not rewrite its badge or football-data id.
+		const teamArs = {
+			id: 'our-ARS',
+			shortName: 'ARS',
+			name: 'Arsenal',
+			externalIds: { fpl: '1' },
+		}
+		const teamPortugalWc = {
+			id: 'our-POR-wc',
+			shortName: 'POR',
+			name: 'Portugal',
+			externalIds: { football_data: '765' },
+			badgeUrl: 'wc-portugal.png',
+		}
+		dbQueryTeamFindMany
+			.mockResolvedValueOnce([teamArs, teamPortugalWc])
+			.mockResolvedValueOnce([
+				{ ...teamArs, externalIds: { fpl: '1', football_data: '57' } },
+				teamPortugalWc,
+			])
+		dbQueryRoundFindMany.mockResolvedValue([
+			{
+				id: 'our-r-1',
+				number: 1,
+				fixtures: [
+					{
+						id: 'our-fx-1',
+						homeTeamId: 'our-ARS',
+						awayTeamId: 'our-ARS',
+						externalIds: { fpl: '1' },
+					},
+				],
+			},
+		])
+
+		fdFetchTeams.mockResolvedValue([
+			{ externalId: '57', name: 'Arsenal FC', shortName: 'ARS', badgeUrl: 'fd-ars.png' },
+			// Hypothetical promoted club whose tla collides with the WC row.
+			{ externalId: '9999', name: 'Portsmouth FC', shortName: 'POR', badgeUrl: 'fd-pompey.png' },
+		])
+		fdFetchRounds.mockResolvedValue([])
+
+		await mergeFootballDataIds(
+			{ id: 'comp-pl', dataSource: 'fpl', externalId: null } as never,
+			'fd-key',
+		)
+
+		const portsmouthWrite = dbUpdateSet.mock.calls.find(
+			(c) =>
+				(c[0] as { externalIds?: { football_data?: string } }).externalIds?.football_data ===
+				'9999',
+		)
+		expect(portsmouthWrite).toBeUndefined()
+	})
+
+	it('coverage assertion ignores dormant teams not referenced by this competition', async () => {
+		// A relegated club's dormant row still carries an fpl id from an earlier
+		// season but no football-data id. It plays no part in this competition,
+		// so it must not trip the loud team-coverage failure.
+		const teamArs = {
+			id: 'our-ARS',
+			shortName: 'ARS',
+			name: 'Arsenal',
+			externalIds: { fpl: '1' },
+		}
+		const dormantRelegated = {
+			id: 'our-DOR',
+			shortName: 'DOR',
+			name: 'Dormant FC',
+			externalIds: { fpl: '888' },
+		}
+		dbQueryTeamFindMany
+			.mockResolvedValueOnce([teamArs, dormantRelegated])
+			.mockResolvedValueOnce([
+				{ ...teamArs, externalIds: { fpl: '1', football_data: '57' } },
+				dormantRelegated,
+			])
+		dbQueryRoundFindMany.mockResolvedValue([
+			{
+				id: 'our-r-1',
+				number: 1,
+				fixtures: [
+					{
+						id: 'our-fx-1',
+						homeTeamId: 'our-ARS',
+						awayTeamId: 'our-ARS',
+						externalIds: { fpl: '1' },
+					},
+				],
+			},
+		])
+
+		fdFetchTeams.mockResolvedValue([
+			{ externalId: '57', name: 'Arsenal FC', shortName: 'ARS', badgeUrl: null },
+		])
+		fdFetchRounds.mockResolvedValue([])
+
+		await expect(
+			mergeFootballDataIds(
+				{ id: 'comp-pl', dataSource: 'fpl', externalId: null } as never,
+				'fd-key',
+			),
+		).resolves.toBeUndefined()
+	})
+
 	it('matches teams via FPL_TO_FD_TLA alias when codes differ across sources (NFO → NOT)', async () => {
 		const teamForest = {
 			id: 'our-NFO',
@@ -541,7 +649,20 @@ describe('mergeFootballDataIds', () => {
 		dbQueryTeamFindMany
 			.mockResolvedValueOnce([teamForest])
 			.mockResolvedValueOnce([{ ...teamForest, externalIds: { fpl: '16', football_data: '351' } }])
-		dbQueryRoundFindMany.mockResolvedValue([])
+		dbQueryRoundFindMany.mockResolvedValue([
+			{
+				id: 'our-r-1',
+				number: 1,
+				fixtures: [
+					{
+						id: 'our-fx-1',
+						homeTeamId: 'our-NFO',
+						awayTeamId: 'our-NFO',
+						externalIds: { fpl: '16' },
+					},
+				],
+			},
+		])
 
 		// Football-data returns the team with its `tla=NOT`, our DB has `short_name=NFO`.
 		fdFetchTeams.mockResolvedValue([
@@ -597,7 +718,22 @@ describe('mergeFootballDataIds', () => {
 		dbQueryTeamFindMany
 			.mockResolvedValueOnce([newPromotedTeam])
 			.mockResolvedValueOnce([newPromotedTeam])
-		dbQueryRoundFindMany.mockResolvedValue([])
+		// The team is in this competition (a fixture references it) — that is
+		// what makes the coverage gap a loud failure rather than dormant noise.
+		dbQueryRoundFindMany.mockResolvedValue([
+			{
+				id: 'our-r-1',
+				number: 1,
+				fixtures: [
+					{
+						id: 'our-fx-1',
+						homeTeamId: 'our-XYZ',
+						awayTeamId: 'our-XYZ',
+						externalIds: { fpl: '900' },
+					},
+				],
+			},
+		])
 
 		// Football-data has the team but under a different tla; merge can't link them.
 		fdFetchTeams.mockResolvedValue([

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -301,6 +301,12 @@ export async function syncCompetition(
 
 	const key = comp.dataSource === 'fpl' ? 'fpl' : 'football_data'
 	const adapterTeams = await adapter.fetchTeams()
+	// Resolve payload team ids to club rows through the payload itself (club
+	// identity = name). Source-assigned ids restart and get reshuffled across
+	// clubs every season (FPL), so they must never be resolved through ids
+	// stored on team rows by an earlier season — a relegated club's stale id
+	// would swallow the promoted club that inherited it.
+	const teamIdByPayloadId = new Map<string, string>()
 	for (const at of adapterTeams) {
 		const existing = await db.query.team.findFirst({ where: eq(team.name, at.name) })
 		if (existing) {
@@ -311,31 +317,52 @@ export async function syncCompetition(
 					externalIds: { ...(existing.externalIds ?? {}), [key]: at.externalId },
 				})
 				.where(eq(team.id, existing.id))
+			teamIdByPayloadId.set(at.externalId, existing.id)
 		} else {
-			await db.insert(team).values({
-				name: at.name,
-				shortName: at.shortName,
-				badgeUrl: at.badgeUrl,
-				externalIds: { [key]: at.externalId },
-			})
+			const [created] = await db
+				.insert(team)
+				.values({
+					name: at.name,
+					shortName: at.shortName,
+					// FPL's badge CDN 404s for clubs it has never hosted before
+					// (newly promoted), so an unseen club gets no badge here — the
+					// UI colour fallback applies until mergeFootballDataIds lands
+					// the football-data crest in the same bootstrap pass.
+					badgeUrl: comp.dataSource === 'fpl' ? null : at.badgeUrl,
+					externalIds: { [key]: at.externalId },
+				})
+				.returning()
+			teamIdByPayloadId.set(at.externalId, created.id)
 		}
 	}
 
-	const allTeams = await db.query.team.findMany({})
-
 	// Persist latest league standings into team.leaguePosition when the adapter
-	// supports standings. Scope by externalIds[key] so updates stay within this
-	// competition's data source.
+	// supports standings. Resolved through the current payload's team list so
+	// updates stay within this competition's own teams.
 	if (typeof adapter.fetchStandings === 'function') {
 		const standings = await adapter.fetchStandings()
 		for (const row of standings) {
-			const match = allTeams.find(
-				(t) =>
-					String((t.externalIds as Record<string, string | number> | null)?.[key]) ===
-					row.teamExternalId,
-			)
-			if (!match) continue
-			await db.update(team).set({ leaguePosition: row.position }).where(eq(team.id, match.id))
+			const teamId = teamIdByPayloadId.get(row.teamExternalId)
+			if (!teamId) continue
+			await db.update(team).set({ leaguePosition: row.position }).where(eq(team.id, teamId))
+		}
+	}
+
+	// Fixture upsert matching is scoped to this competition's own rounds:
+	// external ids are unique only within (competition, data source), so a
+	// global match would let restarted FPL ids rewrite another season's rows
+	// in place (the 2026/27 silent-corruption incident).
+	const compRoundsForUpsert = await db.query.round.findMany({
+		where: eq(round.competitionId, comp.id),
+		with: { fixtures: true },
+	})
+	const compFixtureByExternalId = new Map<
+		string,
+		(typeof compRoundsForUpsert)[number]['fixtures'][number]
+	>()
+	for (const r of compRoundsForUpsert) {
+		for (const f of r.fixtures) {
+			if (f.externalId != null) compFixtureByExternalId.set(f.externalId, f)
 		}
 	}
 
@@ -410,25 +437,15 @@ export async function syncCompetition(
 		})
 
 		for (const af of ar.fixtures) {
-			const home = allTeams.find(
-				(t) =>
-					String((t.externalIds as Record<string, string | number> | null)?.[key]) ===
-					af.homeTeamExternalId,
-			)
-			const away = allTeams.find(
-				(t) =>
-					String((t.externalIds as Record<string, string | number> | null)?.[key]) ===
-					af.awayTeamExternalId,
-			)
-			if (!home || !away) continue
+			const homeTeamId = teamIdByPayloadId.get(af.homeTeamExternalId)
+			const awayTeamId = teamIdByPayloadId.get(af.awayTeamExternalId)
+			if (!homeTeamId || !awayTeamId) continue
 
-			const existingFixture = await db.query.fixture.findFirst({
-				where: eq(fixture.externalId, af.externalId),
-			})
+			const existingFixture = compFixtureByExternalId.get(af.externalId)
 			// A provisional tie we seeded for this same matchup, not yet bound.
 			const provisional = existingFixture
 				? undefined
-				: findByTeamPair(home.id, away.id, unboundRoundFixtures)
+				: findByTeamPair(homeTeamId, awayTeamId, unboundRoundFixtures)
 			if (existingFixture) {
 				await db
 					.update(fixture)
@@ -465,8 +482,8 @@ export async function syncCompetition(
 				await db
 					.update(fixture)
 					.set({
-						homeTeamId: home.id,
-						awayTeamId: away.id,
+						homeTeamId,
+						awayTeamId,
 						kickoff: af.kickoff,
 						status: af.status,
 						homeScore: af.homeScore,
@@ -484,8 +501,8 @@ export async function syncCompetition(
 			} else {
 				await db.insert(fixture).values({
 					roundId,
-					homeTeamId: home.id,
-					awayTeamId: away.id,
+					homeTeamId,
+					awayTeamId,
 					kickoff: af.kickoff,
 					status: af.status,
 					homeScore: af.homeScore,

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -153,6 +153,19 @@ function fdTlaForFplShortName(fplShortName: string): string {
 }
 
 /**
+ * A competition's rounds with their fixtures — the scope boundary for every
+ * sync-owned mutation. External ids are unique only within (competition,
+ * data source), so matching always starts from this set, never the whole
+ * fixture or team table.
+ */
+function competitionRoundsWithFixtures(competitionId: string) {
+	return db.query.round.findMany({
+		where: eq(round.competitionId, competitionId),
+		with: { fixtures: true },
+	})
+}
+
+/**
  * For competitions whose primary adapter is FPL, this fetches the same matchdays
  * from football-data.org and merges football-data IDs into existing teams +
  * fixtures. The FPL adapter remains the source of truth for round structure
@@ -186,10 +199,7 @@ export async function mergeFootballDataIds(comp: CompetitionRow, apiKey: string)
 	// competition's fixtures define its team set — matching by tla over the
 	// whole team table could hit another competition's row (e.g. a WC country
 	// sharing a promoted club's code) and rewrite its badge + football-data id.
-	const ourRounds = await db.query.round.findMany({
-		where: eq(round.competitionId, comp.id),
-		with: { fixtures: true },
-	})
+	const ourRounds = await competitionRoundsWithFixtures(comp.id)
 	const compTeamIds = new Set<string>()
 	for (const r of ourRounds) {
 		for (const f of r.fixtures) {
@@ -197,10 +207,12 @@ export async function mergeFootballDataIds(comp: CompetitionRow, apiKey: string)
 			compTeamIds.add(f.awayTeamId)
 		}
 	}
+	const teamsInCompetition = async () =>
+		(await db.query.team.findMany({})).filter((t) => compTeamIds.has(t.id))
 
 	// 1) Merge football-data team IDs onto this competition's teams via
 	// short_name === tla (with the FPL_TO_FD_TLA alias map covering NFO → NOT).
-	const ourTeams = (await db.query.team.findMany({})).filter((t) => compTeamIds.has(t.id))
+	const ourTeams = await teamsInCompetition()
 	const ourTeamIdByFdId = new Map<string, string>() // football-data id -> our team UUID
 	for (const fdTeam of fdTeams) {
 		const ourTeam = ourTeams.find((t) => fdTlaForFplShortName(t.shortName) === fdTeam.shortName)
@@ -260,7 +272,7 @@ export async function mergeFootballDataIds(comp: CompetitionRow, apiKey: string)
 	// football-data temporarily. Scoped to this competition's teams — a dormant
 	// relegated club's row (stale fpl id, no current-season fd merge) plays no
 	// part here and must not trip the loud failure.
-	const refreshedTeams = (await db.query.team.findMany({})).filter((t) => compTeamIds.has(t.id))
+	const refreshedTeams = await teamsInCompetition()
 	const fplTeams = refreshedTeams.filter(
 		(t) => (t.externalIds as Record<string, string | number> | null)?.fpl != null,
 	)
@@ -274,12 +286,7 @@ export async function mergeFootballDataIds(comp: CompetitionRow, apiKey: string)
 		)
 	}
 
-	const fixturesAll = (
-		await db.query.round.findMany({
-			where: eq(round.competitionId, comp.id),
-			with: { fixtures: true },
-		})
-	).flatMap((r) => r.fixtures)
+	const fixturesAll = (await competitionRoundsWithFixtures(comp.id)).flatMap((r) => r.fixtures)
 	const fixturesMissing = fixturesAll.filter(
 		(f) => (f.externalIds as Record<string, string | number> | null)?.football_data == null,
 	)
@@ -374,10 +381,7 @@ export async function syncCompetition(
 	// external ids are unique only within (competition, data source), so a
 	// global match would let restarted FPL ids rewrite another season's rows
 	// in place (the 2026/27 silent-corruption incident).
-	const compRoundsForUpsert = await db.query.round.findMany({
-		where: eq(round.competitionId, comp.id),
-		with: { fixtures: true },
-	})
+	const compRoundsForUpsert = await competitionRoundsWithFixtures(comp.id)
 	const compFixtureByExternalId = new Map<
 		string,
 		(typeof compRoundsForUpsert)[number]['fixtures'][number]
@@ -573,10 +577,7 @@ async function seedProvisionalKnockoutTies(
 	adapterRounds: { number: number; isKnockout: boolean; allMatchesDeadline: Date | null }[],
 	key: string,
 ): Promise<number> {
-	const dbRounds = await db.query.round.findMany({
-		where: eq(round.competitionId, competitionId),
-		with: { fixtures: true },
-	})
+	const dbRounds = await competitionRoundsWithFixtures(competitionId)
 	const metaByNumber = new Map(adapterRounds.map((r) => [r.number, r]))
 
 	const plannerRounds: PlannerRound[] = dbRounds.map((r) => ({
@@ -642,10 +643,7 @@ export async function applyPotAssignments(
 		where: eq(competition.id, competitionId),
 	})
 	if (!comp || comp.status === 'archived') return { matched: 0, unmatched: [] }
-	const rounds = await db.query.round.findMany({
-		where: eq(round.competitionId, competitionId),
-		with: { fixtures: true },
-	})
+	const rounds = await competitionRoundsWithFixtures(competitionId)
 	const teamIds = new Set<string>()
 	for (const r of rounds) {
 		for (const f of r.fixtures) {

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -328,7 +328,14 @@ export async function syncCompetition(
 			await db
 				.update(team)
 				.set({
-					badgeUrl: at.badgeUrl ?? existing.badgeUrl,
+					// For FPL-sourced competitions, never write the constructed FPL
+					// badge URL over what we have: the football-data crest (set by
+					// mergeFootballDataIds) is the durable badge, the FPL CDN 404s
+					// for promoted clubs, and the merge that would re-fix a stomped
+					// crest is exactly the step that fails loudly on a new-season
+					// tla gap.
+					badgeUrl:
+						comp.dataSource === 'fpl' ? existing.badgeUrl : (at.badgeUrl ?? existing.badgeUrl),
 					externalIds: { ...(existing.externalIds ?? {}), [key]: at.externalId },
 				})
 				.where(eq(team.id, existing.id))

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -181,9 +181,26 @@ export async function mergeFootballDataIds(comp: CompetitionRow, apiKey: string)
 	const fdTeams = await fdAdapter.fetchTeams()
 	const fdRounds = await fdAdapter.fetchRounds()
 
-	// 1) Merge football-data team IDs onto our teams via short_name === tla
-	// (with the FPL_TO_FD_TLA alias map covering the NFO → NOT case).
-	const ourTeams = await db.query.team.findMany({})
+	// Everything this merge touches must belong to the competition being
+	// merged (same identity rule as syncCompetition's upsert scoping). The
+	// competition's fixtures define its team set — matching by tla over the
+	// whole team table could hit another competition's row (e.g. a WC country
+	// sharing a promoted club's code) and rewrite its badge + football-data id.
+	const ourRounds = await db.query.round.findMany({
+		where: eq(round.competitionId, comp.id),
+		with: { fixtures: true },
+	})
+	const compTeamIds = new Set<string>()
+	for (const r of ourRounds) {
+		for (const f of r.fixtures) {
+			compTeamIds.add(f.homeTeamId)
+			compTeamIds.add(f.awayTeamId)
+		}
+	}
+
+	// 1) Merge football-data team IDs onto this competition's teams via
+	// short_name === tla (with the FPL_TO_FD_TLA alias map covering NFO → NOT).
+	const ourTeams = (await db.query.team.findMany({})).filter((t) => compTeamIds.has(t.id))
 	const ourTeamIdByFdId = new Map<string, string>() // football-data id -> our team UUID
 	for (const fdTeam of fdTeams) {
 		const ourTeam = ourTeams.find((t) => fdTlaForFplShortName(t.shortName) === fdTeam.shortName)
@@ -209,10 +226,6 @@ export async function mergeFootballDataIds(comp: CompetitionRow, apiKey: string)
 	// they're tracked under in our DB. Since each PL pairing happens exactly
 	// once per home venue per season, (home, away) is a unique key across the
 	// whole competition and gives us a one-shot match regardless of round.
-	const ourRounds = await db.query.round.findMany({
-		where: eq(round.competitionId, comp.id),
-		with: { fixtures: true },
-	})
 	const ourFixtureByPair = new Map<string, (typeof ourRounds)[number]['fixtures'][number]>()
 	for (const r of ourRounds) {
 		for (const f of r.fixtures) {
@@ -244,8 +257,10 @@ export async function mergeFootballDataIds(comp: CompetitionRow, apiKey: string)
 	// Fails loudly on team-level gaps because every PL team must be matchable
 	// for live scoring to work; warns on fixture-level gaps because rescheduled
 	// or yet-to-be-published fixtures may legitimately be absent from
-	// football-data temporarily.
-	const refreshedTeams = await db.query.team.findMany({})
+	// football-data temporarily. Scoped to this competition's teams — a dormant
+	// relegated club's row (stale fpl id, no current-season fd merge) plays no
+	// part here and must not trip the loud failure.
+	const refreshedTeams = (await db.query.team.findMany({})).filter((t) => compTeamIds.has(t.id))
 	const fplTeams = refreshedTeams.filter(
 		(t) => (t.externalIds as Record<string, string | number> | null)?.fpl != null,
 	)

--- a/src/lib/teams/colours.test.ts
+++ b/src/lib/teams/colours.test.ts
@@ -1,14 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { getTeamColour } from './colours'
-
-const FALLBACK_GREY = '#6b6b6b'
+import { FALLBACK_TEAM_COLOUR, getTeamColour } from './colours'
 
 describe('getTeamColour', () => {
 	// 2026/27 promoted clubs — must not render the grey fallback when a badge
 	// is unavailable (issue #115).
 	it.each(['COV', 'HUL', 'IPS'])('%s has a non-grey fallback colour', (code) => {
 		const colour = getTeamColour(code)
-		expect(colour).not.toBe(FALLBACK_GREY)
+		expect(colour).not.toBe(FALLBACK_TEAM_COLOUR)
 		expect(colour).toMatch(/^#[0-9a-fA-F]{6}$/)
 	})
 
@@ -17,6 +15,6 @@ describe('getTeamColour', () => {
 	})
 
 	it('falls back to grey for unknown codes', () => {
-		expect(getTeamColour('ZZZ')).toBe(FALLBACK_GREY)
+		expect(getTeamColour('ZZZ')).toBe(FALLBACK_TEAM_COLOUR)
 	})
 })

--- a/src/lib/teams/colours.test.ts
+++ b/src/lib/teams/colours.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { getTeamColour } from './colours'
+
+const FALLBACK_GREY = '#6b6b6b'
+
+describe('getTeamColour', () => {
+	// 2026/27 promoted clubs — must not render the grey fallback when a badge
+	// is unavailable (issue #115).
+	it.each(['COV', 'HUL', 'IPS'])('%s has a non-grey fallback colour', (code) => {
+		const colour = getTeamColour(code)
+		expect(colour).not.toBe(FALLBACK_GREY)
+		expect(colour).toMatch(/^#[0-9a-fA-F]{6}$/)
+	})
+
+	it('is case-insensitive', () => {
+		expect(getTeamColour('cov')).toBe(getTeamColour('COV'))
+	})
+
+	it('falls back to grey for unknown codes', () => {
+		expect(getTeamColour('ZZZ')).toBe(FALLBACK_GREY)
+	})
+})

--- a/src/lib/teams/colours.ts
+++ b/src/lib/teams/colours.ts
@@ -1,6 +1,6 @@
 // Team colour mapping by short code.
 // Used for badge backgrounds and contextual accents.
-// Covers 2024/25 and 2025/26 Premier League squads.
+// Covers 2024/25 through 2026/27 Premier League squads.
 export const TEAM_COLOURS: Record<string, string> = {
 	ARS: '#EF0107',
 	AVL: '#670E36',
@@ -9,9 +9,11 @@ export const TEAM_COLOURS: Record<string, string> = {
 	BHA: '#0057B8',
 	BUR: '#6C1D45',
 	CHE: '#034694',
+	COV: '#78D0F5',
 	CRY: '#1B458F',
 	EVE: '#003399',
 	FUL: '#000000',
+	HUL: '#F18A01',
 	IPS: '#3a64a3',
 	LEE: '#FFCD00',
 	LEI: '#003090',

--- a/src/lib/teams/colours.ts
+++ b/src/lib/teams/colours.ts
@@ -29,6 +29,9 @@ export const TEAM_COLOURS: Record<string, string> = {
 	WOL: '#FDB913',
 }
 
+// Neutral grey for teams without a colour entry.
+export const FALLBACK_TEAM_COLOUR = '#6b6b6b'
+
 export function getTeamColour(shortName: string): string {
-	return TEAM_COLOURS[shortName.toUpperCase()] ?? '#6b6b6b'
+	return TEAM_COLOURS[shortName.toUpperCase()] ?? FALLBACK_TEAM_COLOUR
 }


### PR DESCRIPTION
Closes #115

## What this does

A sync run is now structurally unable to touch any competition other than the one being synced, and resolves teams from the payload it is processing — the fix for the 2026/27 silent fixture-corruption incident.

- **Fixture upserts are competition-scoped.** Matching starts from the competition's own rounds, so restarted FPL ids (1–380 each season) can never find — let alone rewrite — another season's rows.
- **Team resolution is payload-driven.** Payload team ids resolve through the payload's own team list to club identity (name), never via per-season ids stored on team rows, so a relegated club's stale FPL id can't swallow the promoted club that inherited it. Standings resolution goes through the same map.
- **Promoted clubs** are inserted without the FPL badge URL (that CDN 404s for clubs FPL has never hosted); the football-data crest lands in the same bootstrap pass via `mergeFootballDataIds`. Sync itself has no football-data payload, so insert-then-merge within the pass is how "created with football-data crest badges" is met — the smoke test asserts the end state, and a follow-up fix stops later re-syncs stomping the crest back to the FPL URL (which matters precisely when the merge is failing loudly on a new-season tla gap). **Relegated clubs' rows are left dormant** — byte-for-byte untouched, stale external ids and all.
- **`mergeFootballDataIds` is scoped to the competition's own teams** (defined by its fixtures) — tla matching over the whole team table could have rewritten another competition's row (e.g. a WC country sharing a promoted club's code). The loud coverage assertion is scoped the same way, so a dormant relegated row can't trip it.
- **poll-scores score-writes are competition-scoped** (the issue-comment carry-over from the #114 review): the per-score fixture match now joins through the polled round's competition. Competition-level rather than round-level because a rescheduled fixture can sit under a different round in our DB than the football-data matchday the score arrived from.
- **Badge-fallback colours** gain Coventry (sky blue) and Hull (amber); Ipswich was already present — a test now pins all three as non-grey.

## Acceptance criteria → tests

All at the two seams the ticket names (smoke lifecycle on real Postgres, primary; bootstrap unit suite for payload-mapping edge cases). Every new test was verified red against the pre-change implementation.

- Second-season payload over a seeded completed first season leaves the first season's rows **byte-for-byte** untouched → `lifecycle.smoke.test.ts` "PL season rollover sync identity" (full `syncCompetition` + `mergeFootballDataIds`, restarted ids 1–3, three churned clubs, first-season competition deliberately kept **active** so scoping holds structurally, not via the archived guard)
- New-season fixtures attach to the correct club rows; promoted clubs created with fd crests; relegated rows unmodified → smoke, incl. a re-sync **after** the merge proving crests survive later daily syncs
- Identical external ids in two competitions cannot collide → smoke: both seasons hold fixtures with external ids 1–3 on distinct rows
- COV/HUL/IPS non-grey fallback colours → `colours.test.ts`
- Payload-mapping edge cases (stale-id standings row ignored, promoted insert without FPL badge, by-name re-link to new payload id, tla-collision row untouched, dormant row doesn't trip coverage) → `bootstrap-competitions.test.ts`
- Competition-scoped score-writes → `poll-scores/route.test.ts` (renders the captured where-clause, asserts `round.competition_id` scoping)

## Self-review (two-axis, vs origin/main with #115 as spec)

Acted on:
- **Spec finding (real):** existing-team updates re-stomped the fd crest with the 404ing FPL badge URL on every daily sync, relying on the merge to re-fix it — the merge being exactly the step that fails loudly on a new-season tla gap. Fixed + pinned (unit + smoke).
- **Standards findings:** the five hand-rolled copies of the rounds-with-fixtures scope query extracted to one helper; fallback-grey literal exported instead of duplicated in the test.

Disagreed / deferred:
- **AGENTS.md rollover-section drift:** the section's ritual steps (alias map, coverage failure, re-run bootstrap) all still hold — nothing in it is now false. The full ritual rewrite is explicitly scoped to the rollover-execution ticket (#122), so I left it there rather than half-updating it here.
- **"Coverage assertion can't fire for a fixtureless competition":** true but not reachable for FPL — bootstrap-static ships events and the fixtures endpoint publishes the full 380 as soon as the season exists, and the merge only ever runs after `syncCompetition` has written them. Noting rather than coding around it.

Pre-existing, untouched: two Biome `noUnusedVariables` warnings in `team-badge.tsx` (present on main).

## Validation

- `vitest run` — 82 files, 623 tests ✅
- smoke suite (real Postgres) — 54 tests ✅
- `tsc --noEmit` ✅, `biome check` ✅ (no new diagnostics), `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)