### PR TITLE
Populate PL league positions from football-data standings

### DIFF
--- a/src/lib/game/auto-pick.test.ts
+++ b/src/lib/game/auto-pick.test.ts
@@ -38,6 +38,19 @@ describe('pickLowestRankedUnusedTeam', () => {
 		).toBe('t-eve')
 	})
 
+	it('selects the genuinely worst-placed unused team when every team has a real position', () => {
+		// The post-standings-sync production state: every club carries a real
+		// league position. With the two worst-placed teams already used, the
+		// pick must fall to the next-worst by position, not an arbitrary team.
+		expect(
+			pickLowestRankedUnusedTeam({
+				fixtures,
+				usedTeamIds: new Set(['t-wba', 't-eve']),
+				teamPositions: positions,
+			}),
+		).toBe('t-che')
+	})
+
 	it('returns null when all teams in round are used', () => {
 		expect(
 			pickLowestRankedUnusedTeam({

--- a/src/lib/game/bootstrap-competitions.test.ts
+++ b/src/lib/game/bootstrap-competitions.test.ts
@@ -407,6 +407,112 @@ describe('mergeFootballDataIds', () => {
 		vi.clearAllMocks()
 		dbQueryTeamFindMany.mockResolvedValue([])
 		dbQueryRoundFindMany.mockResolvedValue([])
+		fdFetchStandings.mockResolvedValue([])
+	})
+
+	it('persists league_position for standings rows resolved through the merged football-data ids', async () => {
+		const teamArs = {
+			id: 'our-ARS',
+			shortName: 'ARS',
+			name: 'Arsenal',
+			externalIds: { fpl: '1' },
+		}
+		const teamLiv = {
+			id: 'our-LIV',
+			shortName: 'LIV',
+			name: 'Liverpool',
+			externalIds: { fpl: '12' },
+		}
+		dbQueryTeamFindMany.mockResolvedValueOnce([teamArs, teamLiv]).mockResolvedValueOnce([
+			{ ...teamArs, externalIds: { fpl: '1', football_data: '57' } },
+			{ ...teamLiv, externalIds: { fpl: '12', football_data: '64' } },
+		])
+		dbQueryRoundFindMany.mockResolvedValue([
+			{
+				id: 'our-r-1',
+				number: 1,
+				fixtures: [
+					{
+						id: 'our-fx-1',
+						homeTeamId: 'our-ARS',
+						awayTeamId: 'our-LIV',
+						externalIds: { fpl: '347' },
+					},
+				],
+			},
+		])
+		fdFetchTeams.mockResolvedValue([
+			{ externalId: '57', name: 'Arsenal FC', shortName: 'ARS', badgeUrl: null },
+			{ externalId: '64', name: 'Liverpool FC', shortName: 'LIV', badgeUrl: null },
+		])
+		fdFetchRounds.mockResolvedValue([])
+		fdFetchStandings.mockResolvedValue([
+			{ teamExternalId: '64', position: 1, played: 10, won: 9, drawn: 1, lost: 0, points: 28 },
+			{ teamExternalId: '57', position: 2, played: 10, won: 8, drawn: 1, lost: 1, points: 25 },
+		])
+
+		await mergeFootballDataIds(
+			{ id: 'comp-pl', dataSource: 'fpl', externalId: null } as never,
+			'fd-key',
+		)
+
+		const positionSets = dbUpdateSet.mock.calls
+			.map((c) => c[0])
+			.filter((payload) => 'leaguePosition' in payload)
+		expect(positionSets).toHaveLength(2)
+		expect(positionSets).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ leaguePosition: 1 }),
+				expect.objectContaining({ leaguePosition: 2 }),
+			]),
+		)
+	})
+
+	it('ignores standings rows whose team was not merged onto one of this competition teams', async () => {
+		// The standings table carries a club (fd id 999) that never merged onto
+		// one of this competition's team rows — its position must not be written
+		// anywhere (same competition-scoped identity rule as the id merge).
+		const teamArs = {
+			id: 'our-ARS',
+			shortName: 'ARS',
+			name: 'Arsenal',
+			externalIds: { fpl: '1' },
+		}
+		dbQueryTeamFindMany
+			.mockResolvedValueOnce([teamArs])
+			.mockResolvedValueOnce([{ ...teamArs, externalIds: { fpl: '1', football_data: '57' } }])
+		dbQueryRoundFindMany.mockResolvedValue([
+			{
+				id: 'our-r-1',
+				number: 1,
+				fixtures: [
+					{
+						id: 'our-fx-1',
+						homeTeamId: 'our-ARS',
+						awayTeamId: 'our-ARS',
+						externalIds: { fpl: '1' },
+					},
+				],
+			},
+		])
+		fdFetchTeams.mockResolvedValue([
+			{ externalId: '57', name: 'Arsenal FC', shortName: 'ARS', badgeUrl: null },
+		])
+		fdFetchRounds.mockResolvedValue([])
+		fdFetchStandings.mockResolvedValue([
+			{ teamExternalId: '57', position: 4, played: 10, won: 6, drawn: 2, lost: 2, points: 20 },
+			{ teamExternalId: '999', position: 20, played: 10, won: 0, drawn: 1, lost: 9, points: 1 },
+		])
+
+		await mergeFootballDataIds(
+			{ id: 'comp-pl', dataSource: 'fpl', externalId: null } as never,
+			'fd-key',
+		)
+
+		const positionSets = dbUpdateSet.mock.calls
+			.map((c) => c[0])
+			.filter((payload) => 'leaguePosition' in payload)
+		expect(positionSets).toEqual([expect.objectContaining({ leaguePosition: 4 })])
 	})
 
 	it('merges football-data team + fixture IDs onto FPL-bootstrapped rows by short_name and (matchday, home, away)', async () => {
@@ -883,6 +989,7 @@ describe('archived competition immutability', () => {
 
 		expect(fdFetchTeams).not.toHaveBeenCalled()
 		expect(fdFetchRounds).not.toHaveBeenCalled()
+		expect(fdFetchStandings).not.toHaveBeenCalled()
 		expect(dbUpdateFn).not.toHaveBeenCalled()
 	})
 })

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -2,7 +2,7 @@ import { and, eq, gt, inArray, isNull, lt } from 'drizzle-orm'
 import { FootballDataAdapter } from '@/lib/data/football-data'
 import { FplAdapter, type FplPreFetched } from '@/lib/data/fpl'
 import { enqueuePollScoresAt } from '@/lib/data/qstash'
