### PR TITLE
Automatic season detection and rollover (fd currentSeason + FPL cross-check)

### DIFF
--- a/scripts/bootstrap-competitions.ts
+++ b/scripts/bootstrap-competitions.ts
@@ -3,7 +3,10 @@ import { bootstrapCompetitions } from '../src/lib/game/bootstrap-competitions'
 async function main() {
 	const apiKey = process.env.FOOTBALL_DATA_API_KEY
 	if (!apiKey) {
-		console.warn('FOOTBALL_DATA_API_KEY not set — WC competition will be created but not synced')
+		console.error(
+			'FOOTBALL_DATA_API_KEY not set — season detection needs football-data currentSeason; aborting',
+		)
+		process.exit(1)
 	}
 	await bootstrapCompetitions({ footballDataApiKey: apiKey })
 	console.log('Bootstrap complete')

--- a/scripts/smoke/lifecycle.smoke.test.ts
+++ b/scripts/smoke/lifecycle.smoke.test.ts
@@ -20,7 +20,12 @@
 import { and, eq, inArray } from 'drizzle-orm'
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { db } from '@/lib/db'
-import { mergeFootballDataIds, syncCompetition } from '@/lib/game/bootstrap-competitions'
+import {
+	ensureCurrentPlSeasonCompetition,
+	mergeFootballDataIds,
+	SeasonDetectionError,
+	syncCompetition,
+} from '@/lib/game/bootstrap-competitions'
 import { getCupLadderData, getCupStandingsData } from '@/lib/game/cup-standings-queries'
 import {
 	getLivePayload,
@@ -2612,6 +2617,190 @@ describe('lifecycle: PL season rollover sync identity', () => {
 			const after = teams.find((t) => t.name === name)
 			expect(after).toEqual(before)
 		}
+	})
+})
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* PL season rollover: automatic detection + competition archival          */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe('lifecycle: PL season rollover auto-detection', () => {
+	// Two seasons of pre-fetched FPL payloads. Season 2 relegates Cedar/Dorne,
+	// promotes Grove/Holt, and — the FPL trap — restarts fixture and team ids.
+	const S1_CLUBS = [
+		{ id: 1, name: 'Alder FC', short_name: 'ALD', code: 11 },
+		{ id: 2, name: 'Birch FC', short_name: 'BIR', code: 12 },
+		{ id: 3, name: 'Cedar FC', short_name: 'CED', code: 13 },
+		{ id: 4, name: 'Dorne FC', short_name: 'DOR', code: 14 },
+	]
+	const S2_CLUBS = [
+		{ id: 1, name: 'Alder FC', short_name: 'ALD', code: 11 },
+		{ id: 2, name: 'Birch FC', short_name: 'BIR', code: 12 },
+		{ id: 3, name: 'Grove FC', short_name: 'GRO', code: 24 },
+		{ id: 4, name: 'Holt FC', short_name: 'HOL', code: 25 },
+	]
+
+	const fplPayload = (clubs: typeof S1_CLUBS, gw1Deadline: string, kickoffs: [string, string]) => ({
+		bootstrap: {
+			teams: clubs,
+			events: [{ id: 1, name: 'Gameweek 1', deadline_time: gw1Deadline, finished: false }],
+		},
+		fixtures: [
+			{ id: 1, team_h: 1, team_a: 3, kickoff_time: kickoffs[0] },
+			{ id: 2, team_h: 2, team_a: 4, kickoff_time: kickoffs[1] },
+		].map((f) => ({
+			...f,
+			event: 1,
+			started: false,
+			finished: false,
+			finished_provisional: false,
+			team_h_score: null,
+			team_a_score: null,
+		})),
+	})
+
+	// FPL still on 2025/26 (GW1 deadline in 2025)…
+	const S1_FPL = fplPayload(S1_CLUBS, '2025-08-15T17:30:00Z', [
+		'2025-08-16T14:00:00Z',
+		'2025-08-16T16:30:00Z',
+	])
+	// …and the 2026/27 payload after the sources flip.
+	const S2_FPL = fplPayload(S2_CLUBS, '2026-08-21T17:30:00Z', [
+		'2026-08-22T14:00:00Z',
+		'2026-08-22T16:30:00Z',
+	])
+
+	/** Serve football-data's competition-detail endpoint (season detection). */
+	function mockFdCurrentSeason(currentSeason: { startDate: string; endDate: string } | null) {
+		vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+			const s = typeof url === 'string' ? url : url.toString()
+			if (s.endsWith('/competitions/PL'))
+				return Promise.resolve(new Response(JSON.stringify({ currentSeason })))
+			return Promise.resolve(new Response('Not found', { status: 404 }))
+		})
+	}
+
+	async function seedPredecessor(): Promise<typeof competition.$inferSelect> {
+		const [c] = await db
+			.insert(competition)
+			.values({
+				name: 'Premier League 2025/26',
+				type: 'league',
+				dataSource: 'fpl',
+				season: '2025/26',
+				status: 'active',
+			})
+			.returning()
+		return c
+	}
+
+	const compRounds = (competitionId: string) =>
+		db.select().from(roundTable).where(eq(roundTable.competitionId, competitionId))
+	const roundFixtures = (roundIds: string[]) =>
+		roundIds.length === 0
+			? Promise.resolve([])
+			: db.select().from(fixtureTable).where(inArray(fixtureTable.roundId, roundIds))
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('rolls over: creates "Premier League 2026/27", archives the predecessor, and populates the new competition only', async () => {
+		const predecessor = await seedPredecessor()
+		await syncCompetition(predecessor, { fplData: S1_FPL })
+		const s1Rounds = await compRounds(predecessor.id)
+		const s1Fixtures = await roundFixtures(s1Rounds.map((r) => r.id))
+		expect(s1Fixtures).toHaveLength(2)
+
+		mockFdCurrentSeason({ startDate: '2026-08-14', endDate: '2027-05-23' })
+		const current = await ensureCurrentPlSeasonCompetition({
+			footballDataApiKey: 'test-key',
+			fplData: S2_FPL,
+		})
+
+		expect(current.name).toBe('Premier League 2026/27')
+		expect(current.season).toBe('2026/27')
+		expect(current.status).toBe('active')
+		expect(current.id).not.toBe(predecessor.id)
+
+		const archived = await db.query.competition.findFirst({
+			where: eq(competition.id, predecessor.id),
+		})
+		expect(archived?.status).toBe('archived')
+
+		// The sync lands rounds/fixtures/teams on the NEW competition only.
+		await syncCompetition(current, { fplData: S2_FPL })
+		const s2Rounds = await compRounds(current.id)
+		expect(s2Rounds).toHaveLength(1)
+		const s2Fixtures = await roundFixtures(s2Rounds.map((r) => r.id))
+		expect(s2Fixtures).toHaveLength(2)
+		const teams = await db.select().from(teamTable)
+		expect(teams.map((t) => t.name).sort()).toEqual([
+			'Alder FC',
+			'Birch FC',
+			'Cedar FC',
+			'Dorne FC',
+			'Grove FC',
+			'Holt FC',
+		])
+
+		// The archived predecessor's rows are byte-for-byte untouched.
+		expect(await compRounds(predecessor.id)).toEqual(s1Rounds)
+		expect(await roundFixtures(s1Rounds.map((r) => r.id))).toEqual(s1Fixtures)
+	})
+
+	it('re-running the sync after rollover is idempotent — no duplicate competitions', async () => {
+		const predecessor = await seedPredecessor()
+		mockFdCurrentSeason({ startDate: '2026-08-14', endDate: '2027-05-23' })
+
+		const first = await ensureCurrentPlSeasonCompetition({
+			footballDataApiKey: 'test-key',
+			fplData: S2_FPL,
+		})
+		await syncCompetition(first, { fplData: S2_FPL })
+
+		const again = await ensureCurrentPlSeasonCompetition({
+			footballDataApiKey: 'test-key',
+			fplData: S2_FPL,
+		})
+		await syncCompetition(again, { fplData: S2_FPL })
+
+		expect(again.id).toBe(first.id)
+		const fplComps = await db.select().from(competition).where(eq(competition.dataSource, 'fpl'))
+		expect(fplComps).toHaveLength(2) // predecessor + current, nothing else
+		expect(fplComps.find((c) => c.id === predecessor.id)?.status).toBe('archived')
+		expect(fplComps.filter((c) => c.season === '2026/27')).toHaveLength(1)
+		// Re-sync did not duplicate rounds or fixtures either.
+		const rounds = await compRounds(first.id)
+		expect(rounds).toHaveLength(1)
+		expect(await roundFixtures(rounds.map((r) => r.id))).toHaveLength(2)
+	})
+
+	it('a source season disagreement aborts loudly with no writes', async () => {
+		const predecessor = await seedPredecessor()
+		// football-data has flipped to 2026/27 but FPL still serves 2025/26.
+		mockFdCurrentSeason({ startDate: '2026-08-14', endDate: '2027-05-23' })
+
+		await expect(
+			ensureCurrentPlSeasonCompetition({ footballDataApiKey: 'test-key', fplData: S1_FPL }),
+		).rejects.toThrow(SeasonDetectionError)
+
+		const comps = await db.select().from(competition)
+		expect(comps).toEqual([predecessor]) // untouched: still active, still alone
+		expect(await db.select().from(roundTable)).toHaveLength(0)
+		expect(await db.select().from(teamTable)).toHaveLength(0)
+	})
+
+	it('a missing football-data currentSeason aborts loudly with no writes', async () => {
+		const predecessor = await seedPredecessor()
+		mockFdCurrentSeason(null)
+
+		await expect(
+			ensureCurrentPlSeasonCompetition({ footballDataApiKey: 'test-key', fplData: S2_FPL }),
+		).rejects.toThrow(SeasonDetectionError)
+
+		const comps = await db.select().from(competition)
+		expect(comps).toEqual([predecessor])
 	})
 })
 

