### PR TITLE
Deadline-time no-pick lock + crown guard on winner declaration

### DIFF
--- a/docs/game-modes/README.md
+++ b/docs/game-modes/README.md
@@ -123,6 +123,14 @@ Safety nets for anything that slips through:
 
 All five paths converge on `settleFixture` for the actual work. Settlement is idempotent on every axis: re-running on a settled pick is a no-op (guard on `pick.result !== 'pending'`); re-running elimination guards on `gamePlayer.status === 'alive'`; cup re-eval is naturally idempotent (same inputs → same writes).
 
+### The deadline no-pick lock
+
+`processDeadlineLock` (`src/lib/game/no-pick-handler.ts`) handles alive players who made no pick once a round's deadline passes: classic round 3+ gets the worst-placed unused team auto-assigned (or elimination when every round team is already used); classic rounds 1–2 and turbo/cup eliminate per their mode rules. It is idempotent and internally gated on `round.deadline <= now`, so every surface calls it unconditionally:
+
+1. **QStash `deadline_lock` job** — scheduled by `openRoundForGame` for deadline+30s (same surface that pre-schedules auto-submits; dedup id collapses concurrent games opening the same round). This is the primary path: no-pick processing lands minutes after the deadline, before any fixture kicks off.
+2. **Daily-sync cron** — `syncCompetition` reports deadline-passed open rounds; the route runs the lock over them as the idempotent fallback.
+3. **Crown guard** — `checkAndMaybeCompleteOrAdvance` (the settle path's completion check) runs the lock for the settling round before evaluating ANY completion. No completion path (last-alive, mass-extinction, rounds-exhausted, turbo/cup crowning) can declare winners while an alive player's no-pick processing is outstanding — a pickless finalist is eliminated before the winner evaluation sees them (the WC LPS split-pot incident, which raced the final's settlement against the next morning's daily sync).
+
 ---
 
 ## Verifying the spec

--- a/docs/game-modes/classic.md
+++ b/docs/game-modes/classic.md
@@ -64,6 +64,8 @@ stateDiagram-v2
 
 **Mid-gameweek auto-completion is also real.** If a fixture's settlement drops the alive count to 1, the game auto-completes immediately — no waiting for the round to finish.
 
+**No-pick processing runs at the deadline, not the next morning.** `processDeadlineLock` fires via a QStash `deadline_lock` job scheduled by `openRoundForGame` for deadline+30s: round 3+ no-pickers get the worst-placed unused team auto-assigned (`isAuto=true`), or are eliminated (`no_pick_no_fallback`) when every team in the round is already used; rounds 1–2 follow the rebuy rules. The daily sync remains the idempotent fallback, and the settle path's completion check runs the same lock before evaluating winners (the crown guard) — so a pickless finalist can never be crowned in the window between the last fixture settling and the next sync. See the [README's trigger surfaces](./README.md#the-deadline-no-pick-lock).
+
 ## Live projection
 
 For an in-progress fixture (status=`live`/`halftime`, scores present):
@@ -115,9 +117,9 @@ See [`docs/superpowers/specs/2026-05-12-fixture-cancellation-handling-design.md`
 - Round advancement on last-fixture settle (3 winners → all advance).
 - WC group-stage settle + advance.
 - Live projection: in-progress fixture surfaces projected `'alive'` / `'eliminated'` per player + `'winning'` / `'losing'` per pick.
+- Deadline no-pick lock + crown guard (`lifecycle: deadline no-pick lock + crown guard`): the Barry race (pickless finalist with no legal team eliminated before rounds-exhausted can crown), pre-deadline no-op, worst-placed-unused auto-pick at deadline time, idempotency across the QStash trigger / daily-sync fallback / crown-guard invocations.
 
 Not yet covered (gaps to fill):
 - WC knockout auto-elimination via `computeWcClassicAutoElims`.
 - Mass-extinction tiebreaker.
-- `processDeadlineLock` end-to-end.
 - Rebuy round R1 → R2.

--- a/docs/game-modes/cup.md
+++ b/docs/game-modes/cup.md
@@ -119,6 +119,8 @@ stateDiagram-v2
 
 Lives are **earned**, not handed out — `startingLives` defaults to 0. The creator can raise it for a more forgiving game.
 
+**No-pick players are eliminated (and refunded) at the deadline.** A player who submitted no picks at all (partial pick sets are fine) is eliminated + refunded by the deadline no-pick lock — which fires at deadline+30s via QStash, with the daily sync as fallback and the crown guard running the same lock before the streak evaluation crowns anyone. See the [README](./README.md#the-deadline-no-pick-lock).
+
 ## Live projection
 
 For in-progress fixtures:

--- a/docs/game-modes/turbo.md
+++ b/docs/game-modes/turbo.md
@@ -64,6 +64,8 @@ stateDiagram-v2
     end note
 ```
 
+**No-pick players are eliminated (and refunded) at the deadline.** A player who submitted no predictions at all is eliminated + refunded by the deadline no-pick lock — which fires at deadline+30s via QStash, with the daily sync as fallback and the crown guard running the same lock before the streak evaluation crowns anyone. See the [README](./README.md#the-deadline-no-pick-lock).
+
 ## Live projection
 
 For an in-progress fixture:

--- a/scripts/smoke/helpers.ts
+++ b/scripts/smoke/helpers.ts
@@ -65,6 +65,7 @@ export async function makeTeam(opts: {
 	name: string
 	shortName: string
 	fifaPot?: 1 | 2 | 3 | 4
+	leaguePosition?: number
 }): Promise<string> {
 	const externalIds: Record<string, string | number> = {}
 	if (opts.fifaPot != null) externalIds.fifa_pot = opts.fifaPot
@@ -74,6 +75,7 @@ export async function makeTeam(opts: {
 			name: opts.name,
 			shortName: opts.shortName,
 			externalIds,
+			leaguePosition: opts.leaguePosition ?? null,
 		})
 		.returning()
 	return t.id

--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -2680,9 +2680,9 @@ describe('lifecycle: deadline no-pick lock + crown guard', () => {
 			modeConfig: { allowRebuys: false },
 		})
 		const gpWin = await makePlayer({ gameId, userId: 'u-win' })
-		const gpBarry = await makePlayer({ gameId, userId: 'u-barry' })
+		const gpPickless = await makePlayer({ gameId, userId: 'u-pickless' })
 		await makePayment({ gameId, userId: 'u-win' })
-		await makePayment({ gameId, userId: 'u-barry' })
+		await makePayment({ gameId, userId: 'u-pickless' })
 
 		// History: both players won rounds 1 + 2 with EQUAL total winning goals,
 		// so a wrong rounds-exhausted completion would split the pot between
@@ -2694,9 +2694,9 @@ describe('lifecycle: deadline no-pick lock + crown guard', () => {
 			teamId: a,
 			fixtureId: fxR1,
 		})
-		const barryR1 = await makePick({
+		const picklessR1 = await makePick({
 			gameId,
-			gamePlayerId: gpBarry,
+			gamePlayerId: gpPickless,
 			roundId: r1,
 			teamId: a,
 			fixtureId: fxR1,
@@ -2708,20 +2708,20 @@ describe('lifecycle: deadline no-pick lock + crown guard', () => {
 			teamId: c,
 			fixtureId: fxR2cf,
 		})
-		const barryR2 = await makePick({
+		const picklessR2 = await makePick({
 			gameId,
-			gamePlayerId: gpBarry,
+			gamePlayerId: gpPickless,
 			roundId: r2,
 			teamId: b,
 			fixtureId: fxR2be,
 		})
 		await db.update(pick).set({ result: 'win', goalsScored: 2 }).where(eq(pick.id, winR1))
-		await db.update(pick).set({ result: 'win', goalsScored: 2 }).where(eq(pick.id, barryR1))
+		await db.update(pick).set({ result: 'win', goalsScored: 2 }).where(eq(pick.id, picklessR1))
 		await db.update(pick).set({ result: 'win', goalsScored: 1 }).where(eq(pick.id, winR2))
-		await db.update(pick).set({ result: 'win', goalsScored: 2 }).where(eq(pick.id, barryR2))
+		await db.update(pick).set({ result: 'win', goalsScored: 2 }).where(eq(pick.id, picklessR2))
 
 		// Final round: the survivor picked B (their only unused finalist).
-		// Barry made no pick — and has already used both A and B, so no legal
+		// The pickless finalist made no pick — and has already used both A and B, so no legal
 		// auto-pick exists.
 		await makePick({ gameId, gamePlayerId: gpWin, roundId: r3, teamId: b, fixtureId: fxFinal })
 
@@ -2729,16 +2729,16 @@ describe('lifecycle: deadline no-pick lock + crown guard', () => {
 		await finishFixture(fxFinal, 0, 1)
 		await settleFixture(fxFinal)
 
-		// Barry is eliminated in the final round — not crowned.
-		const barry = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gpBarry) })
-		expect(barry?.status).toBe('eliminated')
-		expect(barry?.eliminatedReason).toBe('no_pick_no_fallback')
-		expect(barry?.eliminatedRoundId).toBe(r3)
-		// No auto-pick was possible — no pick row appears for Barry in r3.
-		const barryFinalPick = await db.query.pick.findFirst({
-			where: and(eq(pick.gamePlayerId, gpBarry), eq(pick.roundId, r3)),
+		// The pickless finalist is eliminated in the final round — not crowned.
+		const pickless = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gpPickless) })
+		expect(pickless?.status).toBe('eliminated')
+		expect(pickless?.eliminatedReason).toBe('no_pick_no_fallback')
+		expect(pickless?.eliminatedRoundId).toBe(r3)
+		// No auto-pick was possible — no pick row appears for them in r3.
+		const picklessFinalPick = await db.query.pick.findFirst({
+			where: and(eq(pick.gamePlayerId, gpPickless), eq(pick.roundId, r3)),
 		})
-		expect(barryFinalPick).toBeUndefined()
+		expect(picklessFinalPick).toBeUndefined()
 
 		// The sole survivor is crowned alone with the full pot — no split.
 		const winner = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gpWin) })
@@ -2881,7 +2881,7 @@ describe('lifecycle: deadline no-pick lock + crown guard', () => {
 		const f = await makeTeam({ name: 'F', shortName: 'F', leaguePosition: 11 })
 		const c = await makeTeam({ name: 'C', shortName: 'C' })
 		const d = await makeTeam({ name: 'D', shortName: 'D' })
-		const g1 = await makeTeam({ name: 'G', shortName: 'G' })
+		const teamG = await makeTeam({ name: 'G', shortName: 'G' })
 		const h = await makeTeam({ name: 'H', shortName: 'H' })
 
 		// Four completed history rounds so one player can have consumed every
@@ -2890,7 +2890,7 @@ describe('lifecycle: deadline no-pick lock + crown guard', () => {
 		const historyRounds: Array<[string, string]> = [
 			[a, c],
 			[b, d],
-			[e, g1],
+			[e, teamG],
 			[f, h],
 		]
 		const historyFixtures: string[] = []
@@ -2933,7 +2933,7 @@ describe('lifecycle: deadline no-pick lock + crown guard', () => {
 		const gpAuto = await makePlayer({ gameId, userId: 'u-auto' })
 		const gpNoTeam = await makePlayer({ gameId, userId: 'u-noteam' })
 		const gpPicked = await makePlayer({ gameId, userId: 'u-own-pick' })
-		const autoUsed = [c, d, g1, h]
+		const autoUsed = [c, d, teamG, h]
 		const noTeamUsed = [a, b, e, f]
 		for (const [i, r] of rounds.entries()) {
 			historyIds.push(

--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -27,6 +27,7 @@ import {
 	getProgressGridData,
 	getTurboStandingsData,
 } from '@/lib/game/detail-queries'
+import { processDeadlineLock } from '@/lib/game/no-pick-handler'
 import { settleFixture } from '@/lib/game/settle'
 import {
 	competition,
@@ -2610,5 +2611,188 @@ describe('lifecycle: PL season rollover sync identity', () => {
 			const after = teams.find((t) => t.name === name)
 			expect(after).toEqual(before)
 		}
+	})
+})
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* deadline no-pick lock + crown guard                                     */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe('lifecycle: deadline no-pick lock + crown guard', () => {
+	/**
+	 * The Barry race (WC LPS final incident): the last round's fixture finishes
+	 * minutes after the deadline while an alive player has made no pick AND has
+	 * no unused team left to auto-pick. Without deadline-time no-pick
+	 * processing, rounds-exhausted completion crowned the pickless player as a
+	 * co-winner (the daily sync that would have eliminated them ran hours after
+	 * the final settled). The crown guard must run the lock before evaluating
+	 * winners, so the pickless finalist is eliminated in that round and the
+	 * sole survivor is crowned alone — the split outcome cannot occur.
+	 */
+	it('the Barry race: pickless finalist with no legal team is eliminated, sole survivor crowned alone', async () => {
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const a = await makeTeam({ name: 'A', shortName: 'A' })
+		const b = await makeTeam({ name: 'B', shortName: 'B' })
+		const c = await makeTeam({ name: 'C', shortName: 'C' })
+		const d = await makeTeam({ name: 'D', shortName: 'D' })
+		const e = await makeTeam({ name: 'E', shortName: 'E' })
+		const f = await makeTeam({ name: 'F', shortName: 'F' })
+
+		// Two completed history rounds, then round 3 is the FINAL round — no
+		// round 4 exists, so completing r3 evaluates rounds-exhausted.
+		const r1 = await makeRound(compId, { number: 1, status: 'completed' })
+		const r2 = await makeRound(compId, { number: 2, status: 'completed' })
+		const r3 = await makeRound(compId, {
+			number: 3,
+			status: 'open',
+			deadline: new Date(Date.now() - 3_600_000), // deadline an hour ago
+		})
+		const fxR1 = await makeFixture({
+			roundId: r1,
+			homeTeamId: a,
+			awayTeamId: d,
+			status: 'finished',
+			homeScore: 2,
+			awayScore: 0,
+		})
+		const fxR2be = await makeFixture({
+			roundId: r2,
+			homeTeamId: b,
+			awayTeamId: e,
+			status: 'finished',
+			homeScore: 2,
+			awayScore: 0,
+		})
+		const fxR2cf = await makeFixture({
+			roundId: r2,
+			homeTeamId: c,
+			awayTeamId: f,
+			status: 'finished',
+			homeScore: 1,
+			awayScore: 0,
+		})
+		const fxFinal = await makeFixture({ roundId: r3, homeTeamId: a, awayTeamId: b })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r3,
+			modeConfig: { allowRebuys: false },
+		})
+		const gpWin = await makePlayer({ gameId, userId: 'u-win' })
+		const gpBarry = await makePlayer({ gameId, userId: 'u-barry' })
+		await makePayment({ gameId, userId: 'u-win' })
+		await makePayment({ gameId, userId: 'u-barry' })
+
+		// History: both players won rounds 1 + 2 with EQUAL total winning goals,
+		// so a wrong rounds-exhausted completion would split the pot between
+		// them (the production outcome this scenario locks out).
+		const winR1 = await makePick({
+			gameId,
+			gamePlayerId: gpWin,
+			roundId: r1,
+			teamId: a,
+			fixtureId: fxR1,
+		})
+		const barryR1 = await makePick({
+			gameId,
+			gamePlayerId: gpBarry,
+			roundId: r1,
+			teamId: a,
+			fixtureId: fxR1,
+		})
+		const winR2 = await makePick({
+			gameId,
+			gamePlayerId: gpWin,
+			roundId: r2,
+			teamId: c,
+			fixtureId: fxR2cf,
+		})
+		const barryR2 = await makePick({
+			gameId,
+			gamePlayerId: gpBarry,
+			roundId: r2,
+			teamId: b,
+			fixtureId: fxR2be,
+		})
+		await db.update(pick).set({ result: 'win', goalsScored: 2 }).where(eq(pick.id, winR1))
+		await db.update(pick).set({ result: 'win', goalsScored: 2 }).where(eq(pick.id, barryR1))
+		await db.update(pick).set({ result: 'win', goalsScored: 1 }).where(eq(pick.id, winR2))
+		await db.update(pick).set({ result: 'win', goalsScored: 2 }).where(eq(pick.id, barryR2))
+
+		// Final round: the survivor picked B (their only unused finalist).
+		// Barry made no pick — and has already used both A and B, so no legal
+		// auto-pick exists.
+		await makePick({ gameId, gamePlayerId: gpWin, roundId: r3, teamId: b, fixtureId: fxFinal })
+
+		// The final finishes minutes after the deadline: B wins 1-0 away.
+		await finishFixture(fxFinal, 0, 1)
+		await settleFixture(fxFinal)
+
+		// Barry is eliminated in the final round — not crowned.
+		const barry = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gpBarry) })
+		expect(barry?.status).toBe('eliminated')
+		expect(barry?.eliminatedReason).toBe('no_pick_no_fallback')
+		expect(barry?.eliminatedRoundId).toBe(r3)
+		// No auto-pick was possible — no pick row appears for Barry in r3.
+		const barryFinalPick = await db.query.pick.findFirst({
+			where: and(eq(pick.gamePlayerId, gpBarry), eq(pick.roundId, r3)),
+		})
+		expect(barryFinalPick).toBeUndefined()
+
+		// The sole survivor is crowned alone with the full pot — no split.
+		const winner = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gpWin) })
+		expect(winner?.status).toBe('winner')
+		const g = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+		expect(g?.status).toBe('completed')
+		const payouts = await db.query.payout.findMany({ where: eq(payout.gameId, gameId) })
+		expect(payouts).toHaveLength(1)
+		expect(payouts[0].userId).toBe('u-win')
+		expect(payouts[0].amount).toBe('20.00')
+		expect(payouts[0].isSplit).toBe(false)
+	})
+
+	it('does nothing before the deadline — a rescheduled fixture finishing early cannot trigger the lock', async () => {
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const a = await makeTeam({ name: 'A', shortName: 'A' })
+		const b = await makeTeam({ name: 'B', shortName: 'B' })
+		const c = await makeTeam({ name: 'C', shortName: 'C' })
+		const d = await makeTeam({ name: 'D', shortName: 'D' })
+		const r3 = await makeRound(compId, {
+			number: 3,
+			status: 'open',
+			deadline: new Date(Date.now() + 86_400_000), // deadline tomorrow
+		})
+		const fxAB = await makeFixture({ roundId: r3, homeTeamId: a, awayTeamId: b })
+		await makeFixture({ roundId: r3, homeTeamId: c, awayTeamId: d })
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r3,
+			modeConfig: { allowRebuys: false },
+		})
+		const gpPicked = await makePlayer({ gameId, userId: 'u-picked' })
+		const gpNoPick = await makePlayer({ gameId, userId: 'u-nopick' })
+		await makePick({ gameId, gamePlayerId: gpPicked, roundId: r3, teamId: a, fixtureId: fxAB })
+
+		// The lock invoked directly (QStash clock skew, manual ops call) is a
+		// no-op while the deadline is in the future.
+		const direct = await processDeadlineLock([r3])
+		expect(direct).toEqual({ autoPicksInserted: 0, playersEliminated: 0, paymentsRefunded: 0 })
+
+		// A fixture moved EARLIER than the round deadline (rescheduled PL match)
+		// finishing must not fire the lock via the crown guard either.
+		await finishFixture(fxAB, 2, 0)
+		await settleFixture(fxAB)
+
+		const noPickPlayer = await db.query.gamePlayer.findFirst({
+			where: eq(gamePlayer.id, gpNoPick),
+		})
+		expect(noPickPlayer?.status).toBe('alive')
+		const autoPick = await db.query.pick.findFirst({
+			where: and(eq(pick.gamePlayerId, gpNoPick), eq(pick.roundId, r3)),
+		})
+		expect(autoPick).toBeUndefined()
 	})
 })

--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -2795,4 +2795,206 @@ describe('lifecycle: deadline no-pick lock + crown guard', () => {
 		})
 		expect(autoPick).toBeUndefined()
 	})
+
+	it('assigns the worst-placed UNUSED team at deadline time, before any fixture kicks off', async () => {
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const a = await makeTeam({ name: 'A', shortName: 'A', leaguePosition: 2 })
+		const b = await makeTeam({ name: 'B', shortName: 'B', leaguePosition: 18 })
+		const c = await makeTeam({ name: 'C', shortName: 'C', leaguePosition: 9 })
+		const d = await makeTeam({ name: 'D', shortName: 'D', leaguePosition: 14 })
+		const r2 = await makeRound(compId, { number: 2, status: 'completed' })
+		const r3 = await makeRound(compId, {
+			number: 3,
+			status: 'open',
+			deadline: new Date(Date.now() - 60_000), // deadline just passed
+		})
+		const fxR2 = await makeFixture({
+			roundId: r2,
+			homeTeamId: b,
+			awayTeamId: c,
+			status: 'finished',
+			homeScore: 1,
+			awayScore: 0,
+		})
+		// Every round-3 fixture kicks off in the future — the lock fires at the
+		// deadline, well before any result is known.
+		const fxAB = await makeFixture({
+			roundId: r3,
+			homeTeamId: a,
+			awayTeamId: b,
+			kickoff: new Date(Date.now() + 2 * 3_600_000),
+		})
+		const fxCD = await makeFixture({
+			roundId: r3,
+			homeTeamId: c,
+			awayTeamId: d,
+			kickoff: new Date(Date.now() + 3 * 3_600_000),
+		})
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r3,
+			modeConfig: { allowRebuys: false },
+		})
+		const gpPicked = await makePlayer({ gameId, userId: 'u-picked' })
+		const gpForgot = await makePlayer({ gameId, userId: 'u-forgot' })
+		await makePick({ gameId, gamePlayerId: gpPicked, roundId: r3, teamId: a, fixtureId: fxAB })
+		// The forgetful player already used B (the overall worst-placed team) in
+		// round 2 — the auto-pick must fall to the worst-placed UNUSED team, D.
+		const usedB = await makePick({
+			gameId,
+			gamePlayerId: gpForgot,
+			roundId: r2,
+			teamId: b,
+			fixtureId: fxR2,
+		})
+		await db.update(pick).set({ result: 'win', goalsScored: 1 }).where(eq(pick.id, usedB))
+
+		const result = await processDeadlineLock([r3])
+		expect(result.autoPicksInserted).toBe(1)
+		expect(result.playersEliminated).toBe(0)
+
+		const autoPick = await db.query.pick.findFirst({
+			where: and(eq(pick.gamePlayerId, gpForgot), eq(pick.roundId, r3)),
+		})
+		expect(autoPick?.teamId).toBe(d)
+		expect(autoPick?.fixtureId).toBe(fxCD)
+		expect(autoPick?.isAuto).toBe(true)
+		expect(autoPick?.predictedResult).toBe('away_win')
+		expect(autoPick?.result).toBe('pending')
+
+		// Player stays alive; nothing has kicked off, let alone settled.
+		const forgot = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gpForgot) })
+		expect(forgot?.status).toBe('alive')
+		const r3Fixtures = await db.query.fixture.findMany({
+			where: eq(fixtureTable.roundId, r3),
+		})
+		expect(r3Fixtures.every((fx) => fx.status === 'scheduled')).toBe(true)
+	})
+
+	it('is idempotent across the deadline trigger, daily-sync fallback and crown-guard invocations', async () => {
+		const compId = await makeCompetition({ type: 'league', dataSource: 'fpl' })
+		const a = await makeTeam({ name: 'A', shortName: 'A', leaguePosition: 1 })
+		const b = await makeTeam({ name: 'B', shortName: 'B', leaguePosition: 20 })
+		const e = await makeTeam({ name: 'E', shortName: 'E', leaguePosition: 10 })
+		const f = await makeTeam({ name: 'F', shortName: 'F', leaguePosition: 11 })
+		const c = await makeTeam({ name: 'C', shortName: 'C' })
+		const d = await makeTeam({ name: 'D', shortName: 'D' })
+		const g1 = await makeTeam({ name: 'G', shortName: 'G' })
+		const h = await makeTeam({ name: 'H', shortName: 'H' })
+
+		// Four completed history rounds so one player can have consumed every
+		// team appearing in the current round (A, B, E, F).
+		const historyIds: string[] = []
+		const historyRounds: Array<[string, string]> = [
+			[a, c],
+			[b, d],
+			[e, g1],
+			[f, h],
+		]
+		const historyFixtures: string[] = []
+		const rounds: string[] = []
+		for (const [num, [home, away]] of historyRounds.entries()) {
+			const r = await makeRound(compId, { number: num + 1, status: 'completed' })
+			rounds.push(r)
+			const fx = await makeFixture({
+				roundId: r,
+				homeTeamId: home,
+				awayTeamId: away,
+				status: 'finished',
+				homeScore: 1,
+				awayScore: 0,
+			})
+			historyFixtures.push(fx)
+		}
+		const r5 = await makeRound(compId, {
+			number: 5,
+			status: 'open',
+			deadline: new Date(Date.now() - 60_000),
+		})
+		const fxAB = await makeFixture({ roundId: r5, homeTeamId: a, awayTeamId: b })
+		const fxEF = await makeFixture({
+			roundId: r5,
+			homeTeamId: e,
+			awayTeamId: f,
+			kickoff: new Date(Date.now() + 3 * 3_600_000),
+		})
+
+		const gameId = await makeGame({
+			competitionId: compId,
+			gameMode: 'classic',
+			currentRoundId: r5,
+			modeConfig: { allowRebuys: false },
+		})
+		// gpAuto used C, D, G, H → every current-round team unused → auto-pick B
+		// (worst-placed). gpNoTeam used A, B, E, F → no legal team → eliminated.
+		// gpPicked made their own pick (E) on the later fixture.
+		const gpAuto = await makePlayer({ gameId, userId: 'u-auto' })
+		const gpNoTeam = await makePlayer({ gameId, userId: 'u-noteam' })
+		const gpPicked = await makePlayer({ gameId, userId: 'u-own-pick' })
+		const autoUsed = [c, d, g1, h]
+		const noTeamUsed = [a, b, e, f]
+		for (const [i, r] of rounds.entries()) {
+			historyIds.push(
+				await makePick({
+					gameId,
+					gamePlayerId: gpAuto,
+					roundId: r,
+					teamId: autoUsed[i],
+					fixtureId: historyFixtures[i],
+				}),
+				await makePick({
+					gameId,
+					gamePlayerId: gpNoTeam,
+					roundId: r,
+					teamId: noTeamUsed[i],
+					fixtureId: historyFixtures[i],
+				}),
+			)
+		}
+		await db.update(pick).set({ result: 'win', goalsScored: 1 }).where(inArray(pick.id, historyIds))
+		await makePick({ gameId, gamePlayerId: gpPicked, roundId: r5, teamId: e, fixtureId: fxEF })
+
+		// Invocation 1 — the deadline-time QStash trigger.
+		const first = await processDeadlineLock([r5])
+		expect(first.autoPicksInserted).toBe(1)
+		expect(first.playersEliminated).toBe(1)
+
+		// Invocation 2 — the daily-sync fallback re-fires the same round.
+		const second = await processDeadlineLock([r5])
+		expect(second).toEqual({ autoPicksInserted: 0, playersEliminated: 0, paymentsRefunded: 0 })
+
+		// Invocation 3 — the crown guard inside the settle path.
+		await finishFixture(fxAB, 0, 1) // B wins away → the auto-pick wins
+		await settleFixture(fxAB)
+
+		// Exactly one auto-pick row, settled as a win; no duplicates anywhere.
+		const autoPicks = await db.query.pick.findMany({
+			where: and(eq(pick.gamePlayerId, gpAuto), eq(pick.roundId, r5)),
+		})
+		expect(autoPicks).toHaveLength(1)
+		expect(autoPicks[0].teamId).toBe(b)
+		expect(autoPicks[0].isAuto).toBe(true)
+		expect(autoPicks[0].result).toBe('win')
+
+		// The no-team player is eliminated exactly once, in the current round.
+		const noTeam = await db.query.gamePlayer.findFirst({ where: eq(gamePlayer.id, gpNoTeam) })
+		expect(noTeam?.status).toBe('eliminated')
+		expect(noTeam?.eliminatedReason).toBe('no_pick_no_fallback')
+		expect(noTeam?.eliminatedRoundId).toBe(r5)
+		const noTeamPicks = await db.query.pick.findMany({
+			where: and(eq(pick.gamePlayerId, gpNoTeam), eq(pick.roundId, r5)),
+		})
+		expect(noTeamPicks).toHaveLength(0)
+
+		// Round not fully settled (E–F still scheduled) → game stays active with
+		// two alive players; nobody was crowned by the repeated invocations.
+		const gAfter = await db.query.game.findFirst({ where: eq(game.id, gameId) })
+		expect(gAfter?.status).toBe('active')
+		const alive = await db.query.gamePlayer.findMany({
+			where: and(eq(gamePlayer.gameId, gameId), eq(gamePlayer.status, 'alive')),
+		})
+		expect(alive.map((p) => p.id).sort()).toEqual([gpAuto, gpPicked].sort())
+	})
 })

--- a/src/app/api/cron/qstash-handler/route.test.ts
+++ b/src/app/api/cron/qstash-handler/route.test.ts
@@ -6,6 +6,7 @@ const {
 	writeEventMock,
 	submitPlannedPickMock,
 	processDeadlineLockMock,
+	scheduleDeadlineLockForRoundMock,
 } = vi.hoisted(() => ({
 	verifyMock: vi.fn(),
 	processGameRoundMock: vi.fn().mockResolvedValue({ processed: true }),
@@ -16,6 +17,7 @@ const {
 		playersEliminated: 0,
 		paymentsRefunded: 0,
 	}),
+	scheduleDeadlineLockForRoundMock: vi.fn().mockResolvedValue(null),
 }))
 
 vi.mock('@upstash/qstash/nextjs', () => ({
@@ -30,6 +32,10 @@ vi.mock('@/lib/game/events', () => ({ writeEvent: writeEventMock }))
 vi.mock('@/lib/game/auto-submit', () => ({ submitPlannedPick: submitPlannedPickMock }))
 
 vi.mock('@/lib/game/no-pick-handler', () => ({ processDeadlineLock: processDeadlineLockMock }))
+
+vi.mock('@/lib/game/round-lifecycle', () => ({
+	scheduleDeadlineLockForRound: scheduleDeadlineLockForRoundMock,
+}))
 
 import { POST } from './route'
 
@@ -80,7 +86,24 @@ describe('qstash-handler', () => {
 		expect(body).toEqual({
 			ok: true,
 			summary: { autoPicksInserted: 1, playersEliminated: 0, paymentsRefunded: 0 },
+			rescheduledFor: null,
 		})
+	})
+
+	it('re-arms a deadline_lock that fired before a moved deadline', async () => {
+		// A daily sync can push round.deadline LATER after the job was queued
+		// (rescheduled fixtures). The job then fires early, the lock no-ops on
+		// its internal gate, and the handler must re-enqueue for the new
+		// deadline — otherwise no-pick processing regresses to the daily-sync
+		// fallback's cadence.
+		const rearmedAt = new Date('2026-08-28T17:31:00Z')
+		scheduleDeadlineLockForRoundMock.mockResolvedValueOnce(rearmedAt)
+		const res = await POST(req({ type: 'deadline_lock', roundId: 'r' }))
+		expect(res.status).toBe(200)
+		expect(processDeadlineLockMock).toHaveBeenCalledWith(['r'])
+		expect(scheduleDeadlineLockForRoundMock).toHaveBeenCalledWith('r')
+		const body = await res.json()
+		expect(body.rescheduledFor).toBe(rearmedAt.toISOString())
 	})
 
 	it('rejects unknown job types', async () => {

--- a/src/app/api/cron/qstash-handler/route.test.ts
+++ b/src/app/api/cron/qstash-handler/route.test.ts
@@ -1,13 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { verifyMock, processGameRoundMock, writeEventMock, submitPlannedPickMock } = vi.hoisted(
-	() => ({
-		verifyMock: vi.fn(),
-		processGameRoundMock: vi.fn().mockResolvedValue({ processed: true }),
-		writeEventMock: vi.fn().mockResolvedValue(undefined),
-		submitPlannedPickMock: vi.fn().mockResolvedValue({ submitted: true }),
+const {
+	verifyMock,
+	processGameRoundMock,
+	writeEventMock,
+	submitPlannedPickMock,
+	processDeadlineLockMock,
+} = vi.hoisted(() => ({
+	verifyMock: vi.fn(),
+	processGameRoundMock: vi.fn().mockResolvedValue({ processed: true }),
+	writeEventMock: vi.fn().mockResolvedValue(undefined),
+	submitPlannedPickMock: vi.fn().mockResolvedValue({ submitted: true }),
+	processDeadlineLockMock: vi.fn().mockResolvedValue({
+		autoPicksInserted: 1,
+		playersEliminated: 0,
+		paymentsRefunded: 0,
 	}),
-)
+}))
 
 vi.mock('@upstash/qstash/nextjs', () => ({
 	verifySignatureAppRouter: (fn: unknown) => fn,
@@ -19,6 +28,8 @@ vi.mock('@/lib/game/process-round', () => ({ processGameRound: processGameRoundM
 vi.mock('@/lib/game/events', () => ({ writeEvent: writeEventMock }))
 
 vi.mock('@/lib/game/auto-submit', () => ({ submitPlannedPick: submitPlannedPickMock }))
+
+vi.mock('@/lib/game/no-pick-handler', () => ({ processDeadlineLock: processDeadlineLockMock }))
 
 import { POST } from './route'
 
@@ -59,6 +70,17 @@ describe('qstash-handler', () => {
 		)
 		expect(res.status).toBe(200)
 		expect(submitPlannedPickMock).toHaveBeenCalledWith('gp', 'r', 't')
+	})
+
+	it('dispatches deadline_lock jobs to the no-pick lock', async () => {
+		const res = await POST(req({ type: 'deadline_lock', roundId: 'r' }))
+		expect(res.status).toBe(200)
+		expect(processDeadlineLockMock).toHaveBeenCalledWith(['r'])
+		const body = await res.json()
+		expect(body).toEqual({
+			ok: true,
+			summary: { autoPicksInserted: 1, playersEliminated: 0, paymentsRefunded: 0 },
+		})
 	})
 
 	it('rejects unknown job types', async () => {

--- a/src/app/api/cron/qstash-handler/route.ts
+++ b/src/app/api/cron/qstash-handler/route.ts
@@ -6,6 +6,7 @@ import { db } from '@/lib/db'
 import { submitPlannedPick } from '@/lib/game/auto-submit'
 import { syncCompetition } from '@/lib/game/bootstrap-competitions'
 import { writeEvent } from '@/lib/game/events'
+import { processDeadlineLock } from '@/lib/game/no-pick-handler'
 import { processGameRound } from '@/lib/game/process-round'
 import { reconcileAllActiveGames } from '@/lib/game/reconcile'
 import { competition } from '@/lib/schema/competition'
@@ -28,6 +29,16 @@ async function handler(request: Request): Promise<Response> {
 		case 'auto_submit': {
 			await submitPlannedPick(body.gamePlayerId, body.roundId, body.teamId)
 			return NextResponse.json({ ok: true })
+		}
+		case 'deadline_lock': {
+			// Deadline-time no-pick processing: auto-pick (or eliminate when no
+			// unused team remains) every alive player without a pick, the moment
+			// the round's deadline passes. Scheduled by openRoundForGame; the
+			// lock is idempotent and internally gated on the deadline, so a
+			// duplicate or early-fired job is harmless. The daily sync remains
+			// the fallback for a trigger that never fires.
+			const summary = await processDeadlineLock([body.roundId])
+			return NextResponse.json({ ok: true, summary })
 		}
 		case 'sync_competition': {
 			// Re-sync one competition (ingest newly-confirmed fixtures, e.g. the

--- a/src/app/api/cron/qstash-handler/route.ts
+++ b/src/app/api/cron/qstash-handler/route.ts
@@ -9,6 +9,7 @@ import { writeEvent } from '@/lib/game/events'
 import { processDeadlineLock } from '@/lib/game/no-pick-handler'
 import { processGameRound } from '@/lib/game/process-round'
 import { reconcileAllActiveGames } from '@/lib/game/reconcile'
+import { scheduleDeadlineLockForRound } from '@/lib/game/round-lifecycle'
 import { competition } from '@/lib/schema/competition'
 
 async function handler(request: Request): Promise<Response> {
@@ -38,7 +39,18 @@ async function handler(request: Request): Promise<Response> {
 			// duplicate or early-fired job is harmless. The daily sync remains
 			// the fallback for a trigger that never fires.
 			const summary = await processDeadlineLock([body.roundId])
-			return NextResponse.json({ ok: true, summary })
+			// A sync may have moved the round's deadline LATER after this job
+			// was queued (rescheduled fixtures). In that case the lock above
+			// no-oped on its internal gate — re-arm the trigger for the new
+			// deadline so processing still happens at deadline time, not at the
+			// daily-sync fallback's cadence. No-ops when the deadline has
+			// passed (the normal case).
+			const rescheduledFor = await scheduleDeadlineLockForRound(body.roundId)
+			return NextResponse.json({
+				ok: true,
+				summary,
+				rescheduledFor: rescheduledFor?.toISOString() ?? null,
+			})
 		}
 		case 'sync_competition': {
 			// Re-sync one competition (ingest newly-confirmed fixtures, e.g. the

--- a/src/lib/data/qstash.test.ts
+++ b/src/lib/data/qstash.test.ts
@@ -11,6 +11,7 @@ vi.mock('@upstash/qstash', () => ({
 import {
 	enqueueAutoSubmit,
 	enqueueCompetitionSync,
+	enqueueDeadlineLock,
 	enqueueDeadlineReminder,
 	enqueuePollScores,
 	enqueuePollScoresAt,
@@ -86,6 +87,18 @@ describe('qstash helpers', () => {
 			teamId: 't-1',
 		})
 		expect(call.notBefore).toBe(Math.floor(notBefore.getTime() / 1000))
+	})
+
+	it('enqueues a deadline lock at the given timestamp with a slot-stable dedup id', async () => {
+		const notBefore = new Date('2026-08-21T17:30:30Z')
+		await enqueueDeadlineLock('r-1', notBefore)
+		const call = publishJSONMock.mock.calls[0][0]
+		expect(call.url).toBe('https://example.com/api/cron/qstash-handler')
+		expect(call.body).toEqual({ type: 'deadline_lock', roundId: 'r-1' })
+		expect(call.notBefore).toBe(Math.floor(notBefore.getTime() / 1000))
+		// Stable id: every game opening the same round enqueues the identical
+		// (notBefore, dedup id), so QStash collapses them to one trigger.
+		expect(call.deduplicationId).toBe(`deadline-lock-r-1-${Math.floor(notBefore.getTime() / 1000)}`)
 	})
 
 	it('enqueuePollScores posts to poll-scores grid-aligned with a slot dedup id', async () => {

--- a/src/lib/data/qstash.ts
+++ b/src/lib/data/qstash.ts
@@ -5,6 +5,7 @@ export type QStashJob =
 	| { type: 'deadline_reminder'; gameId: string; roundId: string; window: '24h' | '2h' }
 	| { type: 'auto_submit'; gamePlayerId: string; roundId: string; teamId: string }
 	| { type: 'sync_competition'; competitionId: string }
+	| { type: 'deadline_lock'; roundId: string }
 
 /**
  * Stable callback origin for QStash jobs.
@@ -83,6 +84,27 @@ export async function enqueueCompetitionSync(
 		body: { type: 'sync_competition', competitionId } satisfies QStashJob,
 		delay: delaySeconds,
 		deduplicationId: `sync-comp-${competitionId}-${bucket}`,
+	})
+}
+
+/**
+ * Enqueue the round's no-pick lock (processDeadlineLock) to fire once the
+ * round's deadline has passed. Scheduled from `openRoundForGame` — the same
+ * surface that pre-schedules auto-submits — so no new trigger path exists;
+ * the daily sync remains the idempotent fallback.
+ *
+ * The dedup id is derived from (roundId, notBefore): every game that opens
+ * the same round enqueues the identical message, so QStash collapses the
+ * cluster to one trigger. Duplicates beyond the dedup window are harmless —
+ * the lock is idempotent and internally gated on the deadline.
+ */
+export async function enqueueDeadlineLock(roundId: string, notBefore: Date): Promise<void> {
+	const notBeforeSec = Math.floor(notBefore.getTime() / 1000)
+	await client().publishJSON({
+		url: handlerUrl(),
+		body: { type: 'deadline_lock', roundId } satisfies QStashJob,
+		notBefore: notBeforeSec,
+		deduplicationId: `deadline-lock-${roundId}-${notBeforeSec}`,
 	})
 }
 

--- a/src/lib/game/no-pick-handler.test.ts
+++ b/src/lib/game/no-pick-handler.test.ts
@@ -59,6 +59,7 @@ describe('processDeadlineLock — classic round 1 & 2 (4c3)', () => {
 		vi.mocked(db.query.round.findFirst).mockResolvedValue({
 			id: 'r1',
 			number: 1,
+			deadline: new Date(Date.now() - 60_000),
 		} as never)
 		vi.mocked(db.query.game.findMany).mockResolvedValue([
 			makeClassicGame(true, [makeClassicPlayer()]),
@@ -80,6 +81,7 @@ describe('processDeadlineLock — classic round 1 & 2 (4c3)', () => {
 		vi.mocked(db.query.round.findFirst).mockResolvedValue({
 			id: 'r1',
 			number: 1,
+			deadline: new Date(Date.now() - 60_000),
 		} as never)
 		vi.mocked(db.query.game.findMany).mockResolvedValue([
 			makeClassicGame(false, [makeClassicPlayer()]),
@@ -95,6 +97,7 @@ describe('processDeadlineLock — classic round 1 & 2 (4c3)', () => {
 		vi.mocked(db.query.round.findFirst).mockResolvedValue({
 			id: 'r2',
 			number: 2,
+			deadline: new Date(Date.now() - 60_000),
 		} as never)
 		vi.mocked(db.query.game.findMany).mockResolvedValue([
 			makeClassicGame(true, [makeClassicPlayer()]),
@@ -120,6 +123,7 @@ describe('processDeadlineLock — classic round 1 & 2 (4c3)', () => {
 		vi.mocked(db.query.round.findFirst).mockResolvedValue({
 			id: 'r2',
 			number: 2,
+			deadline: new Date(Date.now() - 60_000),
 		} as never)
 		vi.mocked(db.query.game.findMany).mockResolvedValue([
 			makeClassicGame(true, [makeClassicPlayer()]),

--- a/src/lib/game/no-pick-handler.ts
+++ b/src/lib/game/no-pick-handler.ts
@@ -17,6 +17,13 @@ export async function processDeadlineLock(roundIds: string[]): Promise<{
 	for (const roundId of roundIds) {
 		const roundRow = await db.query.round.findFirst({ where: eq(round.id, roundId) })
 		if (!roundRow) continue
+		// The lock only ever fires after the round's deadline. Gating here (not
+		// at the call sites) makes the lock safe to invoke from ANY surface —
+		// the QStash deadline trigger, the daily-sync fallback, and the crown
+		// guard in the settle path all call it unconditionally; a round whose
+		// deadline hasn't passed (e.g. a rescheduled fixture finishing early,
+		// or an early-fired job) is a no-op.
+		if (roundRow.deadline == null || roundRow.deadline.getTime() > Date.now()) continue
 
 		const games = await db.query.game.findMany({
 			where: and(eq(game.currentRoundId, roundId), ne(game.status, 'completed')),

--- a/src/lib/game/round-lifecycle.test.ts
+++ b/src/lib/game/round-lifecycle.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { dbMock, enqueueAutoSubmitMock } = vi.hoisted(() => {
+const { dbMock, enqueueAutoSubmitMock, enqueueDeadlineLockMock } = vi.hoisted(() => {
 	const enqueueAutoSubmitMock = vi.fn().mockResolvedValue(undefined)
+	const enqueueDeadlineLockMock = vi.fn().mockResolvedValue(undefined)
 	const updateSet = vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) }))
 	return {
 		enqueueAutoSubmitMock,
+		enqueueDeadlineLockMock,
 		dbMock: {
 			query: {
 				round: { findFirst: vi.fn() },
@@ -18,9 +20,11 @@ const { dbMock, enqueueAutoSubmitMock } = vi.hoisted(() => {
 vi.mock('@/lib/db', () => ({ db: dbMock }))
 vi.mock('@/lib/data/qstash', () => ({
 	enqueueAutoSubmit: enqueueAutoSubmitMock,
+	enqueueDeadlineLock: enqueueDeadlineLockMock,
 }))
 
 import {
+	DEADLINE_LOCK_LAG_MS,
 	openRoundForGame,
 	scheduleAutoSubmitForPlan,
 	scheduleAutoSubmitsForRound,
@@ -100,6 +104,54 @@ describe('openRoundForGame', () => {
 		await openRoundForGame('missing')
 		expect(dbMock.update).not.toHaveBeenCalled()
 		expect(enqueueAutoSubmitMock).not.toHaveBeenCalled()
+		expect(enqueueDeadlineLockMock).not.toHaveBeenCalled()
+	})
+
+	it('schedules the deadline no-pick lock just after the deadline, even with no auto-submit plans', async () => {
+		const deadline = new Date(Date.now() + 7 * 24 * 3600 * 1000)
+		dbMock.query.round.findFirst.mockResolvedValue({
+			id: 'r1',
+			status: 'upcoming',
+			deadline,
+		} as never)
+		dbMock.query.plannedPick.findMany.mockResolvedValue([] as never)
+
+		await openRoundForGame('r1')
+
+		expect(enqueueDeadlineLockMock).toHaveBeenCalledTimes(1)
+		expect(enqueueDeadlineLockMock).toHaveBeenCalledWith(
+			'r1',
+			new Date(deadline.getTime() + DEADLINE_LOCK_LAG_MS),
+		)
+	})
+
+	it('does not schedule the deadline lock when the deadline has already passed', async () => {
+		// A stale round (deadline in the past) is covered by the daily-sync
+		// fallback + crown guard — re-opening it must not queue a trigger.
+		dbMock.query.round.findFirst.mockResolvedValue({
+			id: 'r1',
+			status: 'upcoming',
+			deadline: new Date(Date.now() - 3600_000),
+		} as never)
+
+		await openRoundForGame('r1')
+
+		expect(enqueueDeadlineLockMock).not.toHaveBeenCalled()
+	})
+
+	it('opens the round even when the deadline-lock enqueue fails (best-effort scheduling)', async () => {
+		// QStash may be unconfigured (local dev) or unreachable — the open
+		// transition must not fail with it; the fallbacks cover the lock.
+		enqueueDeadlineLockMock.mockRejectedValueOnce(new Error('QSTASH_TOKEN not configured'))
+		dbMock.query.round.findFirst.mockResolvedValue({
+			id: 'r1',
+			status: 'upcoming',
+			deadline: new Date(Date.now() + 24 * 3600 * 1000),
+		} as never)
+
+		await expect(openRoundForGame('r1')).resolves.toBeUndefined()
+		// The status flip still happened.
+		expect(dbMock.update).toHaveBeenCalled()
 	})
 })
 

--- a/src/lib/game/round-lifecycle.test.ts
+++ b/src/lib/game/round-lifecycle.test.ts
@@ -28,6 +28,7 @@ import {
 	openRoundForGame,
 	scheduleAutoSubmitForPlan,
 	scheduleAutoSubmitsForRound,
+	scheduleDeadlineLockForRound,
 } from './round-lifecycle'
 
 describe('openRoundForGame', () => {
@@ -152,6 +153,40 @@ describe('openRoundForGame', () => {
 		await expect(openRoundForGame('r1')).resolves.toBeUndefined()
 		// The status flip still happened.
 		expect(dbMock.update).toHaveBeenCalled()
+	})
+})
+
+describe('scheduleDeadlineLockForRound', () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it('returns the scheduled time (deadline + lag) when it enqueues', async () => {
+		const deadline = new Date(Date.now() + 24 * 3600 * 1000)
+		dbMock.query.round.findFirst.mockResolvedValue({ id: 'r1', deadline } as never)
+
+		const scheduled = await scheduleDeadlineLockForRound('r1')
+
+		expect(scheduled).toEqual(new Date(deadline.getTime() + DEADLINE_LOCK_LAG_MS))
+		expect(enqueueDeadlineLockMock).toHaveBeenCalledWith('r1', scheduled)
+	})
+
+	it('returns null without enqueueing when the deadline (+lag) has passed', async () => {
+		dbMock.query.round.findFirst.mockResolvedValue({
+			id: 'r1',
+			deadline: new Date(Date.now() - 3600_000),
+		} as never)
+
+		expect(await scheduleDeadlineLockForRound('r1')).toBeNull()
+		expect(enqueueDeadlineLockMock).not.toHaveBeenCalled()
+	})
+
+	it('returns null when the enqueue fails (best-effort)', async () => {
+		enqueueDeadlineLockMock.mockRejectedValueOnce(new Error('quota'))
+		dbMock.query.round.findFirst.mockResolvedValue({
+			id: 'r1',
+			deadline: new Date(Date.now() + 3600_000),
+		} as never)
+
+		expect(await scheduleDeadlineLockForRound('r1')).toBeNull()
 	})
 })
 

--- a/src/lib/game/round-lifecycle.ts
+++ b/src/lib/game/round-lifecycle.ts
@@ -1,10 +1,19 @@
 import { eq } from 'drizzle-orm'
-import { enqueueAutoSubmit } from '@/lib/data/qstash'
+import { enqueueAutoSubmit, enqueueDeadlineLock } from '@/lib/data/qstash'
 import { db } from '@/lib/db'
 import { round } from '@/lib/schema/competition'
 import { plannedPick } from '@/lib/schema/game'
 
 const AUTO_SUBMIT_LEAD_MS = 60_000
+
+/**
+ * How long after the deadline the no-pick lock trigger fires. Orders it
+ * safely after the T-60s auto-submits have landed and absorbs QStash/server
+ * clock skew, so the lock never observes a not-quite-passed deadline (its
+ * internal gate would turn an early firing into a silent no-op with no
+ * retry until the daily-sync fallback).
+ */
+export const DEADLINE_LOCK_LAG_MS = 30_000
 
 /**
  * A round transitions from 'upcoming' → 'open' when a game starts using it
@@ -22,6 +31,27 @@ export async function openRoundForGame(roundId: string): Promise<void> {
 		await db.update(round).set({ status: 'open' }).where(eq(round.id, roundId))
 	}
 	await scheduleAutoSubmitsForRound(roundId)
+	await scheduleDeadlineLockForRound(r.id, r.deadline)
+}
+
+/**
+ * Schedule the round's no-pick lock (processDeadlineLock via the QStash
+ * handler) for just after the deadline. Best-effort: a failed enqueue is
+ * logged, never thrown — the daily-sync fallback and the settle-path crown
+ * guard both run the same idempotent lock, so a missed trigger delays
+ * no-pick processing but can never change its outcome.
+ */
+async function scheduleDeadlineLockForRound(roundId: string, deadline: Date | null): Promise<void> {
+	if (!deadline) return
+	const notBefore = new Date(deadline.getTime() + DEADLINE_LOCK_LAG_MS)
+	// Deadline already passed (stale round being re-opened / healed): the
+	// fallbacks own it; queueing a trigger now would just burn quota.
+	if (notBefore.getTime() <= Date.now()) return
+	try {
+		await enqueueDeadlineLock(roundId, notBefore)
+	} catch (err) {
+		console.warn(`[round-lifecycle] failed to enqueue deadline lock for round ${roundId}`, err)
+	}
 }
 
 /**

--- a/src/lib/game/round-lifecycle.ts
+++ b/src/lib/game/round-lifecycle.ts
@@ -31,26 +31,37 @@ export async function openRoundForGame(roundId: string): Promise<void> {
 		await db.update(round).set({ status: 'open' }).where(eq(round.id, roundId))
 	}
 	await scheduleAutoSubmitsForRound(roundId)
-	await scheduleDeadlineLockForRound(r.id, r.deadline)
+	await scheduleDeadlineLockForRound(roundId)
 }
 
 /**
  * Schedule the round's no-pick lock (processDeadlineLock via the QStash
- * handler) for just after the deadline. Best-effort: a failed enqueue is
- * logged, never thrown — the daily-sync fallback and the settle-path crown
- * guard both run the same idempotent lock, so a missed trigger delays
- * no-pick processing but can never change its outcome.
+ * handler) for just after the deadline. Returns the scheduled time, or null
+ * when nothing was queued. Best-effort: a failed enqueue is logged, never
+ * thrown — the daily-sync fallback and the settle-path crown guard both run
+ * the same idempotent lock, so a missed trigger delays no-pick processing
+ * but can never change its outcome.
+ *
+ * Also called by the qstash-handler when a deadline_lock job fires while the
+ * round's deadline is still in the future (a sync moved it later after the
+ * job was queued) — the re-enqueue keeps the trigger chained to the real
+ * deadline. The dedup id is derived from the notBefore slot, so a moved
+ * deadline produces a fresh id and QStash accepts the new message.
  */
-async function scheduleDeadlineLockForRound(roundId: string, deadline: Date | null): Promise<void> {
-	if (!deadline) return
-	const notBefore = new Date(deadline.getTime() + DEADLINE_LOCK_LAG_MS)
-	// Deadline already passed (stale round being re-opened / healed): the
-	// fallbacks own it; queueing a trigger now would just burn quota.
-	if (notBefore.getTime() <= Date.now()) return
+export async function scheduleDeadlineLockForRound(roundId: string): Promise<Date | null> {
+	const r = await db.query.round.findFirst({ where: eq(round.id, roundId) })
+	if (!r?.deadline) return null
+	const notBefore = new Date(r.deadline.getTime() + DEADLINE_LOCK_LAG_MS)
+	// Deadline already passed (stale round being re-opened / healed, or the
+	// trigger firing on time): the daily-sync fallback and crown guard own
+	// anything outstanding; queueing a trigger now would just burn quota.
+	if (notBefore.getTime() <= Date.now()) return null
 	try {
 		await enqueueDeadlineLock(roundId, notBefore)
+		return notBefore
 	} catch (err) {
 		console.warn(`[round-lifecycle] failed to enqueue deadline lock for round ${roundId}`, err)
+		return null
 	}
 }
 

--- a/src/lib/game/settle.ts
+++ b/src/lib/game/settle.ts
@@ -6,6 +6,7 @@ import {
 	checkCupCompletion,
 	checkTurboCompletion,
 } from '@/lib/game/auto-complete'
+import { processDeadlineLock } from '@/lib/game/no-pick-handler'
 import { openRoundForGame } from '@/lib/game/round-lifecycle'
 import type { WipeoutPlayerInput } from '@/lib/game-logic/auto-complete-tiebreakers'
 import { determinePickResult } from '@/lib/game-logic/common'
@@ -445,6 +446,16 @@ async function checkAndMaybeCompleteOrAdvance(
 		with: { competition: true },
 	})
 	if (!g || g.status !== 'active') return
+
+	// Crown guard: run the no-pick lock for this round before evaluating ANY
+	// completion. If the round's deadline has passed and an alive player made
+	// no pick, they must be auto-picked (or eliminated when no unused team
+	// remains) BEFORE winners are considered — otherwise a pickless finalist
+	// can be crowned in the window between the final fixture settling and the
+	// daily-sync fallback running (the WC LPS split-pot incident). The lock is
+	// idempotent and internally gated on the deadline having passed, so this
+	// is a no-op on healthy rounds.
+	await processDeadlineLock([roundId])
 
 	const allRoundFixtures = await db.query.fixture.findMany({
 		where: eq(fixture.roundId, roundId),


### PR DESCRIPTION
Closes #117

## What

No-pick processing now fires **at the round deadline** instead of the next morning's daily sync, and **winner declaration can no longer race it**:

- **QStash `deadline_lock` job** (existing trigger surface — no new path): `openRoundForGame` (game creation + round advance, the same surface that pre-schedules auto-submits) enqueues the lock for deadline+30s with a `(roundId, notBefore)`-stable dedup id, so every game opening the same round collapses to one trigger. Enqueue is best-effort (logged, never thrown) because two idempotent fallbacks exist.
- **Crown guard**: `checkAndMaybeCompleteOrAdvance` (the settle path's completion check) runs `processDeadlineLock` for the settling round before evaluating *any* completion — last-alive, mass-extinction, rounds-exhausted, turbo/cup crowning. A pickless finalist is eliminated (or auto-picked) before the winner evaluation ever sees them, making the WC LPS split-pot incident structurally impossible — deterministic, not cadence-dependent. Applies equally to PL GW38.
- **Internal deadline gate**: `processDeadlineLock` now skips rounds whose deadline is null or in the future, so every surface (trigger, daily-sync fallback, crown guard) calls it unconditionally and a rescheduled fixture finishing *before* the deadline can't fire premature auto-picks.
- **Moved-deadline re-arm** (self-review finding): a sync can push `round.deadline` later after the job was queued; the handler re-runs `scheduleDeadlineLockForRound` after the lock, chaining the trigger to the real deadline instead of silently regressing to the daily-sync cadence.
- Daily sync remains untouched as the idempotent fallback.

## Acceptance criteria → tests (smoke seam, real Postgres)

| Criterion | Test |
|---|---|
| The Barry race: pickless finalist with no legal team → eliminated in that round, sole survivor crowned alone, no split | `lifecycle: deadline no-pick lock + crown guard › the Barry race…` (red before the fix: both players crowned with split payouts) |
| Worst-placed unused team assigned at deadline time, before kickoffs | `…assigns the worst-placed UNUSED team at deadline time…` |
| Lock idempotent across trigger / daily-sync / crown-guard invocations | `…is idempotent across the deadline trigger, daily-sync fallback and crown-guard invocations` |
| No new trigger path | new `deadline_lock` case on the existing qstash-handler; scheduling rides `openRoundForGame`; unit tests in `qstash.test.ts`, `round-lifecycle.test.ts`, `qstash-handler/route.test.ts` |

Plus a pre-deadline no-op scenario (the internal gate).

## Validation

- `vitest run`: 635 passed
- `vitest run --config vitest.smoke.config.ts`: 58 passed (54 baseline + 4 new)
- `tsc --noEmit`: clean; `biome check`: only 2 pre-existing warnings in `team-badge.tsx` (untouched by this PR); `pnpm build`: clean

## Self-review notes (findings I did not act on, and why)

- **Concurrent duplicate auto-pick inserts (spec review, plausible):** `processDeadlineLock`'s read-then-insert is only sequentially idempotent; two *concurrent* invocations (e.g. the QStash trigger racing a poll-scores crown guard) could double-insert an auto-pick, and the existing `pick_player_round_idx` unique index doesn't catch it for classic picks (`confidenceRank` is NULL, NULLs are distinct). I did not fix this here: the window is tiny (trigger fires at deadline+30s; crown guard fires at fixture finish, normally hours later), the race pre-exists this PR, the duplicate outcome is bounded (two identical picks that settle identically — not a pot-corruption risk), and the proper fix (a `NULLS NOT DISTINCT` unique index + `ON CONFLICT DO NOTHING`) needs an audit of the admin remove/re-make-pick flows before changing index semantics. Recommend a follow-up ticket.
- **No single end-to-end enqueue→handler→lock test:** each link is pinned (enqueue payload, handler dispatch, lock behaviour at the smoke seam), but no test exercises the QStash chain end-to-end — that's the seam the ticket pre-agreed (smoke suite drives `processDeadlineLock`; QStash itself is mocked at unit level, consistent with every other job type).
- **Comment repetition (standards review, judgement call):** the "idempotent + internally gated" invariant is restated at each call site deliberately — each surface documents *why it* may call unconditionally.
- **No new turbo/cup smoke scenarios:** the ticket's acceptance scenarios are classic; turbo/cup got doc notes (their no-pick elimination semantics are unchanged — only the timing moved earlier, via the same shared lock the classic scenarios exercise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