-import type { CompetitionAdapter } from '@/lib/data/types'
+import type { AdapterStanding, CompetitionAdapter } from '@/lib/data/types'
 import { WC_2026_POTS } from '@/lib/data/wc-pots'
 import { db } from '@/lib/db'
 import { settleFixture } from '@/lib/game/settle'
@@ -166,6 +166,24 @@ function competitionRoundsWithFixtures(competitionId: string) {
 }
 
 /**
+ * Write source standings into team.leaguePosition, resolved strictly through
+ * the given external-id → team-UUID map (payload-built in syncCompetition,
+ * merge-built in mergeFootballDataIds) so writes stay within the competition
+ * being synced. Rows whose team is not in the map are skipped. Feeds the
+ * pick-UI ordinals and the auto-pick worst-placed-team ordering.
+ */
+async function persistLeaguePositions(
+	standings: AdapterStanding[],
+	teamIdByExternalId: Map<string, string>,
+): Promise<void> {
+	for (const row of standings) {
+		const teamId = teamIdByExternalId.get(row.teamExternalId)
+		if (!teamId) continue
+		await db.update(team).set({ leaguePosition: row.position }).where(eq(team.id, teamId))
+	}
+}
+
+/**
  * For competitions whose primary adapter is FPL, this fetches the same matchdays
  * from football-data.org and merges football-data IDs into existing teams +
  * fixtures. The FPL adapter remains the source of truth for round structure
@@ -265,18 +283,10 @@ export async function mergeFootballDataIds(comp: CompetitionRow, apiKey: string)
 	}
 
 	// 3) Persist current league standings into team.leaguePosition, resolved
-	// through the football-data ids merged in step 1 (the FPL adapter has no
+	// through the football-data ids merged in step 1. The FPL adapter has no
 	// standings source, so this merge step is what makes positions real for
-	// FPL-bootstrapped competitions). Feeds the pick-UI ordinals and the
-	// auto-pick worst-placed-team ordering. Standings rows whose team was not
-	// merged onto one of this competition's teams are skipped — same identity
-	// rule as everything above.
-	const standings = await fdAdapter.fetchStandings()
-	for (const row of standings) {
-		const teamId = ourTeamIdByFdId.get(row.teamExternalId)
-		if (!teamId) continue
-		await db.update(team).set({ leaguePosition: row.position }).where(eq(team.id, teamId))
-	}
+	// FPL-bootstrapped competitions.
+	await persistLeaguePositions(await fdAdapter.fetchStandings(), ourTeamIdByFdId)
 
 	// 4) Coverage assertion. Self-diagnosing for the next time the FPL/football-
 	// data data shape drifts (likely each August when promoted PL teams arrive).
@@ -383,12 +393,7 @@ export async function syncCompetition(
 	// supports standings. Resolved through the current payload's team list so
 	// updates stay within this competition's own teams.
 	if (typeof adapter.fetchStandings === 'function') {
-		const standings = await adapter.fetchStandings()
-		for (const row of standings) {
-			const teamId = teamIdByPayloadId.get(row.teamExternalId)
-			if (!teamId) continue
-			await db.update(team).set({ leaguePosition: row.position }).where(eq(team.id, teamId))
-		}
+		await persistLeaguePositions(await adapter.fetchStandings(), teamIdByPayloadId)
 	}
 
 	// Fixture upsert matching is scoped to this competition's own rounds:

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -264,7 +264,21 @@ export async function mergeFootballDataIds(comp: CompetitionRow, apiKey: string)
 		}
 	}
 
-	// 3) Coverage assertion. Self-diagnosing for the next time the FPL/football-
+	// 3) Persist current league standings into team.leaguePosition, resolved
+	// through the football-data ids merged in step 1 (the FPL adapter has no
+	// standings source, so this merge step is what makes positions real for
+	// FPL-bootstrapped competitions). Feeds the pick-UI ordinals and the
+	// auto-pick worst-placed-team ordering. Standings rows whose team was not
+	// merged onto one of this competition's teams are skipped — same identity
+	// rule as everything above.
+	const standings = await fdAdapter.fetchStandings()
+	for (const row of standings) {
+		const teamId = ourTeamIdByFdId.get(row.teamExternalId)
+		if (!teamId) continue
+		await db.update(team).set({ leaguePosition: row.position }).where(eq(team.id, teamId))
+	}
+
+	// 4) Coverage assertion. Self-diagnosing for the next time the FPL/football-
 	// data data shape drifts (likely each August when promoted PL teams arrive).
 	// Fails loudly on team-level gaps because every PL team must be matchable
 	// for live scoring to work; warns on fixture-level gaps because rescheduled

--- a/src/lib/game/detail-queries.ts
+++ b/src/lib/game/detail-queries.ts
@@ -414,6 +414,7 @@ export async function getClassicPickData(gameId: string, roundId: string, gamePl
 			shortName: f.homeTeam.shortName,
 			badgeUrl: f.homeTeam.badgeUrl,
 			form: formMap.get(f.homeTeamId),
+			leaguePosition: f.homeTeam.leaguePosition,
 		},
 		away: {
 			id: f.awayTeamId,
@@ -421,6 +422,7 @@ export async function getClassicPickData(gameId: string, roundId: string, gamePl
 			shortName: f.awayTeam.shortName,
 			badgeUrl: f.awayTeam.badgeUrl,
 			form: formMap.get(f.awayTeamId),
+			leaguePosition: f.awayTeam.leaguePosition,
 		},
 		kickoff: f.kickoff ? f.kickoff.toISOString() : null,
 	}))
@@ -489,6 +491,7 @@ export async function getTurboPickData(gameId: string, roundId: string, gamePlay
 			shortName: f.homeTeam.shortName,
 			badgeUrl: f.homeTeam.badgeUrl,
 			form: formMap.get(f.homeTeamId),
+			leaguePosition: f.homeTeam.leaguePosition,
 		},
 		away: {
 			id: f.awayTeamId,
@@ -496,6 +499,7 @@ export async function getTurboPickData(gameId: string, roundId: string, gamePlay
 			shortName: f.awayTeam.shortName,
 			badgeUrl: f.awayTeam.badgeUrl,
 			form: formMap.get(f.awayTeamId),
+			leaguePosition: f.awayTeam.leaguePosition,
 		},
 		kickoff: f.kickoff ? f.kickoff.toISOString() : null,
 	}))


### PR DESCRIPTION
Closes #116

## What

- **`mergeFootballDataIds` now writes league positions.** The PL is bootstrapped from the FPL adapter, which has no standings source, so `syncCompetition`'s existing standings block never fired for the PL and `team.league_position` stayed null in production. The merge step now fetches football-data's standings and writes each club's position through the competition-scoped football-data-id → team-UUID map the id merge already builds — standings rows that didn't resolve onto one of this competition's teams are skipped, preserving the payload-driven identity rule. The write happens before the loud team-coverage assertion and after the id merges, so a standings API failure can't abort the live-scoring id merge, and the shared write loop is extracted into `persistLeaguePositions` used by both `syncCompetition` and the merge (review finding — two write paths for the same column would drift).
- **Pick data queries pass the column through.** `FixtureRow`'s ordinal rendering and `turbo-pick`'s plumbing already consumed `FixtureTeamInfo.leaguePosition`, but `getClassicPickData` / `getTurboPickData` dropped the column when mapping team objects, so ordinals could never render even with positions in the DB. They now pass it through — no rendering changes.
- **Auto-pick needed no code change.** `pickLowestRankedUnusedTeam` already orders by position (missing → Infinity, i.e. picked first as the safe default); the bug was purely that positions were never populated.

## Acceptance criteria

- *Every current-season club has a position after sync + merge*: football-data's TOTAL standings table lists all clubs, and the merge's existing coverage assertion fails loudly if any club missed the id merge — so a merge that completes has written every club's position. (Not separately asserted end-to-end; the unit seam covers the mechanism, per the ticket's stated coverage scope.)
- *Pick UI ordinals reflect standings*: verified the existing chain — `team.league_position` → pick data queries (now passing it through) → `FixtureRow`'s `FormHalf` ordinal. Note the ordinal renders inside the form bar, which only appears once teams have form (i.e. from GW2); that gate is pre-existing rendering, untouched per "verify, don't redesign".
- *Auto-pick worst-placed*: `no-pick-handler` maps `team.leaguePosition ?? Infinity` into the pre-existing, tested ordering.
- *Coverage*: bootstrap unit seam — standings rows persisted through the merged ids, unresolved rows skipped, archived competitions never fetch standings; auto-pick seam — new explicit all-positions-present ordering case alongside the existing ordering tests.

## Review findings not acted on

- **Standards (judgement call):** the home/away team-info literal is repeated across four sites in `detail-queries.ts`, so adding a team field fans out to four edits. Pre-existing idiom; extracting a `toFixtureTeamInfo` helper is a worthwhile follow-up but touches code beyond this ticket's scope.
- **Spec (informational):** the classic planner's future-round fixtures still omit `leaguePosition` — but they also omit `form`, so the form bar (where ordinals live) never rendered there. Wiring it would change what that surface shows, i.e. a redesign the ticket excludes.

## Validation

`just typecheck`, `just lint`, `just test` (626 passed), `just smoke` against a fresh Postgres 17 (54 passed), `just build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)