### PR TITLE
Prod repair scripts: World Cup LPS record correction + SI World Cup deletion

### DIFF
--- a/scripts/repair/README.md
+++ b/scripts/repair/README.md
@@ -1,0 +1,72 @@
+# One-off prod repair scripts — issue #119
+
+Two approved production repairs from the World Cup endgame incidents
+(parent spec: #112), plus a read-only inspector to verify them. Prod
+execution is gated on human sign-off: the agent delivers the scripts and
+dry-run evidence; **a human runs `--apply`**.
+
+Convention: every mutating script is dry-run by default, prints every
+intended mutation, asserts hard preconditions against live data (any drift
+aborts loudly with no writes), and only mutates with an explicit `--apply`
+flag — all writes in a single transaction.
+
+## Runbook (human, in order)
+
+All commands run from the repo root. WSL note: run outside any network
+sandbox (Neon DNS is blocked in it); Neon idle-suspends, so retry once on
+an initial `ETIMEDOUT`.
+
+```bash
+# 0. Baseline — read-only census of both games
+doppler run -p last-person-standing -c prd -- pnpm exec tsx scripts/repair/inspect-wc-repair.ts
+
+# 1a. World Cup LPS record correction — dry run, review the printed mutations
+doppler run -p last-person-standing -c prd -- pnpm exec tsx scripts/repair/repair-wc-lps-endgame.ts
+# 1b. ...then apply
+doppler run -p last-person-standing -c prd -- pnpm exec tsx scripts/repair/repair-wc-lps-endgame.ts --apply
+
+# 2a. SI World Cup husk deletion — dry run, review the printed rows
+doppler run -p last-person-standing -c prd -- pnpm exec tsx scripts/repair/delete-si-world-cup.ts
+# 2b. ...then apply
+doppler run -p last-person-standing -c prd -- pnpm exec tsx scripts/repair/delete-si-world-cup.ts --apply
+
+# 3. Re-run the inspector and check against the acceptance criteria below
+doppler run -p last-person-standing -c prd -- pnpm exec tsx scripts/repair/inspect-wc-repair.ts
+```
+
+Expected inspector output after both applies (issue #119 acceptance
+criteria):
+
+- The R5 Round of 16 `COL` pick shows `loss`; its owner is eliminated in
+  **R5 Round of 16** (reason `loss`), with their R6 Quarter-finals pick row
+  still present as history.
+- The previously pickless finalist is **eliminated in R8 Final** (reason
+  `no_pick_no_fallback`); exactly **one** player has status `winner`.
+- Payouts: exactly one row, **£160.00, `isSplit=false`** — no split rows.
+- All 62 World Cup LPS pick rows still present (only the one stuck pick's
+  result changed).
+- SI World Cup reports **`Game NOT FOUND (deleted...)`**.
+
+## 4. Authenticated page check (final acceptance criterion)
+
+Verify the corrected game page renders through real SSR without errors
+(headless browsers are usually blocked here; use the curl recipe):
+
+```bash
+# Sign in (any account that is a member of the game) and keep the cookie
+curl -s -c /tmp/lps-cookies.txt -H 'content-type: application/json' \
+  -d '{"email":"<email>","password":"<password>"}' \
+  https://last-person-standing.app/api/auth/sign-in/email >/dev/null
+
+# SSR-fetch the corrected game page — expect HTTP 200
+curl -s -b /tmp/lps-cookies.txt -o /tmp/lps-game.html -w '%{http_code}\n' \
+  https://last-person-standing.app/game/dc857c5f-8a07-4c3b-aeef-71d9883a218e
+
+# Expect 0 error markers
+grep -ci 'application error\|internal server error' /tmp/lps-game.html
+```
+
+Also confirm the deleted game is gone from the signed-in dashboard listing.
+
+These scripts are single-use: once applied and verified, their
+preconditions can never pass again (each aborts loudly if re-run).

--- a/scripts/repair/delete-si-world-cup.ts
+++ b/scripts/repair/delete-si-world-cup.ts
@@ -1,0 +1,101 @@
+/**
+ * One-off prod repair: delete the abandoned "SI World Cup" husk game.
+ * Issue #119 / parent #112.
+ *
+ * The game is a one-player husk (single player, one pending payment, zero
+ * picks) that would otherwise sit in every listing forever. Deleting it —
+ * rather than flipping state — is an explicitly approved exception to the
+ * preserve-history convention, confirmed by the game owner.
+ *
+ * Deletes, in FK order and in one transaction: planned picks → payments →
+ * game players → the game row. Aborts loudly if the game has grown any
+ * real history since the decision was made (more than one player, any pick,
+ * any payout, any paid payment).
+ *
+ * Usage (prod):
+ *   dry run: doppler run --config prd -- pnpm exec tsx scripts/repair/delete-si-world-cup.ts
+ *   apply:   doppler run --config prd -- pnpm exec tsx scripts/repair/delete-si-world-cup.ts --apply
+ */
+
+import { eq, inArray } from 'drizzle-orm'
+import { db } from '../../src/lib/db'
+import { user } from '../../src/lib/schema/auth'
+import { game, gamePlayer, pick, plannedPick } from '../../src/lib/schema/game'
+import { payment, payout } from '../../src/lib/schema/payment'
+import { fail, heading, SI_WC_GAME_ID, SI_WC_GAME_NAME } from './shared'
+
+async function main() {
+	const apply = process.argv.includes('--apply')
+
+	heading(`Delete: ${SI_WC_GAME_NAME} husk game — ${apply ? 'APPLY' : 'DRY RUN'}`)
+
+	const g = await db.query.game.findFirst({ where: eq(game.id, SI_WC_GAME_ID) })
+	if (!g) fail(`game ${SI_WC_GAME_ID} not found (already deleted?)`)
+	if (g.name !== SI_WC_GAME_NAME) {
+		fail(`game name is ${JSON.stringify(g.name)}, expected ${JSON.stringify(SI_WC_GAME_NAME)}`)
+	}
+
+	const players = await db.select().from(gamePlayer).where(eq(gamePlayer.gameId, g.id))
+	if (players.length !== 1) fail(`expected exactly 1 player, found ${players.length}`)
+
+	const picks = await db.select().from(pick).where(eq(pick.gameId, g.id))
+	if (picks.length !== 0) fail(`expected zero picks, found ${picks.length} — this is not a husk`)
+
+	const payouts = await db.select().from(payout).where(eq(payout.gameId, g.id))
+	if (payouts.length !== 0) fail(`expected zero payouts, found ${payouts.length}`)
+
+	const payments = await db.select().from(payment).where(eq(payment.gameId, g.id))
+	const paid = payments.filter((p) => p.status === 'paid')
+	if (paid.length > 0) {
+		fail(`found ${paid.length} PAID payment(s) — real money history, refusing to delete`)
+	}
+
+	const planned = await db
+		.select()
+		.from(plannedPick)
+		.where(
+			inArray(
+				plannedPick.gamePlayerId,
+				players.map((p) => p.id),
+			),
+		)
+
+	const playerUser = await db.query.user.findFirst({ where: eq(user.id, players[0].userId) })
+	const playerName = playerUser?.name ?? players[0].userId
+
+	heading('Rows to delete')
+	console.log(`game ${g.id}: ${JSON.stringify(g.name)} (${g.gameMode}, ${g.status})`)
+	for (const p of planned) console.log(`planned_pick ${p.id}`)
+	for (const p of payments) console.log(`payment ${p.id}: ${playerName} £${p.amount} ${p.status}`)
+	for (const p of players) console.log(`game_player ${p.id}: ${playerName} (${p.status})`)
+	console.log('(the user account itself is untouched — only this game and its rows go)')
+
+	if (!apply) {
+		console.log('\nDRY RUN — nothing written. Re-run with --apply to commit.')
+		process.exit(0)
+	}
+
+	await db.transaction(async (tx) => {
+		if (planned.length > 0) {
+			await tx.delete(plannedPick).where(
+				inArray(
+					plannedPick.id,
+					planned.map((p) => p.id),
+				),
+			)
+		}
+		await tx.delete(payment).where(eq(payment.gameId, g.id))
+		await tx.delete(gamePlayer).where(eq(gamePlayer.gameId, g.id))
+		await tx.delete(game).where(eq(game.id, g.id))
+	})
+
+	heading('Applied — post-state')
+	const gone = await db.query.game.findFirst({ where: eq(game.id, SI_WC_GAME_ID) })
+	console.log(`game lookup after delete: ${gone ? 'STILL EXISTS (!)' : 'not found — deleted'}`)
+	process.exit(0)
+}
+
+main().catch((err) => {
+	console.error('Delete failed:', err)
+	process.exit(1)
+})

--- a/scripts/repair/inspect-wc-repair.ts
+++ b/scripts/repair/inspect-wc-repair.ts
@@ -1,0 +1,166 @@
+/**
+ * Read-only inspector for the two games covered by issue #119.
+ *
+ * Prints the full endgame state of "World Cup LPS" (players, picks by round,
+ * payouts, payments) and the existence + dependent-row census of the
+ * "SI World Cup" husk game. SELECT-only — safe to run against prod at any
+ * time, before or after the repair scripts.
+ *
+ * Usage (prod):
+ *   doppler run --config prd -- pnpm exec tsx scripts/repair/inspect-wc-repair.ts
+ */
+
+import { asc, eq, inArray } from 'drizzle-orm'
+import { db } from '../../src/lib/db'
+import { user } from '../../src/lib/schema/auth'
+import { round, team } from '../../src/lib/schema/competition'
+import { game, gamePlayer, pick, plannedPick } from '../../src/lib/schema/game'
+import { payment, payout } from '../../src/lib/schema/payment'
+import { heading, SI_WC_GAME_ID, WC_LPS_GAME_ID } from './shared'
+
+async function userNames(userIds: string[]): Promise<Map<string, string>> {
+	if (userIds.length === 0) return new Map()
+	const rows = await db
+		.select({ id: user.id, name: user.name })
+		.from(user)
+		.where(inArray(user.id, userIds))
+	return new Map(rows.map((r) => [r.id, r.name]))
+}
+
+async function inspectWcLps(): Promise<void> {
+	heading(`World Cup LPS — ${WC_LPS_GAME_ID}`)
+
+	const g = await db.query.game.findFirst({ where: eq(game.id, WC_LPS_GAME_ID) })
+	if (!g) {
+		console.log('Game NOT FOUND.')
+		return
+	}
+	console.log(
+		`name=${JSON.stringify(g.name)} mode=${g.gameMode} status=${g.status} currentRoundId=${g.currentRoundId}`,
+	)
+
+	const rounds = await db
+		.select()
+		.from(round)
+		.where(eq(round.competitionId, g.competitionId))
+		.orderBy(asc(round.number))
+	const roundById = new Map(rounds.map((r) => [r.id, r]))
+	const roundLabel = (roundId: string | null) => {
+		if (roundId == null) return '—'
+		const r = roundById.get(roundId)
+		return r ? `R${r.number} ${r.name ?? ''}`.trim() : roundId
+	}
+
+	const players = await db.select().from(gamePlayer).where(eq(gamePlayer.gameId, g.id))
+	const names = await userNames(players.map((p) => p.userId))
+
+	console.log(`\nPlayers (${players.length}):`)
+	for (const p of players) {
+		const elim =
+			p.status === 'eliminated'
+				? ` eliminatedIn=${roundLabel(p.eliminatedRoundId)} reason=${p.eliminatedReason}`
+				: ''
+		console.log(`  ${names.get(p.userId) ?? p.userId}: ${p.status}${elim}`)
+	}
+
+	const picks = await db
+		.select({
+			playerId: pick.gamePlayerId,
+			roundId: pick.roundId,
+			result: pick.result,
+			goals: pick.goalsScored,
+			teamShort: team.shortName,
+			createdAt: pick.createdAt,
+		})
+		.from(pick)
+		.innerJoin(team, eq(pick.teamId, team.id))
+		.where(eq(pick.gameId, g.id))
+	const playerById = new Map(players.map((p) => [p.id, p]))
+	const byRound = new Map<string, typeof picks>()
+	for (const p of picks) {
+		const bucket = byRound.get(p.roundId) ?? []
+		bucket.push(p)
+		byRound.set(p.roundId, bucket)
+	}
+	console.log(`\nPicks (${picks.length}):`)
+	for (const r of rounds) {
+		const bucket = byRound.get(r.id)
+		if (!bucket) continue
+		console.log(`  ${roundLabel(r.id)} deadline=${r.deadline?.toISOString() ?? '—'}:`)
+		for (const p of bucket) {
+			const who = playerById.get(p.playerId)
+			const name = who ? (names.get(who.userId) ?? who.userId) : p.playerId
+			console.log(
+				`    ${name}: ${p.teamShort} → ${p.result} (goals=${p.goals ?? '—'}, made=${p.createdAt.toISOString()})`,
+			)
+		}
+	}
+
+	const payouts = await db.select().from(payout).where(eq(payout.gameId, g.id))
+	console.log(`\nPayouts (${payouts.length}):`)
+	for (const p of payouts) {
+		console.log(
+			`  ${names.get(p.userId) ?? p.userId}: £${p.amount} isSplit=${p.isSplit} status=${p.status} id=${p.id}`,
+		)
+	}
+
+	const payments = await db.select().from(payment).where(eq(payment.gameId, g.id))
+	const byStatus = new Map<string, number>()
+	for (const p of payments) byStatus.set(p.status, (byStatus.get(p.status) ?? 0) + 1)
+	console.log(
+		`\nPayments (${payments.length}): ${[...byStatus].map(([s, n]) => `${s}=${n}`).join(' ')}`,
+	)
+}
+
+async function inspectSiWorldCup(): Promise<void> {
+	heading(`SI World Cup — ${SI_WC_GAME_ID}`)
+
+	const g = await db.query.game.findFirst({ where: eq(game.id, SI_WC_GAME_ID) })
+	if (!g) {
+		console.log('Game NOT FOUND (deleted or never existed).')
+		return
+	}
+	console.log(
+		`name=${JSON.stringify(g.name)} mode=${g.gameMode} status=${g.status} createdAt=${g.createdAt.toISOString()}`,
+	)
+
+	const players = await db.select().from(gamePlayer).where(eq(gamePlayer.gameId, g.id))
+	const names = await userNames(players.map((p) => p.userId))
+	const picks = await db.select().from(pick).where(eq(pick.gameId, g.id))
+	const planned =
+		players.length > 0
+			? await db
+					.select()
+					.from(plannedPick)
+					.where(
+						inArray(
+							plannedPick.gamePlayerId,
+							players.map((p) => p.id),
+						),
+					)
+			: []
+	const payments = await db.select().from(payment).where(eq(payment.gameId, g.id))
+	const payouts = await db.select().from(payout).where(eq(payout.gameId, g.id))
+
+	console.log(
+		`Dependent rows: players=${players.length} picks=${picks.length} plannedPicks=${planned.length} payments=${payments.length} payouts=${payouts.length}`,
+	)
+	for (const p of players) {
+		console.log(`  player: ${names.get(p.userId) ?? p.userId} status=${p.status}`)
+	}
+	for (const p of payments) {
+		console.log(`  payment: ${names.get(p.userId) ?? p.userId} £${p.amount} status=${p.status}`)
+	}
+}
+
+async function main() {
+	await inspectWcLps()
+	await inspectSiWorldCup()
+	console.log()
+	process.exit(0)
+}
+
+main().catch((err) => {
+	console.error('Inspect failed:', err)
+	process.exit(1)
+})

--- a/scripts/repair/repair-wc-lps-endgame.ts
+++ b/scripts/repair/repair-wc-lps-endgame.ts
@@ -13,7 +13,10 @@
  *   3. Flips the pickless finalist from winner to eliminated in the final
  *      round (reason: no_pick_no_fallback) — they had no legal pick left.
  *   4. Deletes both £80 split payout rows and creates a single £160
- *      non-split payout for the sole remaining winner.
+ *      non-split payout for the sole remaining winner. ("Void" from the
+ *      ticket is implemented as delete + replace: the payout table has no
+ *      voided status, and the acceptance criteria require that no split
+ *      payout rows remain.)
  *
  * All pick rows are preserved; only the one stuck pick's result changes.
  * Targets are found structurally (the pending pick, the winner without a
@@ -36,6 +39,8 @@ import { fail, heading, toPence, toPounds, WC_LPS_GAME_ID, WC_LPS_GAME_NAME } fr
 
 const EXPECTED_STUCK_TEAM_SHORT = 'COL'
 const EXPECTED_SPLIT_PAYOUT_PENCE = 8000 // £80.00 each
+
+type PickRow = typeof pick.$inferSelect
 
 async function userName(userId: string): Promise<string> {
 	const row = await db.query.user.findFirst({ where: eq(user.id, userId) })
@@ -142,7 +147,7 @@ async function main() {
 		.where(and(eq(gamePlayer.gameId, g.id), eq(gamePlayer.status, 'winner')))
 	if (winners.length !== 2) fail(`expected exactly 2 winners, found ${winners.length}`)
 
-	const finalPicksByWinner = new Map<string, (typeof pendingPicks)[number][]>()
+	const finalPicksByWinner = new Map<string, PickRow[]>()
 	for (const w of winners) {
 		finalPicksByWinner.set(
 			w.id,

--- a/scripts/repair/repair-wc-lps-endgame.ts
+++ b/scripts/repair/repair-wc-lps-endgame.ts
@@ -1,0 +1,266 @@
+/**
+ * One-off prod repair: "World Cup LPS" (classic) endgame record correction.
+ * Issue #119 / parent #112 — both outcomes confirmed as deliberate rules
+ * calls by the game owner.
+ *
+ * What it does (all-or-nothing, single transaction):
+ *   1. Resolves the stuck Round-of-16 pick (left `pending` on a finished,
+ *      decided fixture) as a loss — mirroring settleClassicPickRow: result
+ *      via determinePickResult (fixture `winner` authoritative), goals 0.
+ *   2. Moves that player's elimination from the quarter-final round to the
+ *      Round of 16 (reason: loss). Their post-deadline quarter-final pick
+ *      row is kept untouched, as history.
+ *   3. Flips the pickless finalist from winner to eliminated in the final
+ *      round (reason: no_pick_no_fallback) — they had no legal pick left.
+ *   4. Deletes both £80 split payout rows and creates a single £160
+ *      non-split payout for the sole remaining winner.
+ *
+ * All pick rows are preserved; only the one stuck pick's result changes.
+ * Targets are found structurally (the pending pick, the winner without a
+ * final-round pick) — never by hardcoded user ids — and every expectation
+ * about the current state is asserted before anything is written.
+ *
+ * Usage (prod):
+ *   dry run: doppler run --config prd -- pnpm exec tsx scripts/repair/repair-wc-lps-endgame.ts
+ *   apply:   doppler run --config prd -- pnpm exec tsx scripts/repair/repair-wc-lps-endgame.ts --apply
+ */
+
+import { and, asc, eq } from 'drizzle-orm'
+import { db } from '../../src/lib/db'
+import { determinePickResult } from '../../src/lib/game-logic/common'
+import { user } from '../../src/lib/schema/auth'
+import { fixture, round, team } from '../../src/lib/schema/competition'
+import { game, gamePlayer, pick } from '../../src/lib/schema/game'
+import { payout } from '../../src/lib/schema/payment'
+import { fail, heading, toPence, toPounds, WC_LPS_GAME_ID, WC_LPS_GAME_NAME } from './shared'
+
+const EXPECTED_STUCK_TEAM_SHORT = 'COL'
+const EXPECTED_SPLIT_PAYOUT_PENCE = 8000 // £80.00 each
+
+async function userName(userId: string): Promise<string> {
+	const row = await db.query.user.findFirst({ where: eq(user.id, userId) })
+	return row?.name ?? userId
+}
+
+async function main() {
+	const apply = process.argv.includes('--apply')
+
+	heading(`Repair: ${WC_LPS_GAME_NAME} endgame — ${apply ? 'APPLY' : 'DRY RUN'}`)
+
+	// ── Game ──────────────────────────────────────────────────────────────
+	const g = await db.query.game.findFirst({ where: eq(game.id, WC_LPS_GAME_ID) })
+	if (!g) fail(`game ${WC_LPS_GAME_ID} not found`)
+	if (g.name !== WC_LPS_GAME_NAME) {
+		fail(`game name is ${JSON.stringify(g.name)}, expected ${JSON.stringify(WC_LPS_GAME_NAME)}`)
+	}
+	if (g.gameMode !== 'classic') fail(`game mode is ${g.gameMode}, expected classic`)
+	if (g.status !== 'completed') fail(`game status is ${g.status}, expected completed`)
+
+	const rounds = await db
+		.select()
+		.from(round)
+		.where(eq(round.competitionId, g.competitionId))
+		.orderBy(asc(round.number))
+	if (rounds.length === 0) fail('no rounds found for competition')
+	const finalRound = rounds[rounds.length - 1]
+	if (finalRound.name !== 'Final') {
+		fail(
+			`last round (R${finalRound.number}) is named ${JSON.stringify(finalRound.name)}, expected "Final"`,
+		)
+	}
+
+	// ── 1. The stuck pick ─────────────────────────────────────────────────
+	const pendingPicks = await db
+		.select()
+		.from(pick)
+		.where(and(eq(pick.gameId, g.id), eq(pick.result, 'pending')))
+	if (pendingPicks.length !== 1) {
+		fail(`expected exactly 1 pending pick, found ${pendingPicks.length}`)
+	}
+	const stuckPick = pendingPicks[0]
+
+	const r16 = rounds.find((r) => r.id === stuckPick.roundId)
+	if (!r16) fail(`stuck pick round ${stuckPick.roundId} not in competition rounds`)
+	if (r16.name !== 'Round of 16') {
+		fail(`stuck pick is in R${r16.number} ${JSON.stringify(r16.name)}, expected "Round of 16"`)
+	}
+
+	const stuckTeam = await db.query.team.findFirst({ where: eq(team.id, stuckPick.teamId) })
+	if (!stuckTeam) fail(`stuck pick team ${stuckPick.teamId} not found`)
+	if (stuckTeam.shortName !== EXPECTED_STUCK_TEAM_SHORT) {
+		fail(`stuck pick team is ${stuckTeam.shortName}, expected ${EXPECTED_STUCK_TEAM_SHORT}`)
+	}
+
+	if (stuckPick.fixtureId == null) fail('stuck pick has no fixtureId')
+	const fx = await db.query.fixture.findFirst({ where: eq(fixture.id, stuckPick.fixtureId) })
+	if (!fx) fail(`stuck pick fixture ${stuckPick.fixtureId} not found`)
+	if (fx.status !== 'finished') fail(`stuck pick fixture status is ${fx.status}, expected finished`)
+	if (fx.homeScore == null || fx.awayScore == null) fail('stuck pick fixture has no score')
+
+	// Mirror settleClassicPickRow: `winner` is authoritative for knockout ties.
+	const resolvedResult = determinePickResult({
+		pickedTeamId: stuckPick.teamId,
+		homeTeamId: fx.homeTeamId,
+		awayTeamId: fx.awayTeamId,
+		homeScore: fx.homeScore,
+		awayScore: fx.awayScore,
+		winner: fx.winner,
+	})
+	if (resolvedResult !== 'loss') {
+		fail(
+			`fixture ${fx.homeScore}-${fx.awayScore} (winner=${fx.winner}) resolves the pick as ${resolvedResult}, expected loss`,
+		)
+	}
+
+	// ── 2. The stuck player's elimination round ───────────────────────────
+	const stuckPlayer = await db.query.gamePlayer.findFirst({
+		where: eq(gamePlayer.id, stuckPick.gamePlayerId),
+	})
+	if (!stuckPlayer) fail(`game player ${stuckPick.gamePlayerId} not found`)
+	if (stuckPlayer.status !== 'eliminated') {
+		fail(`stuck-pick player status is ${stuckPlayer.status}, expected eliminated`)
+	}
+	const currentElimRound = rounds.find((r) => r.id === stuckPlayer.eliminatedRoundId)
+	if (!currentElimRound || currentElimRound.name !== 'Quarter-finals') {
+		fail(
+			`stuck-pick player is eliminated in ${currentElimRound ? `R${currentElimRound.number} ${JSON.stringify(currentElimRound.name)}` : 'no round'}, expected "Quarter-finals"`,
+		)
+	}
+	const qfHistoryPicks = await db
+		.select()
+		.from(pick)
+		.where(and(eq(pick.gamePlayerId, stuckPlayer.id), eq(pick.roundId, currentElimRound.id)))
+	if (qfHistoryPicks.length === 0) {
+		fail('expected the post-deadline quarter-final pick row (kept as history) to exist')
+	}
+	const stuckPlayerName = await userName(stuckPlayer.userId)
+
+	// ── 3. The two crowned winners ────────────────────────────────────────
+	const winners = await db
+		.select()
+		.from(gamePlayer)
+		.where(and(eq(gamePlayer.gameId, g.id), eq(gamePlayer.status, 'winner')))
+	if (winners.length !== 2) fail(`expected exactly 2 winners, found ${winners.length}`)
+
+	const finalPicksByWinner = new Map<string, (typeof pendingPicks)[number][]>()
+	for (const w of winners) {
+		finalPicksByWinner.set(
+			w.id,
+			await db
+				.select()
+				.from(pick)
+				.where(and(eq(pick.gamePlayerId, w.id), eq(pick.roundId, finalRound.id))),
+		)
+	}
+	const pickless = winners.filter((w) => (finalPicksByWinner.get(w.id) ?? []).length === 0)
+	if (pickless.length !== 1) {
+		fail(`expected exactly 1 winner with no final-round pick, found ${pickless.length}`)
+	}
+	const picklessFinalist = pickless[0]
+	const soleWinner = winners.find((w) => w.id !== picklessFinalist.id)
+	if (!soleWinner) fail('unreachable: two winners but no sole winner')
+	const soleWinnerFinalPicks = finalPicksByWinner.get(soleWinner.id) ?? []
+	if (soleWinnerFinalPicks.length !== 1 || soleWinnerFinalPicks[0].result !== 'win') {
+		fail(
+			`expected the sole winner to have exactly 1 winning final-round pick, found ${soleWinnerFinalPicks.map((p) => p.result).join(', ') || 'none'}`,
+		)
+	}
+	const picklessName = await userName(picklessFinalist.userId)
+	const soleWinnerName = await userName(soleWinner.userId)
+
+	// ── 4. The split payouts ──────────────────────────────────────────────
+	const payouts = await db.select().from(payout).where(eq(payout.gameId, g.id))
+	if (payouts.length !== 2) fail(`expected exactly 2 payout rows, found ${payouts.length}`)
+	for (const p of payouts) {
+		if (!p.isSplit) fail(`payout ${p.id} (£${p.amount}) is not a split payout`)
+		if (toPence(p.amount) !== EXPECTED_SPLIT_PAYOUT_PENCE) {
+			fail(`payout ${p.id} is £${p.amount}, expected £${toPounds(EXPECTED_SPLIT_PAYOUT_PENCE)}`)
+		}
+	}
+	const payoutUserIds = new Set(payouts.map((p) => p.userId))
+	const winnerUserIds = new Set(winners.map((w) => w.userId))
+	if (payoutUserIds.size !== 2 || [...payoutUserIds].some((userId) => !winnerUserIds.has(userId))) {
+		fail('payout user ids do not match the two crowned winners')
+	}
+	if (payouts[0].status !== payouts[1].status) {
+		fail(`split payouts disagree on status (${payouts[0].status} vs ${payouts[1].status})`)
+	}
+	const newPayoutStatus = payouts[0].status
+	const newPayoutPence = payouts.reduce((sum, p) => sum + toPence(p.amount), 0)
+
+	// ── Intended mutations ────────────────────────────────────────────────
+	heading('Intended mutations')
+	console.log(
+		`1. pick ${stuckPick.id} (${stuckPlayerName}, ${stuckTeam.shortName}, R${r16.number} ${r16.name}):\n` +
+			`     result pending → loss, goalsScored ${stuckPick.goalsScored ?? 'null'} → 0\n` +
+			`     (fixture ${fx.homeScore}-${fx.awayScore}, winner=${fx.winner ?? 'score-decided'})`,
+	)
+	console.log(
+		`2. game_player ${stuckPlayer.id} (${stuckPlayerName}):\n` +
+			`     eliminatedRound R${currentElimRound.number} ${currentElimRound.name} → R${r16.number} ${r16.name}, reason ${stuckPlayer.eliminatedReason} → loss\n` +
+			`     (their R${currentElimRound.number} pick row${qfHistoryPicks.length > 1 ? 's' : ''} kept untouched as history)`,
+	)
+	console.log(
+		`3. game_player ${picklessFinalist.id} (${picklessName}):\n` +
+			`     status winner → eliminated, eliminatedRound → R${finalRound.number} ${finalRound.name}, reason → no_pick_no_fallback`,
+	)
+	for (const p of payouts) {
+		console.log(`4. DELETE payout ${p.id}: £${p.amount} split → ${await userName(p.userId)}`)
+	}
+	console.log(
+		`5. INSERT payout: £${toPounds(newPayoutPence)} non-split → ${soleWinnerName} (status=${newPayoutStatus})`,
+	)
+
+	if (!apply) {
+		console.log('\nDRY RUN — nothing written. Re-run with --apply to commit.')
+		process.exit(0)
+	}
+
+	// ── Apply ─────────────────────────────────────────────────────────────
+	await db.transaction(async (tx) => {
+		await tx.update(pick).set({ result: 'loss', goalsScored: 0 }).where(eq(pick.id, stuckPick.id))
+		await tx
+			.update(gamePlayer)
+			.set({ eliminatedRoundId: r16.id, eliminatedReason: 'loss' })
+			.where(eq(gamePlayer.id, stuckPlayer.id))
+		await tx
+			.update(gamePlayer)
+			.set({
+				status: 'eliminated',
+				eliminatedRoundId: finalRound.id,
+				eliminatedReason: 'no_pick_no_fallback',
+			})
+			.where(eq(gamePlayer.id, picklessFinalist.id))
+		for (const p of payouts) {
+			await tx.delete(payout).where(eq(payout.id, p.id))
+		}
+		await tx.insert(payout).values({
+			gameId: g.id,
+			userId: soleWinner.userId,
+			amount: toPounds(newPayoutPence),
+			isSplit: false,
+			status: newPayoutStatus,
+		})
+	})
+
+	// ── Post-apply verification ───────────────────────────────────────────
+	heading('Applied — post-state')
+	const winnersAfter = await db
+		.select()
+		.from(gamePlayer)
+		.where(and(eq(gamePlayer.gameId, g.id), eq(gamePlayer.status, 'winner')))
+	const payoutsAfter = await db.select().from(payout).where(eq(payout.gameId, g.id))
+	const pickAfter = await db.query.pick.findFirst({ where: eq(pick.id, stuckPick.id) })
+	console.log(`winners: ${winnersAfter.length} (expect 1)`)
+	console.log(
+		`payouts: ${payoutsAfter.map((p) => `£${p.amount} isSplit=${p.isSplit}`).join(', ')} (expect one £${toPounds(newPayoutPence)} isSplit=false)`,
+	)
+	console.log(`stuck pick result: ${pickAfter?.result} (expect loss)`)
+	console.log('\nRun scripts/repair/inspect-wc-repair.ts for the full corrected record.')
+	process.exit(0)
+}
+
+main().catch((err) => {
+	console.error('Repair failed:', err)
+	process.exit(1)
+})

--- a/scripts/repair/shared.ts
+++ b/scripts/repair/shared.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared constants + helpers for the issue #119 one-off prod repair scripts.
+ *
+ * Convention (established incident-repair pattern): every mutating script is
+ * dry-run by default and only writes with an explicit `--apply` flag. All
+ * preconditions are asserted against live data before anything is printed as
+ * an intended mutation; any drift from the expected state aborts loudly.
+ */
+
+export const WC_LPS_GAME_ID = 'dc857c5f-8a07-4c3b-aeef-71d9883a218e'
+export const WC_LPS_GAME_NAME = 'World Cup LPS'
+
+export const SI_WC_GAME_ID = '55747598-5ef3-42c3-9635-ae5f531e3db3'
+export const SI_WC_GAME_NAME = 'SI World Cup'
+
+/** Parse a numeric-string money amount (e.g. '80.00') into integer pence. */
+export function toPence(amount: string): number {
+	const parsed = Number(amount)
+	if (!Number.isFinite(parsed)) {
+		fail(`unparseable money amount: ${JSON.stringify(amount)}`)
+	}
+	return Math.round(parsed * 100)
+}
+
+/** Format integer pence back into the DB's numeric-string form. */
+export function toPounds(pence: number): string {
+	return (pence / 100).toFixed(2)
+}
+
+/** Abort loudly: preconditions are hard gates, not warnings. */
+export function fail(message: string): never {
+	console.error(`\n✖ PRECONDITION FAILED: ${message}`)
+	console.error('No changes have been written. Fix the drift (or the script) and re-run.')
+	process.exit(1)
+}
+
+export function heading(title: string): void {
+	console.log(`\n${'─'.repeat(72)}\n${title}\n${'─'.repeat(72)}`)
+}


### PR DESCRIPTION
Closes #119

Two one-off prod repair scripts (dry-run by default, `--apply` to commit), a read-only inspector to verify them, and a committed runbook for the sign-off human. **No `--apply` has been run — prod is untouched.** Per the ticket, a human runs the applies.

## What's in the branch

| File | Purpose |
|---|---|
| `scripts/repair/inspect-wc-repair.ts` | SELECT-only census of both games — run before and after |
| `scripts/repair/repair-wc-lps-endgame.ts` | (a) World Cup LPS record correction |
| `scripts/repair/delete-si-world-cup.ts` | (b) SI World Cup husk deletion |
| `scripts/repair/README.md` | Human runbook: apply order, expected post-apply state, authenticated SSR page-check recipe |
| `scripts/repair/shared.ts` | Game ids + money/fail helpers shared by the three scripts |

Both mutating scripts find their targets **structurally** (the one pending pick; the crowned winner with no final-round pick) rather than by hardcoded user ids, assert every expectation about current prod state as a hard precondition (any drift aborts with no writes), and apply all mutations in a single transaction. The stuck pick is resolved exactly as `settleClassicPickRow` would have: `determinePickResult` with the fixture `winner` column authoritative, `goalsScored = 0` on a loss. "Void the split payouts" is implemented as delete + replace — the payout table has no voided status and the acceptance criteria require no split rows remain.

## Dry-run evidence (prod, 2026-08-02)

### Inspector — current state (relevant excerpts)

```
World Cup LPS — dc857c5f-8a07-4c3b-aeef-71d9883a218e
name="World Cup LPS" mode=classic status=completed currentRoundId=null
  Barry George : winner
  Mark Edworthy: winner
  Sean Lennon: eliminated eliminatedIn=R6 Quarter-finals reason=loss
  R5 Round of 16:
    Sean Lennon: COL → pending (goals=—, made=2026-07-04T07:25:56.567Z)
  R6 Quarter-finals deadline=2026-07-09T18:30:00.000Z:
    Sean Lennon: NOR → loss (goals=0, made=2026-07-10T07:34:05.085Z)   ← post-deadline, kept as history
  R8 Final:
    Mark Edworthy: ESP → win (goals=1)          ← Barry George has no final pick
Payouts (2):
  Barry George : £80.00 isSplit=true status=pending
  Mark Edworthy: £80.00 isSplit=true status=pending
Picks (62)   Payments (16): paid=16

SI World Cup — 55747598-5ef3-42c3-9635-ae5f531e3db3
name="SI World Cup" mode=classic status=active
Dependent rows: players=1 picks=0 plannedPicks=0 payments=1 payouts=0
  payment: £10.00 status=pending
```

### Repair (a) dry run — all preconditions pass

```
1. pick eb316c83-c0eb-4a92-b183-d01137e5e5a6 (Sean Lennon, COL, R5 Round of 16):
     result pending → loss, goalsScored null → 0
     (fixture 4-3, winner=home)
2. game_player 92c5d8c5-3802-4bea-ab32-01ab5255d7d1 (Sean Lennon):
     eliminatedRound R6 Quarter-finals → R5 Round of 16, reason loss → loss
     (their R6 pick row kept untouched as history)
3. game_player 24aa63ca-3f56-4f36-bc98-5b5d2fa6c8b3 (Barry George ):
     status winner → eliminated, eliminatedRound → R8 Final, reason → no_pick_no_fallback
4. DELETE payout b4284dfb-692d-4633-8c4e-5c2ef5fe7474: £80.00 split → Barry George
4. DELETE payout 0728832f-1372-4f5d-a725-452c3f10edfc: £80.00 split → Mark Edworthy
5. INSERT payout: £160.00 non-split → Mark Edworthy (status=pending)

DRY RUN — nothing written. Re-run with --apply to commit.
```

### Repair (b) dry run — all preconditions pass

```
game 55747598-5ef3-42c3-9635-ae5f531e3db3: "SI World Cup" (classic, active)
payment 1a13ce08-5eda-42e3-97cd-2be4920a8cd4: £10.00 pending
game_player 9b01a578-825d-4fc0-905d-1a1a9ece4985: (eliminated)
(the user account itself is untouched — only this game and its rows go)

DRY RUN — nothing written. Re-run with --apply to commit.
```

## Human sign-off steps

Follow `scripts/repair/README.md`: dry-run → `--apply` for each script, re-run the inspector against the acceptance criteria, then the authenticated SSR page check on the corrected game. Post-apply state is reconcile-safe: `reconcileGameState` no-ops on non-active games, so nothing will "self-heal" the correction away.

## Self-review notes (two-axis /code-review vs origin/main)

Acted on: committed the human runbook incl. the SSR page-check recipe (spec axis flagged the post-apply verification path as undocumented); documented void = delete + replace in the script header; honest `PickRow` type alias. Disagreed with one standards finding, noting here rather than fixing: `toPence` round-trips the numeric string through a double (`Math.round(Number(a) * 100)`), which the reviewer felt clashes with the "numeric columns are strings for arbitrary precision" convention — at the asserted magnitudes (£80.00 exactly, else the script aborts) the double round-trip is provably exact, and string-splitting arithmetic would add parsing code to a one-off with no added safety. Also left as-is (deliberate for one-off ops scripts): minor duplication of the `--apply` parse / error trailer across the three scripts.

Validation: `tsc --noEmit` clean, Biome clean, unit suite 635/635 green. Ops scripts are not vitest-tested per the parent spec's testing decisions; their verification path is the dry-run evidence above plus the post-apply inspector re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