--- a/src/app/api/cron/daily-sync/route.test.ts
+++ b/src/app/api/cron/daily-sync/route.test.ts
@@ -21,6 +21,12 @@ vi.mock('@/lib/game/bootstrap-competitions', () => ({
 	}),
 	mergeFootballDataIds: vi.fn().mockResolvedValue(undefined),
 	scheduleUpcomingFixturePolls: vi.fn().mockResolvedValue(undefined),
+	ensureCurrentPlSeasonCompetition: vi.fn().mockResolvedValue({
+		id: 'c-pl',
+		dataSource: 'fpl',
+		season: '2026/27',
+		status: 'active',
+	}),
 }))
 
 vi.mock('@/lib/game/no-pick-handler', () => ({
@@ -44,7 +50,10 @@ vi.mock('@/lib/game/reconcile', () => ({
 }))
 
 import { db } from '@/lib/db'
-import { syncCompetition } from '@/lib/game/bootstrap-competitions'
+import {
+	ensureCurrentPlSeasonCompetition,
+	syncCompetition,
+} from '@/lib/game/bootstrap-competitions'
 import { processDeadlineLock } from '@/lib/game/no-pick-handler'
 import { openRoundForGame } from '@/lib/game/round-lifecycle'
 import { POST } from './route'
@@ -55,6 +64,55 @@ describe('daily-sync route', () => {
 		cronRunInsertValues.mockClear()
 		cronRunInsertValues.mockResolvedValue(undefined)
 		process.env.CRON_SECRET = 'test-secret'
+		process.env.FOOTBALL_DATA_API_KEY = 'fd-test-key'
+		vi.mocked(ensureCurrentPlSeasonCompetition).mockResolvedValue({
+			id: 'c-pl',
+			dataSource: 'fpl',
+			season: '2026/27',
+			status: 'active',
+		} as never)
+	})
+
+	it('runs season detection/rollover with the pre-fetched payload before syncing anything', async () => {
+		vi.mocked(db.query.competition.findMany).mockResolvedValue([{ id: 'c1' }] as never)
+		const fplPayload = { bootstrap: { teams: [], events: [] }, fixtures: [] }
+		await POST(
+			new Request('http://x', {
+				method: 'POST',
+				headers: {
+					authorization: 'Bearer test-secret',
+					'content-type': 'application/json',
+				},
+				body: JSON.stringify({ fpl: fplPayload }),
+			}),
+		)
+		expect(ensureCurrentPlSeasonCompetition).toHaveBeenCalledWith({
+			footballDataApiKey: 'fd-test-key',
+			fplData: fplPayload,
+		})
+		// Detection must complete before the first competition sync — a season
+		// failure has to abort the run with zero sync writes.
+		expect(vi.mocked(ensureCurrentPlSeasonCompetition).mock.invocationCallOrder[0]).toBeLessThan(
+			vi.mocked(syncCompetition).mock.invocationCallOrder[0],
+		)
+	})
+
+	it('aborts the whole run — no competition syncs — when season detection fails', async () => {
+		vi.mocked(db.query.competition.findMany).mockResolvedValue([{ id: 'c1' }] as never)
+		vi.mocked(ensureCurrentPlSeasonCompetition).mockRejectedValue(
+			new Error('season disagreement: football-data says 2026 but FPL says 2025'),
+		)
+		const res = await POST(
+			new Request('http://x', {
+				method: 'POST',
+				headers: { authorization: 'Bearer test-secret' },
+			}),
+		)
+		expect(res.status).toBe(500)
+		const body = (await res.json()) as { error: { message: string } }
+		expect(body.error.message).toContain('season disagreement')
+		expect(syncCompetition).not.toHaveBeenCalled()
+		expect(cronRunInsertValues.mock.calls[0][0]).toMatchObject({ status: 'failure' })
 	})
 
 	it('records a success cron_run when the body completes', async () => {

--- a/src/app/api/cron/daily-sync/route.ts
+++ b/src/app/api/cron/daily-sync/route.ts
@@ -5,6 +5,7 @@ import type { FplPreFetched } from '@/lib/data/fpl'
 import { db } from '@/lib/db'
 import {
 	applyPotAssignments,
+	ensureCurrentPlSeasonCompetition,
 	mergeFootballDataIds,
 	scheduleUpcomingFixturePolls,
 	syncCompetition,
@@ -40,6 +41,14 @@ export async function POST(request: Request) {
 	try {
 		const body = await readJsonBody(request)
 		const apiKey = process.env.FOOTBALL_DATA_API_KEY
+		// Season detection + rollover runs BEFORE any sync writes: it derives the
+		// current PL season from football-data's currentSeason cross-checked
+		// against FPL's GW1 deadline, creating the new-season competition and
+		// archiving the predecessor when the sources flip in August. A detection
+		// failure (missing data, source disagreement) throws — the run aborts
+		// with zero writes, a failed cron_run, and a red Actions job. It never
+		// guesses a season.
+		await ensureCurrentPlSeasonCompetition({ footballDataApiKey: apiKey, fplData: body.fpl })
 		const comps = await db.query.competition.findMany({
 			where: eq(competition.status, 'active'),
 		})

--- a/src/lib/data/football-data.test.ts
+++ b/src/lib/data/football-data.test.ts
@@ -450,4 +450,43 @@ describe('FootballDataAdapter', () => {
 			points: 25,
 		})
 	})
+
+	describe('fetchCurrentSeason', () => {
+		function mockCompetitionDetail(body: unknown) {
+			vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+				const urlStr = typeof url === 'string' ? url : url.toString()
+				if (urlStr.endsWith('/competitions/PL'))
+					return Promise.resolve(new Response(JSON.stringify(body)))
+				return Promise.resolve(new Response('Not found', { status: 404 }))
+			})
+		}
+
+		it('returns the current season start/end dates from the competition detail endpoint', async () => {
+			mockCompetitionDetail({
+				id: 2021,
+				code: 'PL',
+				currentSeason: {
+					id: 2403,
+					startDate: '2026-08-14',
+					endDate: '2027-05-23',
+					currentMatchday: 1,
+				},
+			})
+
+			await expect(adapter.fetchCurrentSeason()).resolves.toEqual({
+				startDate: '2026-08-14',
+				endDate: '2027-05-23',
+			})
+		})
+
+		it('returns null when the response carries no currentSeason', async () => {
+			mockCompetitionDetail({ id: 2021, code: 'PL' })
+			await expect(adapter.fetchCurrentSeason()).resolves.toBeNull()
+		})
+
+		it('returns null when currentSeason is missing its dates', async () => {
+			mockCompetitionDetail({ currentSeason: { id: 2403, startDate: null, endDate: null } })
+			await expect(adapter.fetchCurrentSeason()).resolves.toBeNull()
+		})
+	})
 })

--- a/src/lib/data/football-data.ts
+++ b/src/lib/data/football-data.ts
@@ -133,6 +133,13 @@ export interface StandingRow {
 	points: number
 }
 
+/** The source's explicit current season (e.g. startDate '2026-08-14',
+ * endDate '2027-05-23' for the 2026/27 PL season). */
+export interface FdCurrentSeason {
+	startDate: string
+	endDate: string
+}
+
 export class FootballDataAdapter implements CompetitionAdapter {
 	constructor(
 		private competitionCode: string,
@@ -267,6 +274,21 @@ export class FootballDataAdapter implements CompetitionAdapter {
 				status: m.status === 'FINISHED' ? ('finished' as const) : ('live' as const),
 				winner: mapWinner(m.score.winner),
 			}))
+	}
+
+	/**
+	 * The competition's explicit current season from the detail endpoint
+	 * (`/competitions/{code}` → `currentSeason`). Returns null when the source
+	 * doesn't report one (or reports it without dates) — the caller decides
+	 * whether that absence is fatal (season detection aborts rather than guess).
+	 */
+	async fetchCurrentSeason(): Promise<FdCurrentSeason | null> {
+		const data = await this.request<{
+			currentSeason?: { startDate?: string | null; endDate?: string | null } | null
+		}>(`/competitions/${this.competitionCode}`)
+		const season = data.currentSeason
+		if (!season?.startDate || !season?.endDate) return null
+		return { startDate: season.startDate, endDate: season.endDate }
 	}
 
 	async fetchStandings(): Promise<StandingRow[]> {

--- a/src/lib/data/fpl.test.ts
+++ b/src/lib/data/fpl.test.ts
@@ -98,6 +98,19 @@ describe('FplAdapter', () => {
 		expect(headers.Accept).toContain('application/json')
 	})
 
+	it('exposes the Gameweek 1 deadline for season cross-checking', async () => {
+		const preFetched = new FplAdapter({ bootstrap: mockBootstrap, fixtures: mockFixtures })
+		await expect(preFetched.fetchGw1Deadline()).resolves.toEqual(new Date('2025-08-16T10:00:00Z'))
+	})
+
+	it('returns null for the Gameweek 1 deadline when the payload has no Gameweek 1', async () => {
+		const preFetched = new FplAdapter({
+			bootstrap: { teams: [], events: [] },
+			fixtures: [],
+		})
+		await expect(preFetched.fetchGw1Deadline()).resolves.toBeNull()
+	})
+
 	it('uses pre-fetched payloads instead of making network calls when provided', async () => {
 		// The pre-fetched path is how production runs — GH Actions fetches FPL
 		// (Cloudflare allows their IPs) and POSTs the JSON to Vercel for

--- a/src/lib/data/fpl.ts
+++ b/src/lib/data/fpl.ts
@@ -122,6 +122,18 @@ export class FplAdapter implements CompetitionAdapter {
 		}))
 	}
 
+	/**
+	 * Deadline of Gameweek 1, used to cross-check football-data's currentSeason
+	 * during season detection (the GW1 year must equal the season's start year).
+	 * Returns null when the payload carries no Gameweek 1 — the caller treats
+	 * that absence as fatal rather than guessing the season.
+	 */
+	async fetchGw1Deadline(): Promise<Date | null> {
+		const data = await this.getBootstrap()
+		const gw1 = data.events.find((e) => e.id === 1)
+		return gw1 ? new Date(gw1.deadline_time) : null
+	}
+
 	async fetchLiveScores(roundNumber: number): Promise<AdapterFixtureScore[]> {
 		const fixtures = await this.getFixtures()
 		return fixtures

--- a/src/lib/game/bootstrap-competitions.test.ts
+++ b/src/lib/game/bootstrap-competitions.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
 	dbQueryCompetitionFindFirst,
+	dbQueryCompetitionFindMany,
 	dbQueryTeamFindFirst,
 	dbQueryTeamFindMany,
 	dbQueryRoundFindFirst,
@@ -18,9 +19,11 @@ const {
 	fplFetchTeams,
 	fplFetchRounds,
 	fplFetchStandings,
+	fplFetchGw1Deadline,
 	fdFetchTeams,
 	fdFetchRounds,
 	fdFetchStandings,
+	fdFetchCurrentSeason,
 	enqueueAutoSubmitMock,
 	enqueuePollScoresAtMock,
 } = vi.hoisted(() => {
@@ -36,6 +39,7 @@ const {
 	}))
 	return {
 		dbQueryCompetitionFindFirst: vi.fn(),
+		dbQueryCompetitionFindMany: vi.fn().mockResolvedValue([]),
 		dbQueryTeamFindFirst: vi.fn(),
 		dbQueryTeamFindMany: vi.fn().mockResolvedValue([]),
 		dbQueryRoundFindFirst: vi.fn(),
@@ -55,9 +59,11 @@ const {
 		fplFetchTeams: vi.fn().mockResolvedValue([]),
 		fplFetchRounds: vi.fn().mockResolvedValue([]),
 		fplFetchStandings: vi.fn().mockResolvedValue([]),
+		fplFetchGw1Deadline: vi.fn().mockResolvedValue(null),
 		fdFetchTeams: vi.fn().mockResolvedValue([]),
 		fdFetchRounds: vi.fn().mockResolvedValue([]),
 		fdFetchStandings: vi.fn().mockResolvedValue([]),
+		fdFetchCurrentSeason: vi.fn().mockResolvedValue(null),
 		enqueueAutoSubmitMock: vi.fn().mockResolvedValue(undefined),
 		enqueuePollScoresAtMock: vi.fn().mockResolvedValue(undefined),
 	}
@@ -66,7 +72,10 @@ const {
 vi.mock('@/lib/db', () => ({
 	db: {
 		query: {
-			competition: { findFirst: dbQueryCompetitionFindFirst },
+			competition: {
+				findFirst: dbQueryCompetitionFindFirst,
+				findMany: dbQueryCompetitionFindMany,
+			},
 			team: { findFirst: dbQueryTeamFindFirst, findMany: dbQueryTeamFindMany },
 			round: { findFirst: dbQueryRoundFindFirst, findMany: dbQueryRoundFindMany },
 			fixture: { findFirst: dbQueryFixtureFindFirst, findMany: dbQueryFixtureFindMany },
@@ -90,6 +99,7 @@ vi.mock('@/lib/data/fpl', () => ({
 			fetchTeams: fplFetchTeams,
 			fetchRounds: fplFetchRounds,
 			fetchStandings: fplFetchStandings,
+			fetchGw1Deadline: fplFetchGw1Deadline,
 		}
 	}),
 }))
@@ -101,6 +111,7 @@ vi.mock('@/lib/data/football-data', () => ({
 			fetchTeams: fdFetchTeams,
 			fetchRounds: fdFetchRounds,
 			fetchStandings: fdFetchStandings,
+			fetchCurrentSeason: fdFetchCurrentSeason,
 		}
 	}),
 	resolveFootballDataCode: vi.fn(() => 'PL'),
@@ -109,11 +120,19 @@ vi.mock('@/lib/data/football-data', () => ({
 import {
 	bootstrapCompetitions,
 	deriveSeasonLabel,
+	ensureCurrentPlSeasonCompetition,
 	mergeFootballDataIds,
 	SeasonDetectionError,
 	scheduleUpcomingFixturePolls,
 	syncCompetition,
 } from './bootstrap-competitions'
+
+/** Every insert(...).values(...) payload captured by the db mock. */
+function insertedValues(): Record<string, unknown>[] {
+	return dbInsertFn.mock.results
+		.map((r) => (r.value as { values: ReturnType<typeof vi.fn> }).values.mock.calls[0]?.[0])
+		.filter((v): v is Record<string, unknown> => v != null)
+}
 
 describe('deriveSeasonLabel', () => {
 	it('derives the season label from football-data currentSeason, cross-checked against the FPL GW1 year', () => {
@@ -174,12 +193,141 @@ describe('deriveSeasonLabel', () => {
 	})
 })
 
+describe('ensureCurrentPlSeasonCompetition', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		dbQueryCompetitionFindMany.mockResolvedValue([])
+	})
+
+	function mockDetectedSeason(startYear: number) {
+		fdFetchCurrentSeason.mockResolvedValue({
+			startDate: `${startYear}-08-14`,
+			endDate: `${startYear + 1}-05-23`,
+		})
+		fplFetchGw1Deadline.mockResolvedValue(new Date(`${startYear}-08-21T17:30:00Z`))
+	}
+
+	it('creates the competition with the DERIVED name and season when no PL competition exists', async () => {
+		// A deliberately non-current year: proves the values come from the
+		// payload derivation, not from any literal left in the module.
+		mockDetectedSeason(2031)
+		dbQueryCompetitionFindFirst.mockResolvedValue(undefined)
+
+		await ensureCurrentPlSeasonCompetition({ footballDataApiKey: 'fd-key' })
+
+		expect(insertedValues()).toEqual([
+			expect.objectContaining({
+				name: 'Premier League 2031/32',
+				type: 'league',
+				dataSource: 'fpl',
+				season: '2031/32',
+				status: 'active',
+			}),
+		])
+	})
+
+	it('returns the existing competition for the detected season without any writes', async () => {
+		mockDetectedSeason(2026)
+		const current = {
+			id: 'comp-current',
+			name: 'Premier League 2026/27',
+			dataSource: 'fpl',
+			season: '2026/27',
+			status: 'active',
+		}
+		dbQueryCompetitionFindFirst.mockResolvedValue(current)
+		dbQueryCompetitionFindMany.mockResolvedValue([current])
+
+		const comp = await ensureCurrentPlSeasonCompetition({ footballDataApiKey: 'fd-key' })
+
+		expect(comp).toBe(current)
+		expect(dbInsertFn).not.toHaveBeenCalled()
+		expect(dbUpdateFn).not.toHaveBeenCalled()
+	})
+
+	it('rolls over: creates the new-season competition and archives the predecessor, loudly', async () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+		mockDetectedSeason(2026)
+		const predecessor = {
+			id: 'comp-old',
+			name: 'Premier League 2025/26',
+			dataSource: 'fpl',
+			season: '2025/26',
+			status: 'active',
+		}
+		// No competition exists yet for the detected season…
+		dbQueryCompetitionFindFirst.mockResolvedValue(undefined)
+		// …and the active PL competition is last season's.
+		dbQueryCompetitionFindMany.mockResolvedValue([predecessor])
+
+		await ensureCurrentPlSeasonCompetition({ footballDataApiKey: 'fd-key' })
+
+		expect(insertedValues()).toEqual([
+			expect.objectContaining({ name: 'Premier League 2026/27', season: '2026/27' }),
+		])
+		const archiveSets = dbUpdateSet.mock.calls.map((c) => c[0]).filter((p) => 'status' in p)
+		expect(archiveSets).toEqual([expect.objectContaining({ status: 'archived' })])
+		expect(warn).toHaveBeenCalledWith(expect.stringContaining('season rollover'))
+		warn.mockRestore()
+	})
+
+	it('aborts with zero writes on a season disagreement between the sources', async () => {
+		fdFetchCurrentSeason.mockResolvedValue({ startDate: '2026-08-14', endDate: '2027-05-23' })
+		fplFetchGw1Deadline.mockResolvedValue(new Date('2025-08-15T17:30:00Z'))
+
+		await expect(
+			ensureCurrentPlSeasonCompetition({ footballDataApiKey: 'fd-key' }),
+		).rejects.toThrow(SeasonDetectionError)
+		expect(dbInsertFn).not.toHaveBeenCalled()
+		expect(dbUpdateFn).not.toHaveBeenCalled()
+	})
+
+	it('aborts with zero writes when football-data reports no currentSeason', async () => {
+		fdFetchCurrentSeason.mockResolvedValue(null)
+		fplFetchGw1Deadline.mockResolvedValue(new Date('2026-08-21T17:30:00Z'))
+
+		await expect(
+			ensureCurrentPlSeasonCompetition({ footballDataApiKey: 'fd-key' }),
+		).rejects.toThrow(SeasonDetectionError)
+		expect(dbInsertFn).not.toHaveBeenCalled()
+		expect(dbUpdateFn).not.toHaveBeenCalled()
+	})
+
+	it('aborts when the football-data API key is missing — detection cannot run', async () => {
+		await expect(ensureCurrentPlSeasonCompetition({})).rejects.toThrow(/FOOTBALL_DATA_API_KEY/)
+		expect(dbInsertFn).not.toHaveBeenCalled()
+	})
+
+	it('refuses to resurrect an archived competition for the detected season', async () => {
+		// The detected season's competition exists but an operator archived it —
+		// an unexpected state; abort rather than sync into (or duplicate) it.
+		mockDetectedSeason(2026)
+		dbQueryCompetitionFindFirst.mockResolvedValue({
+			id: 'comp-current',
+			name: 'Premier League 2026/27',
+			dataSource: 'fpl',
+			season: '2026/27',
+			status: 'archived',
+		})
+
+		await expect(
+			ensureCurrentPlSeasonCompetition({ footballDataApiKey: 'fd-key' }),
+		).rejects.toThrow(/archived/)
+		expect(dbInsertFn).not.toHaveBeenCalled()
+		expect(dbUpdateFn).not.toHaveBeenCalled()
+	})
+})
+
 describe('bootstrapCompetitions', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
 		dbQueryTeamFindMany.mockResolvedValue([])
 		dbQueryRoundFindMany.mockResolvedValue([])
 		dbQueryPlannedPickFindMany.mockResolvedValue([])
+		dbQueryCompetitionFindMany.mockResolvedValue([])
+		// Season sources agree on 2026/27 unless a test overrides them.
+		fdFetchCurrentSeason.mockResolvedValue({ startDate: '2026-08-14', endDate: '2027-05-23' })
+		fplFetchGw1Deadline.mockResolvedValue(new Date('2026-08-21T17:30:00Z'))
 	})
 
 	it('creates PL and WC competitions when they do not exist', async () => {
@@ -188,13 +336,30 @@ describe('bootstrapCompetitions', () => {
 		expect(dbInsertFn).toHaveBeenCalled()
 	})
 
+	it('creates the PL competition from the derived season, not a hardcoded literal', async () => {
+		dbQueryCompetitionFindFirst.mockResolvedValue(undefined)
+		fdFetchCurrentSeason.mockResolvedValue({ startDate: '2027-08-13', endDate: '2028-05-21' })
+		fplFetchGw1Deadline.mockResolvedValue(new Date('2027-08-20T17:30:00Z'))
+
+		await bootstrapCompetitions({ footballDataApiKey: 'fd-key' })
+
+		const plInsert = insertedValues().find((v) => v.dataSource === 'fpl')
+		expect(plInsert).toEqual(
+			expect.objectContaining({ name: 'Premier League 2027/28', season: '2027/28' }),
+		)
+	})
+
 	it('is idempotent when competitions already exist', async () => {
 		dbQueryCompetitionFindFirst.mockResolvedValue({
 			id: 'existing',
 			dataSource: 'fpl',
 			externalId: null,
+			season: '2026/27',
 			status: 'active',
 		})
+		dbQueryCompetitionFindMany.mockResolvedValue([
+			{ id: 'existing', dataSource: 'fpl', season: '2026/27', status: 'active' },
+		])
 		await bootstrapCompetitions({ footballDataApiKey: 'fd-key' })
 		// No assertion that insert was NOT called — adapters may still insert teams/rounds.
 		// This test just ensures the function runs without error when comps already exist.

--- a/src/lib/game/bootstrap-competitions.test.ts
+++ b/src/lib/game/bootstrap-competitions.test.ts
@@ -14,6 +14,7 @@ const {
 	dbInsertFn,
 	dbUpdateFn,
 	dbUpdateSet,
+	dbTransactionFn,
 	dbSelectFn,
 	dbSelectWhere,
 	fplFetchTeams,
@@ -37,6 +38,12 @@ const {
 			where: selectWhere,
 		}),
 	}))
+	const insertFn = vi.fn(() => ({
+		values: vi.fn(() => ({
+			returning: vi.fn().mockResolvedValue([{ id: 'new', externalId: 'WC' }]),
+		})),
+	}))
+	const updateFn = vi.fn(() => ({ set: updateSet }))
 	return {
 		dbQueryCompetitionFindFirst: vi.fn(),
 		dbQueryCompetitionFindMany: vi.fn().mockResolvedValue([]),
@@ -47,13 +54,14 @@ const {
 		dbQueryFixtureFindFirst: vi.fn(),
 		dbQueryFixtureFindMany: vi.fn().mockResolvedValue([]),
 		dbQueryPlannedPickFindMany: vi.fn().mockResolvedValue([]),
-		dbInsertFn: vi.fn(() => ({
-			values: vi.fn(() => ({
-				returning: vi.fn().mockResolvedValue([{ id: 'new', externalId: 'WC' }]),
-			})),
-		})),
-		dbUpdateFn: vi.fn(() => ({ set: updateSet })),
+		dbInsertFn: insertFn,
+		dbUpdateFn: updateFn,
 		dbUpdateSet: updateSet,
+		// db.transaction passthrough: the callback gets a tx exposing the same
+		// insert/update mocks, so assertions on writes see through transactions.
+		dbTransactionFn: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
+			fn({ insert: insertFn, update: updateFn }),
+		),
 		dbSelectFn: selectFn,
 		dbSelectWhere: selectWhere,
 		fplFetchTeams: vi.fn().mockResolvedValue([]),
@@ -84,6 +92,7 @@ vi.mock('@/lib/db', () => ({
 		insert: dbInsertFn,
 		update: dbUpdateFn,
 		select: dbSelectFn,
+		transaction: dbTransactionFn,
 	},
 }))
 

--- a/src/lib/game/bootstrap-competitions.test.ts
+++ b/src/lib/game/bootstrap-competitions.test.ts
@@ -108,10 +108,71 @@ vi.mock('@/lib/data/football-data', () => ({
 
 import {
 	bootstrapCompetitions,
+	deriveSeasonLabel,
 	mergeFootballDataIds,
+	SeasonDetectionError,
 	scheduleUpcomingFixturePolls,
 	syncCompetition,
 } from './bootstrap-competitions'
+
+describe('deriveSeasonLabel', () => {
+	it('derives the season label from football-data currentSeason, cross-checked against the FPL GW1 year', () => {
+		expect(
+			deriveSeasonLabel(
+				{ startDate: '2026-08-14', endDate: '2027-05-23' },
+				new Date('2026-08-21T17:30:00Z'),
+			),
+		).toBe('2026/27')
+	})
+
+	it('throws when football-data reports no currentSeason — never guesses', () => {
+		expect(() => deriveSeasonLabel(null, new Date('2026-08-21T17:30:00Z'))).toThrow(
+			SeasonDetectionError,
+		)
+		expect(() => deriveSeasonLabel(null, new Date('2026-08-21T17:30:00Z'))).toThrow(/currentSeason/)
+	})
+
+	it('throws when the FPL Gameweek 1 deadline is missing', () => {
+		expect(() =>
+			deriveSeasonLabel({ startDate: '2026-08-14', endDate: '2027-05-23' }, null),
+		).toThrow(SeasonDetectionError)
+		expect(() =>
+			deriveSeasonLabel({ startDate: '2026-08-14', endDate: '2027-05-23' }, null),
+		).toThrow(/Gameweek 1/)
+	})
+
+	it('throws on a season disagreement between the sources, naming both values', () => {
+		// football-data has flipped to 2026/27 but FPL still serves the 2025/26
+		// GW1 — a weird API state; abort rather than pick a side.
+		const call = () =>
+			deriveSeasonLabel(
+				{ startDate: '2026-08-14', endDate: '2027-05-23' },
+				new Date('2025-08-15T17:30:00Z'),
+			)
+		expect(call).toThrow(SeasonDetectionError)
+		expect(call).toThrow(/2026/)
+		expect(call).toThrow(/2025/)
+	})
+
+	it('throws when the currentSeason dates are not a cross-year league season', () => {
+		// A single-year or multi-year span is not a PL season shape — abort.
+		expect(() =>
+			deriveSeasonLabel(
+				{ startDate: '2026-08-14', endDate: '2026-12-19' },
+				new Date('2026-08-21T17:30:00Z'),
+			),
+		).toThrow(SeasonDetectionError)
+	})
+
+	it('throws when the currentSeason dates are unparseable', () => {
+		expect(() =>
+			deriveSeasonLabel(
+				{ startDate: 'not-a-date', endDate: '2027-05-23' },
+				new Date('2026-08-21T17:30:00Z'),
+			),
+		).toThrow(SeasonDetectionError)
+	})
+})
 
 describe('bootstrapCompetitions', () => {
 	beforeEach(() => {

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -121,29 +121,37 @@ export async function ensureCurrentPlSeasonCompetition(
 		})
 	).filter((c) => c.season !== season)
 
-	let current = existing
-	if (!current) {
-		const [created] = await db
-			.insert(competition)
-			.values({
-				name: `Premier League ${season}`,
-				type: 'league',
-				dataSource: 'fpl',
-				season,
-				status: 'active',
-			})
-			.returning()
-		current = created
-	}
+	// Steady state: the detected season's competition is the only active one.
+	if (existing && predecessors.length === 0) return existing
 
-	for (const old of predecessors) {
-		await db.update(competition).set({ status: 'archived' }).where(eq(competition.id, old.id))
-		console.warn(
-			`[bootstrap] season rollover: detected PL season ${season} — created/kept "${current.name}" (${current.id}), archived predecessor "${old.name}" (${old.id})`,
-		)
-	}
-
-	return current
+	// Create the new season's competition and archive its predecessors in one
+	// transaction so a crash can never leave two active PL competitions.
+	return await db.transaction(async (tx) => {
+		let current = existing
+		if (!current) {
+			const [created] = await tx
+				.insert(competition)
+				.values({
+					name: `Premier League ${season}`,
+					type: 'league',
+					dataSource: 'fpl',
+					season,
+					status: 'active',
+				})
+				.returning()
+			current = created
+			console.warn(
+				`[bootstrap] season rollover: created "${created.name}" (${created.id}) for detected PL season ${season}`,
+			)
+		}
+		for (const old of predecessors) {
+			await tx.update(competition).set({ status: 'archived' }).where(eq(competition.id, old.id))
+			console.warn(
+				`[bootstrap] season rollover: archived predecessor "${old.name}" (${old.id}) — superseded by "${current.name}" (${current.id})`,
+			)
+		}
+		return current
+	})
 }
 
 export async function bootstrapCompetitions(opts: BootstrapOptions): Promise<void> {

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -77,23 +77,77 @@ export function deriveSeasonLabel(
 	return `${startYear}/${String(endYear).slice(-2)}`
 }
 
-export async function bootstrapCompetitions(opts: BootstrapOptions): Promise<void> {
-	let pl = await db.query.competition.findFirst({
-		where: and(eq(competition.dataSource, 'fpl'), eq(competition.season, '2025/26')),
+/**
+ * Detect the current PL season from the sources and return the competition
+ * row to sync into, creating it (and archiving its predecessor) when the
+ * season has rolled over. Runs BEFORE any sync writes so a detection failure
+ * (SeasonDetectionError) aborts the run with zero writes.
+ *
+ * Idempotent: once the detected season's competition exists and is the only
+ * active fpl-sourced one, this is a pure read.
+ */
+export async function ensureCurrentPlSeasonCompetition(
+	opts: BootstrapOptions,
+): Promise<CompetitionRow> {
+	if (!opts.footballDataApiKey) {
+		throw new SeasonDetectionError(
+			'FOOTBALL_DATA_API_KEY is not configured — season detection needs football-data currentSeason; aborting sync',
+		)
+	}
+	const fplAdapter = new FplAdapter(opts.fplData)
+	const fdAdapter = new FootballDataAdapter('PL', opts.footballDataApiKey)
+	const [fdSeason, fplGw1Deadline] = await Promise.all([
+		fdAdapter.fetchCurrentSeason(),
+		fplAdapter.fetchGw1Deadline(),
+	])
+	const season = deriveSeasonLabel(fdSeason, fplGw1Deadline)
+
+	const existing = await db.query.competition.findFirst({
+		where: and(eq(competition.dataSource, 'fpl'), eq(competition.season, season)),
 	})
-	if (!pl) {
+	if (existing?.status === 'archived') {
+		// An archived competition is permanently immutable — if the CURRENT
+		// season's row is archived, something is wrong (manual intervention?).
+		// Abort rather than resurrect it or create a duplicate.
+		throw new Error(
+			`detected current PL season ${season}, but competition "${existing.name}" (${existing.id}) is archived — refusing to sync into an archived season`,
+		)
+	}
+
+	// Any other still-active fpl-sourced competition is a predecessor season.
+	const predecessors = (
+		await db.query.competition.findMany({
+			where: and(eq(competition.dataSource, 'fpl'), eq(competition.status, 'active')),
+		})
+	).filter((c) => c.season !== season)
+
+	let current = existing
+	if (!current) {
 		const [created] = await db
 			.insert(competition)
 			.values({
-				name: 'Premier League 2025/26',
+				name: `Premier League ${season}`,
 				type: 'league',
 				dataSource: 'fpl',
-				season: '2025/26',
+				season,
 				status: 'active',
 			})
 			.returning()
-		pl = created
+		current = created
 	}
+
+	for (const old of predecessors) {
+		await db.update(competition).set({ status: 'archived' }).where(eq(competition.id, old.id))
+		console.warn(
+			`[bootstrap] season rollover: detected PL season ${season} — created/kept "${current.name}" (${current.id}), archived predecessor "${old.name}" (${old.id})`,
+		)
+	}
+
+	return current
+}
+
+export async function bootstrapCompetitions(opts: BootstrapOptions): Promise<void> {
+	const pl = await ensureCurrentPlSeasonCompetition(opts)
 
 	let wc = await db.query.competition.findFirst({
 		where: and(eq(competition.dataSource, 'football_data'), eq(competition.externalId, 'WC')),

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -1,5 +1,5 @@
 import { and, eq, gt, inArray, isNull, lt } from 'drizzle-orm'
-import { FootballDataAdapter } from '@/lib/data/football-data'
+import { type FdCurrentSeason, FootballDataAdapter } from '@/lib/data/football-data'
 import { FplAdapter, type FplPreFetched } from '@/lib/data/fpl'
 import { enqueuePollScoresAt } from '@/lib/data/qstash'
 import type { AdapterStanding, CompetitionAdapter } from '@/lib/data/types'
@@ -22,6 +22,60 @@ export interface BootstrapOptions {
 }
 
 type CompetitionRow = typeof competition.$inferSelect
+
+/**
+ * Season detection could not produce a trustworthy answer (source data
+ * missing, malformed, or the two sources disagree). Always fatal: the sync
+ * must abort with zero writes rather than guess a season — a wrong guess is
+ * exactly how the 2026/27 silent-corruption incident happened.
+ */
+export class SeasonDetectionError extends Error {
+	constructor(message: string) {
+		super(message)
+		this.name = 'SeasonDetectionError'
+	}
+}
+
+/**
+ * Derive the PL season label (e.g. '2026/27') from football-data's explicit
+ * `currentSeason`, cross-checked against the year of FPL's Gameweek 1
+ * deadline. Throws SeasonDetectionError on any absence, malformed dates, or
+ * disagreement between the sources — it never guesses.
+ */
+export function deriveSeasonLabel(
+	fdSeason: FdCurrentSeason | null,
+	fplGw1Deadline: Date | null,
+): string {
+	if (!fdSeason) {
+		throw new SeasonDetectionError(
+			'football-data reported no currentSeason for the PL — cannot derive the season; aborting sync',
+		)
+	}
+	const startYear = new Date(fdSeason.startDate).getUTCFullYear()
+	const endYear = new Date(fdSeason.endDate).getUTCFullYear()
+	if (!Number.isFinite(startYear) || !Number.isFinite(endYear)) {
+		throw new SeasonDetectionError(
+			`football-data currentSeason dates are unparseable (startDate=${fdSeason.startDate}, endDate=${fdSeason.endDate}); aborting sync`,
+		)
+	}
+	if (endYear !== startYear + 1) {
+		throw new SeasonDetectionError(
+			`football-data currentSeason is not a cross-year league season (startDate=${fdSeason.startDate}, endDate=${fdSeason.endDate}); aborting sync`,
+		)
+	}
+	if (!fplGw1Deadline || Number.isNaN(fplGw1Deadline.getTime())) {
+		throw new SeasonDetectionError(
+			'FPL bootstrap carries no Gameweek 1 deadline — cannot cross-check the season; aborting sync',
+		)
+	}
+	const fplYear = fplGw1Deadline.getUTCFullYear()
+	if (fplYear !== startYear) {
+		throw new SeasonDetectionError(
+			`season disagreement: football-data currentSeason starts in ${startYear} but FPL's Gameweek 1 deadline is in ${fplYear} (${fplGw1Deadline.toISOString()}); aborting sync`,
+		)
+	}
+	return `${startYear}/${String(endYear).slice(-2)}`
+}
 
 export async function bootstrapCompetitions(opts: BootstrapOptions): Promise<void> {
 	let pl = await db.query.competition.findFirst({


### PR DESCRIPTION
Closes #120

## What this does

The sync now derives the current PL season from football-data's explicit `currentSeason` (`GET /competitions/PL` → start/end dates → "2026/27"), cross-checked against the year of FPL's Gameweek 1 deadline. On any absence, malformed dates, or disagreement it throws `SeasonDetectionError` **before any sync writes** — the daily-sync route 500s, records a failure `cron_run`, and the GH Actions job goes red. It never guesses.

When the detected season differs from the active PL competition's season, `ensureCurrentPlSeasonCompetition` creates "Premier League {season}", archives the predecessor (atomically, in one transaction), logs the rollover loudly, and the sync loop then syncs into the new row. The bootstrap module's hardcoded `'2025/26'` / `'Premier League 2025/26'` literals are gone; the August flip now needs no code change and no human memory.

- `FootballDataAdapter.fetchCurrentSeason()` — new thin fetch of the competition detail endpoint.
- `FplAdapter.fetchGw1Deadline()` — GW1 deadline for the cross-check.
- `deriveSeasonLabel()` — pure derivation + cross-check, unit-tested at the bootstrap seam.
- `ensureCurrentPlSeasonCompetition()` — detection + create/archive rollover; refuses to resurrect an archived current-season competition; idempotent steady-state is a pure read.
- `/api/cron/daily-sync` runs detection/rollover before enumerating active competitions, so a detection failure aborts with zero writes.

## Acceptance criteria → tests

- Rollover smoke (real Postgres): seeded active "2025/26" comp + next-season payloads → "Premier League 2026/27" created, predecessor archived, rounds/fixtures/teams populate the new competition only; predecessor rows byte-for-byte untouched.
- Disagreement / missing `currentSeason`: unit tests at the bootstrap seam + smoke tests asserting **no writes** on real Postgres; route test asserts 500 + no `syncCompetition` calls + failure `cron_run`.
- Idempotency smoke: re-running ensure+sync yields exactly one 2026/27 competition, no duplicate rounds/fixtures.
- No hardcoded season literals in the bootstrap path (only a historical comment about the NFO tla mismatch mentions 2025/26); the unit test derives 2031/32 from payloads to prove nothing is pinned.

## Behaviour changes worth knowing

- **`FOOTBALL_DATA_API_KEY` is now a hard requirement of the daily sync and the manual bootstrap script** (season detection needs football-data). Previously the script warned and continued; it now fails fast. Production always has the key.
- A manual daily-sync call without an FPL payload still aborts loudly (as before), but now before any sync writes.
- The WC competition block is untouched: its `season: '2026'` is the tournament's identity, not an annual-flip hazard.

## Self-review findings (code-review skill, Standards + Spec axes)

Acted on:
- Create+archive now runs in a single `db.transaction` (repo idiom) so a crash can't leave two active PL competitions.
- Competition **creation** is now logged loudly, not just predecessor archival.

Declined, with reasons:
- *Smoke should drive the HTTP route:* the smoke suite's documented convention is "No API calls: seed the DB directly so the test is decoupled from route plumbing" — smoke drives `ensureCurrentPlSeasonCompetition` + `syncCompetition`; the route wiring (detection-before-sync, abort-on-failure) is covered by the route unit tests.
- *Season label as a domain type:* `competition.season` is a `varchar` throughout the schema; a wrapper type would fight the existing convention.
- *Extract season detection into its own module:* the ticket names "the bootstrap unit suite" as the seam; keeping the trio in `bootstrap-competitions.ts` keeps that seam intact. Reasonable future refactor if the module keeps growing.
- *Archived-current-season guard throws plain `Error`, not `SeasonDetectionError`:* deliberate — detection succeeded; that guard is a state conflict, and both abort the run loudly either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)