### PR TITLE
One-off script: restore 2025/26 PL season from football-data, then archive

### DIFF
--- a/scripts/repair/README.md
+++ b/scripts/repair/README.md
@@ -1,20 +1,66 @@
-# One-off prod repair scripts — issue #119
+# One-off prod repair scripts
 
-Two approved production repairs from the World Cup endgame incidents
-(parent spec: #112), plus a read-only inspector to verify them. Prod
-execution is gated on human sign-off: the agent delivers the scripts and
-dry-run evidence; **a human runs `--apply`**.
+Approved production repairs from the #112 parent spec, each with a
+read-only inspector to verify it. Prod execution is gated on human
+sign-off: the agent delivers the scripts and dry-run evidence; **a human
+runs `--apply`**.
 
 Convention: every mutating script is dry-run by default, prints every
 intended mutation, asserts hard preconditions against live data (any drift
 aborts loudly with no writes), and only mutates with an explicit `--apply`
 flag — all writes in a single transaction.
 
-## Runbook (human, in order)
-
 All commands run from the repo root. WSL note: run outside any network
 sandbox (Neon DNS is blocked in it); Neon idle-suspends, so retry once on
 an initial `ETIMEDOUT`.
+
+## Issue #121 — 2025/26 PL season restore + archive
+
+The pre-#124 nightly sync matched fixtures on globally-unique external
+ids; when FPL flipped to 2026/27 it rewrote all 380 of the 2025/26
+season's fixture rows in place (2026/27 kickoffs, wiped scores, colliding
+FPL ids — team pairings untouched). `restore-pl-2526-season.ts` restores
+the season from football-data's archive (`?season=2025`) and archives the
+competition. Requires `FOOTBALL_DATA_API_KEY` (in Doppler `prd`).
+
+### Runbook (human, in order)
+
+```bash
+# 0. Baseline — read-only census of the competition + its games
+doppler run -p last-person-standing -c prd -- pnpm exec tsx scripts/repair/inspect-pl-2526-restore.ts
+
+# 1a. Restore + archive — dry run, review the printed mutations
+doppler run -p last-person-standing -c prd -- pnpm exec tsx scripts/repair/restore-pl-2526-season.ts
+# 1b. ...then apply
+doppler run -p last-person-standing -c prd -- pnpm exec tsx scripts/repair/restore-pl-2526-season.ts --apply
+
+# 2. Re-run the inspector and check against the acceptance criteria below
+doppler run -p last-person-standing -c prd -- pnpm exec tsx scripts/repair/inspect-pl-2526-restore.ts
+```
+
+Expected inspector output after apply (issue #121 acceptance criteria):
+
+- Fixture census: **380 finished** fixtures, **0 missing scores**,
+  **380 kickoffs inside the 2025/26 window** (0 outside, 0 null),
+  **0 carrying an FPL id**, **380 carrying a football-data id**.
+- The GW1 listing opens with **LIV 4-2 BOU, kickoff 2025-08-15**; the
+  GW38 listing shows ten finished fixtures all kicking off 2026-05-24.
+- Every round shows a 2025/26 deadline (earliest kickoff − 90 min).
+- Competition **status=archived**.
+- "Last Day Lightning 26" picks list real scores and kickoffs on their
+  fixtures.
+
+Then verify the game page renders through real SSR (curl recipe in the
+issue-#119 section below, with the game id from the inspector output) and
+spot-check a few printed scores across the season against
+football-data / BBC.
+
+## Issue #119 — World Cup endgame repairs
+
+Two approved production repairs from the World Cup endgame incidents,
+plus a read-only inspector to verify them.
+
+### Runbook (human, in order)
 
 ```bash
 # 0. Baseline — read-only census of both games
@@ -47,7 +93,7 @@ criteria):
   result changed).
 - SI World Cup reports **`Game NOT FOUND (deleted...)`**.
 
-## 4. Authenticated page check (final acceptance criterion)
+### Authenticated page check (final acceptance criterion)
 
 Verify the corrected game page renders through real SSR without errors
 (headless browsers are usually blocked here; use the curl recipe):

--- a/scripts/repair/inspect-pl-2526-restore.ts
+++ b/scripts/repair/inspect-pl-2526-restore.ts
@@ -17,7 +17,7 @@ import { db } from '../../src/lib/db'
 import { user } from '../../src/lib/schema/auth'
 import { competition, fixture, round, team } from '../../src/lib/schema/competition'
 import { game, gamePlayer, pick } from '../../src/lib/schema/game'
-import { heading, PL_2526_KICKOFF_MAX, PL_2526_KICKOFF_MIN, PL_2526_SEASON } from './shared'
+import { fixtureCensusLines, heading, PL_2526_SEASON } from './shared'
 
 type FixtureRow = typeof fixture.$inferSelect
 
@@ -70,23 +70,9 @@ async function main() {
 	}
 
 	// ── Fixture census ────────────────────────────────────────────────────
-	const inWindow = (d: Date | null) =>
-		d != null && d >= PL_2526_KICKOFF_MIN && d <= PL_2526_KICKOFF_MAX
-	const statusCounts = new Map<string, number>()
-	for (const f of fixtures) statusCounts.set(f.status, (statusCounts.get(f.status) ?? 0) + 1)
-	const ids = (f: FixtureRow) => f.externalIds as Record<string, string | number> | null
+	const extIds = (f: FixtureRow) => f.externalIds as Record<string, string | number> | null
 	console.log(`\nFixture census (${fixtures.length} fixtures, ${rounds.length} rounds):`)
-	console.log(`  status: ${[...statusCounts].map(([s, n]) => `${s}=${n}`).join(' ')}`)
-	console.log(
-		`  kickoff in ${PL_2526_SEASON} window: ${fixtures.filter((f) => inWindow(f.kickoff)).length}` +
-			` | outside: ${fixtures.filter((f) => f.kickoff != null && !inWindow(f.kickoff)).length}` +
-			` | null: ${fixtures.filter((f) => f.kickoff == null).length}`,
-	)
-	console.log(`  missing scores: ${fixtures.filter((f) => f.homeScore == null).length}`)
-	console.log(
-		`  carrying an FPL id: ${fixtures.filter((f) => f.externalId != null || ids(f)?.fpl != null).length}` +
-			` | carrying a football-data id: ${fixtures.filter((f) => ids(f)?.football_data != null).length}`,
-	)
+	for (const line of fixtureCensusLines(fixtures)) console.log(`  ${line}`)
 
 	// ── Rounds ────────────────────────────────────────────────────────────
 	console.log('\nRounds:')
@@ -115,7 +101,7 @@ async function main() {
 				`  ${shortName(f.homeTeamId)} ${score(f)} ${shortName(f.awayTeamId)}` +
 					` kickoff=${fmt(f.kickoff)} status=${f.status}` +
 					`${f.winner ? ` winner=${f.winner}` : ''}` +
-					` fplId=${f.externalId ?? ids(f)?.fpl ?? '—'} fdId=${ids(f)?.football_data ?? '—'}`,
+					` fplId=${f.externalId ?? extIds(f)?.fpl ?? '—'} fdId=${extIds(f)?.football_data ?? '—'}`,
 			)
 		}
 	}

--- a/scripts/repair/inspect-pl-2526-restore.ts
+++ b/scripts/repair/inspect-pl-2526-restore.ts
@@ -1,0 +1,173 @@
+/**
+ * Read-only inspector for the 2025/26 PL season restore (issue #121).
+ *
+ * Prints the competition's status, per-round deadlines + fixture census,
+ * the full GW1 and GW38 fixture lists (the ticket's spot-check surfaces),
+ * and every game on the competition with its picks joined to their
+ * fixtures' scores — the "Last Day Lightning 26" truthfulness evidence.
+ * SELECT-only — safe to run against prod at any time, before or after the
+ * restore.
+ *
+ * Usage (prod):
+ *   doppler run -p last-person-standing -c prd -- pnpm exec tsx scripts/repair/inspect-pl-2526-restore.ts
+ */
+
+import { and, asc, eq, inArray } from 'drizzle-orm'
+import { db } from '../../src/lib/db'
+import { user } from '../../src/lib/schema/auth'
+import { competition, fixture, round, team } from '../../src/lib/schema/competition'
+import { game, gamePlayer, pick } from '../../src/lib/schema/game'
+import { heading, PL_2526_KICKOFF_MAX, PL_2526_KICKOFF_MIN, PL_2526_SEASON } from './shared'
+
+type FixtureRow = typeof fixture.$inferSelect
+
+function fmt(d: Date | null): string {
+	return d ? d.toISOString() : '—'
+}
+
+function score(f: FixtureRow): string {
+	return f.homeScore != null ? `${f.homeScore}-${f.awayScore}` : '—'
+}
+
+async function main() {
+	heading(`Premier League ${PL_2526_SEASON} — restore inspector`)
+
+	const comps = await db
+		.select()
+		.from(competition)
+		.where(and(eq(competition.dataSource, 'fpl'), eq(competition.season, PL_2526_SEASON)))
+	if (comps.length !== 1) {
+		console.log(
+			`Found ${comps.length} fpl competitions with season ${PL_2526_SEASON} — nothing to inspect.`,
+		)
+		process.exit(0)
+	}
+	const comp = comps[0]
+	console.log(`name=${JSON.stringify(comp.name)} id=${comp.id} status=${comp.status}`)
+
+	const rounds = await db
+		.select()
+		.from(round)
+		.where(eq(round.competitionId, comp.id))
+		.orderBy(asc(round.number))
+	const fixtures = await db
+		.select()
+		.from(fixture)
+		.where(
+			inArray(
+				fixture.roundId,
+				rounds.map((r) => r.id),
+			),
+		)
+	const teams = await db.select().from(team)
+	const teamById = new Map(teams.map((t) => [t.id, t]))
+	const shortName = (teamId: string) => teamById.get(teamId)?.shortName ?? teamId.slice(0, 8)
+	const fixturesByRoundId = new Map<string, FixtureRow[]>()
+	for (const f of fixtures) {
+		const bucket = fixturesByRoundId.get(f.roundId) ?? []
+		bucket.push(f)
+		fixturesByRoundId.set(f.roundId, bucket)
+	}
+
+	// ── Fixture census ────────────────────────────────────────────────────
+	const inWindow = (d: Date | null) =>
+		d != null && d >= PL_2526_KICKOFF_MIN && d <= PL_2526_KICKOFF_MAX
+	const statusCounts = new Map<string, number>()
+	for (const f of fixtures) statusCounts.set(f.status, (statusCounts.get(f.status) ?? 0) + 1)
+	const ids = (f: FixtureRow) => f.externalIds as Record<string, string | number> | null
+	console.log(`\nFixture census (${fixtures.length} fixtures, ${rounds.length} rounds):`)
+	console.log(`  status: ${[...statusCounts].map(([s, n]) => `${s}=${n}`).join(' ')}`)
+	console.log(
+		`  kickoff in ${PL_2526_SEASON} window: ${fixtures.filter((f) => inWindow(f.kickoff)).length}` +
+			` | outside: ${fixtures.filter((f) => f.kickoff != null && !inWindow(f.kickoff)).length}` +
+			` | null: ${fixtures.filter((f) => f.kickoff == null).length}`,
+	)
+	console.log(`  missing scores: ${fixtures.filter((f) => f.homeScore == null).length}`)
+	console.log(
+		`  carrying an FPL id: ${fixtures.filter((f) => f.externalId != null || ids(f)?.fpl != null).length}` +
+			` | carrying a football-data id: ${fixtures.filter((f) => ids(f)?.football_data != null).length}`,
+	)
+
+	// ── Rounds ────────────────────────────────────────────────────────────
+	console.log('\nRounds:')
+	for (const r of rounds) {
+		const bucket = fixturesByRoundId.get(r.id) ?? []
+		const kickoffs = bucket
+			.map((f) => f.kickoff)
+			.filter((k): k is Date => k != null)
+			.sort((a, b) => a.getTime() - b.getTime())
+		console.log(
+			`  R${String(r.number).padStart(2)} ${r.name}: status=${r.status} deadline=${fmt(r.deadline)}` +
+				` fixtures=${bucket.length} kickoffs=${fmt(kickoffs[0] ?? null)} … ${fmt(kickoffs[kickoffs.length - 1] ?? null)}`,
+		)
+	}
+
+	// ── GW1 + GW38 listings (the ticket's spot-check surfaces) ────────────
+	for (const number of [1, rounds.length]) {
+		const r = rounds.find((row) => row.number === number)
+		if (!r) continue
+		console.log(`\nR${r.number} ${r.name} fixtures:`)
+		const bucket = (fixturesByRoundId.get(r.id) ?? []).sort(
+			(a, b) => (a.kickoff?.getTime() ?? 0) - (b.kickoff?.getTime() ?? 0),
+		)
+		for (const f of bucket) {
+			console.log(
+				`  ${shortName(f.homeTeamId)} ${score(f)} ${shortName(f.awayTeamId)}` +
+					` kickoff=${fmt(f.kickoff)} status=${f.status}` +
+					`${f.winner ? ` winner=${f.winner}` : ''}` +
+					` fplId=${f.externalId ?? ids(f)?.fpl ?? '—'} fdId=${ids(f)?.football_data ?? '—'}`,
+			)
+		}
+	}
+
+	// ── Games on the competition ──────────────────────────────────────────
+	const games = await db.select().from(game).where(eq(game.competitionId, comp.id))
+	const roundById = new Map(rounds.map((r) => [r.id, r]))
+	const fixtureById = new Map(fixtures.map((f) => [f.id, f]))
+	console.log(`\nGames on this competition (${games.length}):`)
+	for (const g of games) {
+		heading(`${g.name} — mode=${g.gameMode} status=${g.status}`)
+		const players = await db.select().from(gamePlayer).where(eq(gamePlayer.gameId, g.id))
+		const names = new Map(
+			players.length > 0
+				? (
+						await db
+							.select({ id: user.id, name: user.name })
+							.from(user)
+							.where(
+								inArray(
+									user.id,
+									players.map((p) => p.userId),
+								),
+							)
+					).map((u) => [u.id, u.name])
+				: [],
+		)
+		const playerById = new Map(players.map((p) => [p.id, p]))
+		const picks = await db.select().from(pick).where(eq(pick.gameId, g.id))
+		picks.sort(
+			(a, b) => (roundById.get(a.roundId)?.number ?? 0) - (roundById.get(b.roundId)?.number ?? 0),
+		)
+		console.log(`players=${players.length} picks=${picks.length}`)
+		for (const p of picks) {
+			const who = playerById.get(p.gamePlayerId)
+			const name = who ? (names.get(who.userId) ?? who.userId) : p.gamePlayerId
+			const r = roundById.get(p.roundId)
+			const f = p.fixtureId ? fixtureById.get(p.fixtureId) : undefined
+			console.log(
+				`  R${r?.number ?? '?'} ${name}: ${shortName(p.teamId)} → ${p.result}` +
+					(f
+						? ` (fixture ${shortName(f.homeTeamId)} ${score(f)} ${shortName(f.awayTeamId)}, kickoff=${fmt(f.kickoff)}, status=${f.status})`
+						: ' (no fixture linked)'),
+			)
+		}
+	}
+
+	console.log()
+	process.exit(0)
+}
+
+main().catch((err) => {
+	console.error('Inspect failed:', err)
+	process.exit(1)
+})

--- a/scripts/repair/restore-pl-2526-season.ts
+++ b/scripts/repair/restore-pl-2526-season.ts
@@ -49,13 +49,13 @@ import { db } from '../../src/lib/db'
 import { competition, fixture, round, team } from '../../src/lib/schema/competition'
 import {
 	fail,
+	fixtureCensusLines,
 	heading,
+	inPl2526Window,
 	PL_2526_EXPECTED_FIXTURES,
 	PL_2526_EXPECTED_ROUNDS,
 	PL_2526_EXPECTED_TEAMS,
 	PL_2526_FD_SEASON,
-	PL_2526_KICKOFF_MAX,
-	PL_2526_KICKOFF_MIN,
 	PL_2526_SEASON,
 } from './shared'
 
@@ -159,22 +159,8 @@ async function main() {
 	}
 
 	// Current-state census — the corruption evidence the dry run documents.
-	const inWindow = (d: Date | null) =>
-		d != null && d >= PL_2526_KICKOFF_MIN && d <= PL_2526_KICKOFF_MAX
-	const statusCounts = new Map<string, number>()
-	for (const f of fixtures) statusCounts.set(f.status, (statusCounts.get(f.status) ?? 0) + 1)
 	console.log(`\nCurrent state (${fixtures.length} fixtures):`)
-	console.log(`  status: ${[...statusCounts].map(([s, n]) => `${s}=${n}`).join(' ')}`)
-	console.log(
-		`  kickoff in ${PL_2526_SEASON} window: ${fixtures.filter((f) => inWindow(f.kickoff)).length}` +
-			` | outside: ${fixtures.filter((f) => f.kickoff != null && !inWindow(f.kickoff)).length}` +
-			` | null: ${fixtures.filter((f) => f.kickoff == null).length}`,
-	)
-	console.log(`  missing scores: ${fixtures.filter((f) => f.homeScore == null).length}`)
-	console.log(
-		`  carrying an FPL id: ${withFplId.length}` +
-			` | carrying a football-data id: ${fixtures.filter((f) => fdId(f.externalIds) != null).length}`,
-	)
+	for (const line of fixtureCensusLines(fixtures)) console.log(`  ${line}`)
 
 	// ── The archive ───────────────────────────────────────────────────────
 	const apiKey = process.env.FOOTBALL_DATA_API_KEY
@@ -197,7 +183,7 @@ async function main() {
 			fail(`archive match ${m.id} has unresolved teams`)
 		}
 		const kickoff = new Date(m.utcDate)
-		if (Number.isNaN(kickoff.getTime()) || !inWindow(kickoff)) {
+		if (Number.isNaN(kickoff.getTime()) || !inPl2526Window(kickoff)) {
 			fail(
 				`archive match ${m.id} kicks off at ${m.utcDate}, outside the ${PL_2526_SEASON} window — wrong season?`,
 			)
@@ -288,6 +274,12 @@ async function main() {
 	if (matchByFixtureId.size !== fixtures.length) {
 		fail(`matched ${matchByFixtureId.size}/${fixtures.length} fixtures — bijection broken`)
 	}
+	// The unit of every remaining step: a fixture row with its archive match.
+	const pairs = fixtures.map((f) => {
+		const m = matchByFixtureId.get(f.id)
+		if (!m) fail(`unreachable: fixture ${f.id} lost its archive match`)
+		return { f, m }
+	})
 
 	// ── Restored round deadlines ──────────────────────────────────────────
 	// Earliest restored kickoff in the round − 90 minutes (FPL's deadline
@@ -295,8 +287,8 @@ async function main() {
 	// OUR round rows — the FPL gameweek grouping the picks were made against
 	// — not football-data's matchday, which can differ after reschedules.
 	const deadlineByRoundId = new Map<string, Date>()
-	for (const f of fixtures) {
-		const kickoff = new Date((matchByFixtureId.get(f.id) as FdArchiveMatch).utcDate)
+	for (const { f, m } of pairs) {
+		const kickoff = new Date(m.utcDate)
 		const current = deadlineByRoundId.get(f.roundId)
 		if (!current || kickoff.getTime() < current.getTime()) {
 			deadlineByRoundId.set(f.roundId, kickoff)
@@ -310,28 +302,26 @@ async function main() {
 
 	// ── Intended mutations ────────────────────────────────────────────────
 	heading('Intended mutations')
-	const fixturesByRoundId = new Map<string, (typeof fixtures)[number][]>()
-	for (const f of fixtures) {
-		const bucket = fixturesByRoundId.get(f.roundId) ?? []
-		bucket.push(f)
-		fixturesByRoundId.set(f.roundId, bucket)
+	const pairsByRoundId = new Map<string, typeof pairs>()
+	for (const p of pairs) {
+		const bucket = pairsByRoundId.get(p.f.roundId) ?? []
+		bucket.push(p)
+		pairsByRoundId.set(p.f.roundId, bucket)
 	}
 	for (const r of rounds) {
 		const newDeadline = deadlineByRoundId.get(r.id) as Date
 		console.log(`\nR${r.number} ${r.name}: deadline ${fmt(r.deadline)} → ${fmt(newDeadline)}`)
-		const bucket = (fixturesByRoundId.get(r.id) ?? []).sort(
-			(a, b) =>
-				new Date((matchByFixtureId.get(a.id) as FdArchiveMatch).utcDate).getTime() -
-				new Date((matchByFixtureId.get(b.id) as FdArchiveMatch).utcDate).getTime(),
+		const bucket = (pairsByRoundId.get(r.id) ?? []).sort(
+			(a, b) => new Date(a.m.utcDate).getTime() - new Date(b.m.utcDate).getTime(),
 		)
-		for (const f of bucket) {
-			const m = matchByFixtureId.get(f.id) as FdArchiveMatch
+		for (const { f, m } of bucket) {
 			const oldScore = f.homeScore != null ? `${f.homeScore}-${f.awayScore}` : '—'
+			const winner = mapWinner(m.score.winner)
 			console.log(
 				`  ${shortName(f.homeTeamId)} v ${shortName(f.awayTeamId)}: ` +
 					`kickoff ${fmt(f.kickoff)} → ${m.utcDate}, ` +
 					`${f.status} ${oldScore} → finished ${m.score.fullTime.home}-${m.score.fullTime.away}` +
-					`${mapWinner(m.score.winner) ? ` (winner=${mapWinner(m.score.winner)})` : ''}, ` +
+					`${winner ? ` (winner=${winner})` : ''}, ` +
 					`fpl id ${f.externalId ?? fplId(f.externalIds) ?? '—'} → cleared, ` +
 					`fd id ${fdId(f.externalIds) ?? '—'} → ${m.id}`,
 			)
@@ -349,8 +339,7 @@ async function main() {
 
 	// ── Apply ─────────────────────────────────────────────────────────────
 	await db.transaction(async (tx) => {
-		for (const f of fixtures) {
-			const m = matchByFixtureId.get(f.id) as FdArchiveMatch
+		for (const { f, m } of pairs) {
 			await tx
 				.update(fixture)
 				.set({
@@ -392,7 +381,7 @@ async function main() {
 		`fixtures finished with scores: ${fixturesAfter.filter((f) => f.status === 'finished' && f.homeScore != null).length}/${fixturesAfter.length} (expect ${PL_2526_EXPECTED_FIXTURES})`,
 	)
 	console.log(
-		`kickoffs in ${PL_2526_SEASON} window: ${fixturesAfter.filter((f) => inWindow(f.kickoff)).length}/${fixturesAfter.length} (expect ${PL_2526_EXPECTED_FIXTURES})`,
+		`kickoffs in ${PL_2526_SEASON} window: ${fixturesAfter.filter((f) => inPl2526Window(f.kickoff)).length}/${fixturesAfter.length} (expect ${PL_2526_EXPECTED_FIXTURES})`,
 	)
 	console.log(
 		`carrying an FPL id: ${fixturesAfter.filter((f) => f.externalId != null || fplId(f.externalIds) != null).length} (expect 0)`,

--- a/scripts/repair/restore-pl-2526-season.ts
+++ b/scripts/repair/restore-pl-2526-season.ts
@@ -1,0 +1,410 @@
+/**
+ * One-off prod repair: restore the overwritten 2025/26 PL season from
+ * football-data's archive, then archive the competition.
+ * Issue #121 / parent #112.
+ *
+ * Background: until the season-scoped sync landed (#124), the nightly sync
+ * matched fixtures on a globally-unique external id. FPL's fixture ids
+ * restart every season, so when FPL flipped to 2026/27 the sync rewrote all
+ * 380 of last season's fixture rows in place — 2026/27 kickoffs, wiped
+ * scores, colliding FPL ids — while keeping the 2025/26 team pairings.
+ *
+ * What it does (all-or-nothing, single transaction):
+ *   1. Fetches the completed 2025/26 season (football-data `?season=2025`,
+ *      380 finished matches) and matches each archive match to our fixture
+ *      row by (home, away) team pair — each PL pairing happens exactly once
+ *      per season, so the pairing is a unique key. Teams resolve through
+ *      `team.external_ids.football_data` (stable across seasons, unlike FPL
+ *      ids).
+ *   2. Restores every fixture's true kickoff, score, status ('finished'),
+ *      winner, and 2025/26 football-data id. The colliding FPL ids
+ *      (`external_id` and `external_ids.fpl`) are cleared, not
+ *      reconstructed — FPL doesn't serve past seasons.
+ *   3. Restores the 38 round deadlines as earliest restored kickoff in the
+ *      round − 90 minutes — FPL's own deadline convention, and the same
+ *      derivation the football-data adapter uses. (FPL doesn't serve past
+ *      seasons, so the original event deadlines can't be re-fetched; this
+ *      is the documented reconstruction.)
+ *   4. Archives the competition so no sync/reconcile/poll surface can ever
+ *      touch it again. This script is the sanctioned, sign-off-gated
+ *      exception to archived-competition immutability: it exists to make
+ *      the archived history truthful before sealing it.
+ *
+ * Matching is structural (team pairs via stable football-data team ids) —
+ * never by round number or kickoff, both of which are corrupted. Every
+ * expectation about the current state is asserted before anything is
+ * printed as an intended mutation; any drift aborts loudly with no writes.
+ *
+ * Single-use: after apply, no fixture carries an FPL id, and the
+ * ≥1-FPL-id precondition can never pass again.
+ *
+ * Usage (prod):
+ *   dry run: doppler run -p last-person-standing -c prd -- pnpm exec tsx scripts/repair/restore-pl-2526-season.ts
+ *   apply:   doppler run -p last-person-standing -c prd -- pnpm exec tsx scripts/repair/restore-pl-2526-season.ts --apply
+ */
+
+import { and, asc, eq, inArray } from 'drizzle-orm'
+import { fetchJson } from '../../src/lib/data/fetch-json'
+import { db } from '../../src/lib/db'
+import { competition, fixture, round, team } from '../../src/lib/schema/competition'
+import {
+	fail,
+	heading,
+	PL_2526_EXPECTED_FIXTURES,
+	PL_2526_EXPECTED_ROUNDS,
+	PL_2526_EXPECTED_TEAMS,
+	PL_2526_FD_SEASON,
+	PL_2526_KICKOFF_MAX,
+	PL_2526_KICKOFF_MIN,
+	PL_2526_SEASON,
+} from './shared'
+
+const FD_BASE_URL = 'https://api.football-data.org/v4'
+
+// The ticket's named spot-check: the 2025/26 opener, Liverpool 4-2
+// Bournemouth on 2025-08-15. Guards against fetching the wrong season.
+const OPENER = { homeTla: 'LIV', awayTla: 'BOU', home: 4, away: 2, date: '2025-08-15' }
+
+interface FdArchiveTeam {
+	id: number | null
+	name: string | null
+	tla: string | null
+}
+
+interface FdArchiveMatch {
+	id: number
+	matchday: number | null
+	utcDate: string
+	status: string
+	homeTeam: FdArchiveTeam
+	awayTeam: FdArchiveTeam
+	score: {
+		winner?: string | null
+		fullTime: { home: number | null; away: number | null }
+		regularTime?: { home: number | null; away: number | null }
+	}
+}
+
+/** Same semantics as the football-data adapter: DRAW/null → null. */
+function mapWinner(winner: string | null | undefined): 'home' | 'away' | null {
+	if (winner === 'HOME_TEAM') return 'home'
+	if (winner === 'AWAY_TEAM') return 'away'
+	return null
+}
+
+function fmt(d: Date | null): string {
+	return d ? d.toISOString() : '—'
+}
+
+function fdId(ids: Record<string, string | number> | null): string | number | null {
+	return ids?.football_data ?? null
+}
+
+function fplId(ids: Record<string, string | number> | null): string | number | null {
+	return ids?.fpl ?? null
+}
+
+async function main() {
+	const apply = process.argv.includes('--apply')
+
+	heading(`Restore PL ${PL_2526_SEASON} from football-data — ${apply ? 'APPLY' : 'DRY RUN'}`)
+
+	// ── The competition ───────────────────────────────────────────────────
+	const comps = await db
+		.select()
+		.from(competition)
+		.where(and(eq(competition.dataSource, 'fpl'), eq(competition.season, PL_2526_SEASON)))
+	if (comps.length !== 1) {
+		fail(`expected exactly 1 fpl competition with season ${PL_2526_SEASON}, found ${comps.length}`)
+	}
+	const comp = comps[0]
+	if (!comp.name.startsWith('Premier League')) {
+		fail(`competition ${comp.id} is named ${JSON.stringify(comp.name)}, expected a Premier League`)
+	}
+	console.log(`competition: ${JSON.stringify(comp.name)} (${comp.id}) status=${comp.status}`)
+
+	// ── Rounds ────────────────────────────────────────────────────────────
+	const rounds = await db
+		.select()
+		.from(round)
+		.where(eq(round.competitionId, comp.id))
+		.orderBy(asc(round.number))
+	if (rounds.length !== PL_2526_EXPECTED_ROUNDS) {
+		fail(`expected ${PL_2526_EXPECTED_ROUNDS} rounds, found ${rounds.length}`)
+	}
+	rounds.forEach((r, i) => {
+		if (r.number !== i + 1) fail(`round numbers are not exactly 1..38 (index ${i} is R${r.number})`)
+	})
+
+	// ── Fixtures ──────────────────────────────────────────────────────────
+	const fixtures = await db
+		.select()
+		.from(fixture)
+		.where(
+			inArray(
+				fixture.roundId,
+				rounds.map((r) => r.id),
+			),
+		)
+	if (fixtures.length !== PL_2526_EXPECTED_FIXTURES) {
+		fail(`expected ${PL_2526_EXPECTED_FIXTURES} fixtures, found ${fixtures.length}`)
+	}
+
+	// Single-use guard: the restore clears every FPL id, so a re-run can
+	// never see one. (The corrupting sync rewrote external_ids.fpl on every
+	// row; external_id has held an FPL id since the original bootstrap.)
+	const withFplId = fixtures.filter((f) => f.externalId != null || fplId(f.externalIds) != null)
+	if (withFplId.length === 0) {
+		fail('no fixture carries an FPL id — the restore appears to have already been applied')
+	}
+
+	// Current-state census — the corruption evidence the dry run documents.
+	const inWindow = (d: Date | null) =>
+		d != null && d >= PL_2526_KICKOFF_MIN && d <= PL_2526_KICKOFF_MAX
+	const statusCounts = new Map<string, number>()
+	for (const f of fixtures) statusCounts.set(f.status, (statusCounts.get(f.status) ?? 0) + 1)
+	console.log(`\nCurrent state (${fixtures.length} fixtures):`)
+	console.log(`  status: ${[...statusCounts].map(([s, n]) => `${s}=${n}`).join(' ')}`)
+	console.log(
+		`  kickoff in ${PL_2526_SEASON} window: ${fixtures.filter((f) => inWindow(f.kickoff)).length}` +
+			` | outside: ${fixtures.filter((f) => f.kickoff != null && !inWindow(f.kickoff)).length}` +
+			` | null: ${fixtures.filter((f) => f.kickoff == null).length}`,
+	)
+	console.log(`  missing scores: ${fixtures.filter((f) => f.homeScore == null).length}`)
+	console.log(
+		`  carrying an FPL id: ${withFplId.length}` +
+			` | carrying a football-data id: ${fixtures.filter((f) => fdId(f.externalIds) != null).length}`,
+	)
+
+	// ── The archive ───────────────────────────────────────────────────────
+	const apiKey = process.env.FOOTBALL_DATA_API_KEY
+	if (!apiKey) fail('FOOTBALL_DATA_API_KEY is not set')
+	const archiveUrl = `${FD_BASE_URL}/competitions/PL/matches?season=${PL_2526_FD_SEASON}`
+	console.log(`\nFetching ${archiveUrl} …`)
+	const { matches } = await fetchJson<{ matches: FdArchiveMatch[] }>(archiveUrl, {
+		headers: { 'X-Auth-Token': apiKey },
+	})
+	if (matches.length !== PL_2526_EXPECTED_FIXTURES) {
+		fail(`archive returned ${matches.length} matches, expected ${PL_2526_EXPECTED_FIXTURES}`)
+	}
+	for (const m of matches) {
+		if (m.status !== 'FINISHED')
+			fail(`archive match ${m.id} has status ${m.status}, expected FINISHED`)
+		if (m.score.fullTime.home == null || m.score.fullTime.away == null) {
+			fail(`archive match ${m.id} has no full-time score`)
+		}
+		if (m.homeTeam.id == null || m.awayTeam.id == null) {
+			fail(`archive match ${m.id} has unresolved teams`)
+		}
+		const kickoff = new Date(m.utcDate)
+		if (Number.isNaN(kickoff.getTime()) || !inWindow(kickoff)) {
+			fail(
+				`archive match ${m.id} kicks off at ${m.utcDate}, outside the ${PL_2526_SEASON} window — wrong season?`,
+			)
+		}
+	}
+	const opener = matches.find(
+		(m) => m.homeTeam.tla === OPENER.homeTla && m.awayTeam.tla === OPENER.awayTla,
+	)
+	if (!opener) fail(`archive has no ${OPENER.homeTla} v ${OPENER.awayTla} match`)
+	if (
+		opener.score.fullTime.home !== OPENER.home ||
+		opener.score.fullTime.away !== OPENER.away ||
+		!opener.utcDate.startsWith(OPENER.date)
+	) {
+		fail(
+			`spot-check failed: ${OPENER.homeTla} v ${OPENER.awayTla} is ${opener.score.fullTime.home}-${opener.score.fullTime.away} on ${opener.utcDate}, expected ${OPENER.home}-${OPENER.away} on ${OPENER.date}`,
+		)
+	}
+	console.log(
+		`archive OK: ${matches.length} finished matches; opener ${OPENER.homeTla} ${OPENER.home}-${OPENER.away} ${OPENER.awayTla} on ${OPENER.date} ✓`,
+	)
+
+	// ── Team resolution: football-data id → our team row ─────────────────
+	// football-data team ids are globally stable across seasons (unlike FPL
+	// ids), and every 2025/26 team row got its football-data id merged while
+	// the season was live.
+	const archiveTeams = new Map<number, FdArchiveTeam>()
+	for (const m of matches) {
+		for (const t of [m.homeTeam, m.awayTeam]) {
+			if (t.id != null) archiveTeams.set(t.id, t)
+		}
+	}
+	if (archiveTeams.size !== PL_2526_EXPECTED_TEAMS) {
+		fail(`archive names ${archiveTeams.size} teams, expected ${PL_2526_EXPECTED_TEAMS}`)
+	}
+	const allTeams = await db.select().from(team)
+	const teamUuidByFdId = new Map<number, string>()
+	for (const [id, t] of archiveTeams) {
+		const ours = allTeams.filter((row) => String(fdId(row.externalIds)) === String(id))
+		if (ours.length !== 1) {
+			fail(
+				`archive team ${t.name} (fd id ${id}) resolves to ${ours.length} team rows, expected exactly 1`,
+			)
+		}
+		teamUuidByFdId.set(id, ours[0].id)
+	}
+	// The pairings on our fixture rows were never corrupted — the resolved
+	// archive teams must be exactly the teams our fixtures reference.
+	const fixtureTeamIds = new Set(fixtures.flatMap((f) => [f.homeTeamId, f.awayTeamId]))
+	const resolvedTeamIds = new Set(teamUuidByFdId.values())
+	if (
+		fixtureTeamIds.size !== resolvedTeamIds.size ||
+		[...fixtureTeamIds].some((id) => !resolvedTeamIds.has(id))
+	) {
+		fail(
+			`teams referenced by our fixtures (${fixtureTeamIds.size}) do not match the archive's resolved teams (${resolvedTeamIds.size})`,
+		)
+	}
+	const teamById = new Map(allTeams.map((t) => [t.id, t]))
+	const shortName = (teamId: string) => teamById.get(teamId)?.shortName ?? teamId.slice(0, 8)
+
+	// ── Fixture matching by team pair (bijection) ─────────────────────────
+	const fixtureByPair = new Map<string, (typeof fixtures)[number]>()
+	for (const f of fixtures) {
+		const key = `${f.homeTeamId}|${f.awayTeamId}`
+		if (fixtureByPair.has(key)) {
+			fail(
+				`duplicate fixture rows for pairing ${shortName(f.homeTeamId)} v ${shortName(f.awayTeamId)}`,
+			)
+		}
+		fixtureByPair.set(key, f)
+	}
+	const matchByFixtureId = new Map<string, FdArchiveMatch>()
+	for (const m of matches) {
+		const home = teamUuidByFdId.get(m.homeTeam.id as number) as string
+		const away = teamUuidByFdId.get(m.awayTeam.id as number) as string
+		const ours = fixtureByPair.get(`${home}|${away}`)
+		if (!ours) {
+			fail(`no fixture row for archive match ${m.id} (${m.homeTeam.tla} v ${m.awayTeam.tla})`)
+		}
+		if (matchByFixtureId.has(ours.id)) {
+			fail(
+				`two archive matches resolve to fixture ${ours.id} (${m.homeTeam.tla} v ${m.awayTeam.tla})`,
+			)
+		}
+		matchByFixtureId.set(ours.id, m)
+	}
+	if (matchByFixtureId.size !== fixtures.length) {
+		fail(`matched ${matchByFixtureId.size}/${fixtures.length} fixtures — bijection broken`)
+	}
+
+	// ── Restored round deadlines ──────────────────────────────────────────
+	// Earliest restored kickoff in the round − 90 minutes (FPL's deadline
+	// convention; same derivation as the football-data adapter). Grouped by
+	// OUR round rows — the FPL gameweek grouping the picks were made against
+	// — not football-data's matchday, which can differ after reschedules.
+	const deadlineByRoundId = new Map<string, Date>()
+	for (const f of fixtures) {
+		const kickoff = new Date((matchByFixtureId.get(f.id) as FdArchiveMatch).utcDate)
+		const current = deadlineByRoundId.get(f.roundId)
+		if (!current || kickoff.getTime() < current.getTime()) {
+			deadlineByRoundId.set(f.roundId, kickoff)
+		}
+	}
+	for (const r of rounds) {
+		const earliest = deadlineByRoundId.get(r.id)
+		if (!earliest) fail(`round R${r.number} ${JSON.stringify(r.name)} has no fixtures`)
+		deadlineByRoundId.set(r.id, new Date(earliest.getTime() - 90 * 60 * 1000))
+	}
+
+	// ── Intended mutations ────────────────────────────────────────────────
+	heading('Intended mutations')
+	const fixturesByRoundId = new Map<string, (typeof fixtures)[number][]>()
+	for (const f of fixtures) {
+		const bucket = fixturesByRoundId.get(f.roundId) ?? []
+		bucket.push(f)
+		fixturesByRoundId.set(f.roundId, bucket)
+	}
+	for (const r of rounds) {
+		const newDeadline = deadlineByRoundId.get(r.id) as Date
+		console.log(`\nR${r.number} ${r.name}: deadline ${fmt(r.deadline)} → ${fmt(newDeadline)}`)
+		const bucket = (fixturesByRoundId.get(r.id) ?? []).sort(
+			(a, b) =>
+				new Date((matchByFixtureId.get(a.id) as FdArchiveMatch).utcDate).getTime() -
+				new Date((matchByFixtureId.get(b.id) as FdArchiveMatch).utcDate).getTime(),
+		)
+		for (const f of bucket) {
+			const m = matchByFixtureId.get(f.id) as FdArchiveMatch
+			const oldScore = f.homeScore != null ? `${f.homeScore}-${f.awayScore}` : '—'
+			console.log(
+				`  ${shortName(f.homeTeamId)} v ${shortName(f.awayTeamId)}: ` +
+					`kickoff ${fmt(f.kickoff)} → ${m.utcDate}, ` +
+					`${f.status} ${oldScore} → finished ${m.score.fullTime.home}-${m.score.fullTime.away}` +
+					`${mapWinner(m.score.winner) ? ` (winner=${mapWinner(m.score.winner)})` : ''}, ` +
+					`fpl id ${f.externalId ?? fplId(f.externalIds) ?? '—'} → cleared, ` +
+					`fd id ${fdId(f.externalIds) ?? '—'} → ${m.id}`,
+			)
+		}
+	}
+	console.log(
+		`\nCompetition ${JSON.stringify(comp.name)}: status ${comp.status} → archived` +
+			(comp.status === 'archived' ? ' (already archived — no-op)' : ''),
+	)
+
+	if (!apply) {
+		console.log('\nDRY RUN — nothing written. Re-run with --apply to commit.')
+		process.exit(0)
+	}
+
+	// ── Apply ─────────────────────────────────────────────────────────────
+	await db.transaction(async (tx) => {
+		for (const f of fixtures) {
+			const m = matchByFixtureId.get(f.id) as FdArchiveMatch
+			await tx
+				.update(fixture)
+				.set({
+					kickoff: new Date(m.utcDate),
+					status: 'finished',
+					homeScore: m.score.fullTime.home,
+					awayScore: m.score.fullTime.away,
+					regularHomeScore: m.score.regularTime?.home ?? null,
+					regularAwayScore: m.score.regularTime?.away ?? null,
+					winner: mapWinner(m.score.winner),
+					externalId: null,
+					externalIds: { football_data: String(m.id) },
+				})
+				.where(eq(fixture.id, f.id))
+		}
+		for (const r of rounds) {
+			await tx
+				.update(round)
+				.set({ deadline: deadlineByRoundId.get(r.id) as Date })
+				.where(eq(round.id, r.id))
+		}
+		await tx.update(competition).set({ status: 'archived' }).where(eq(competition.id, comp.id))
+	})
+
+	// ── Post-apply verification ───────────────────────────────────────────
+	heading('Applied — post-state')
+	const compAfter = await db.query.competition.findFirst({ where: eq(competition.id, comp.id) })
+	const fixturesAfter = await db
+		.select()
+		.from(fixture)
+		.where(
+			inArray(
+				fixture.roundId,
+				rounds.map((r) => r.id),
+			),
+		)
+	console.log(`competition status: ${compAfter?.status} (expect archived)`)
+	console.log(
+		`fixtures finished with scores: ${fixturesAfter.filter((f) => f.status === 'finished' && f.homeScore != null).length}/${fixturesAfter.length} (expect ${PL_2526_EXPECTED_FIXTURES})`,
+	)
+	console.log(
+		`kickoffs in ${PL_2526_SEASON} window: ${fixturesAfter.filter((f) => inWindow(f.kickoff)).length}/${fixturesAfter.length} (expect ${PL_2526_EXPECTED_FIXTURES})`,
+	)
+	console.log(
+		`carrying an FPL id: ${fixturesAfter.filter((f) => f.externalId != null || fplId(f.externalIds) != null).length} (expect 0)`,
+	)
+	console.log(
+		`carrying a football-data id: ${fixturesAfter.filter((f) => fdId(f.externalIds) != null).length} (expect ${PL_2526_EXPECTED_FIXTURES})`,
+	)
+	console.log('\nRun scripts/repair/inspect-pl-2526-restore.ts for the full restored record.')
+	process.exit(0)
+}
+
+main().catch((err) => {
+	console.error('Restore failed:', err)
+	process.exit(1)
+})

--- a/scripts/repair/shared.ts
+++ b/scripts/repair/shared.ts
@@ -32,6 +32,38 @@ export const PL_2526_EXPECTED_TEAMS = 20
 export const PL_2526_KICKOFF_MIN = new Date('2025-08-01T00:00:00Z')
 export const PL_2526_KICKOFF_MAX = new Date('2026-06-15T00:00:00Z')
 
+export function inPl2526Window(d: Date | null): boolean {
+	return d != null && d >= PL_2526_KICKOFF_MIN && d <= PL_2526_KICKOFF_MAX
+}
+
+/** The fixture columns the #121 census inspects (structural, schema-free). */
+interface CensusFixture {
+	status: string
+	kickoff: Date | null
+	homeScore: number | null
+	externalId: string | null
+	externalIds: Record<string, string | number> | null
+}
+
+/**
+ * The corruption/restoration census shared by the #121 inspector and the
+ * restore script's current-state print: statuses, kickoff-window buckets,
+ * missing scores, and which external ids the rows carry.
+ */
+export function fixtureCensusLines(fixtures: CensusFixture[]): string[] {
+	const statusCounts = new Map<string, number>()
+	for (const f of fixtures) statusCounts.set(f.status, (statusCounts.get(f.status) ?? 0) + 1)
+	return [
+		`status: ${[...statusCounts].map(([s, n]) => `${s}=${n}`).join(' ')}`,
+		`kickoff in ${PL_2526_SEASON} window: ${fixtures.filter((f) => inPl2526Window(f.kickoff)).length}` +
+			` | outside: ${fixtures.filter((f) => f.kickoff != null && !inPl2526Window(f.kickoff)).length}` +
+			` | null: ${fixtures.filter((f) => f.kickoff == null).length}`,
+		`missing scores: ${fixtures.filter((f) => f.homeScore == null).length}`,
+		`carrying an FPL id: ${fixtures.filter((f) => f.externalId != null || f.externalIds?.fpl != null).length}` +
+			` | carrying a football-data id: ${fixtures.filter((f) => f.externalIds?.football_data != null).length}`,
+	]
+}
+
 /** Parse a numeric-string money amount (e.g. '80.00') into integer pence. */
 export function toPence(amount: string): number {
 	const parsed = Number(amount)

--- a/scripts/repair/shared.ts
+++ b/scripts/repair/shared.ts
@@ -1,5 +1,5 @@
 /**
- * Shared constants + helpers for the issue #119 one-off prod repair scripts.
+ * Shared constants + helpers for the one-off prod repair scripts.
  *
  * Convention (established incident-repair pattern): every mutating script is
  * dry-run by default and only writes with an explicit `--apply` flag. All
@@ -7,11 +7,30 @@
  * an intended mutation; any drift from the expected state aborts loudly.
  */
 
+// -- Issue #119: World Cup endgame repairs --
+
 export const WC_LPS_GAME_ID = 'dc857c5f-8a07-4c3b-aeef-71d9883a218e'
 export const WC_LPS_GAME_NAME = 'World Cup LPS'
 
 export const SI_WC_GAME_ID = '55747598-5ef3-42c3-9635-ae5f531e3db3'
 export const SI_WC_GAME_NAME = 'SI World Cup'
+
+// -- Issue #121: 2025/26 PL season restore + archive --
+
+/** `competition.season` on the row to restore (dataSource 'fpl'). */
+export const PL_2526_SEASON = '2025/26'
+/** football-data `?season=` start-year for the 2025/26 archive. */
+export const PL_2526_FD_SEASON = '2025'
+export const PL_2526_EXPECTED_ROUNDS = 38
+export const PL_2526_EXPECTED_FIXTURES = 380
+export const PL_2526_EXPECTED_TEAMS = 20
+/**
+ * Sanity window every restored kickoff must fall in. The season ran
+ * 2025-08-15 → 2026-05-24; the window is padded so a rescheduled outlier
+ * can't trip it, while a 2026/27 kickoff (from 2026-08) still fails.
+ */
+export const PL_2526_KICKOFF_MIN = new Date('2025-08-01T00:00:00Z')
+export const PL_2526_KICKOFF_MAX = new Date('2026-06-15T00:00:00Z')
 
 /** Parse a numeric-string money amount (e.g. '80.00') into integer pence. */
 export function toPence(amount: string): number {


### PR DESCRIPTION
Closes #121

One-off prod repair, gated on human sign-off (`human-signoff` label): **the scripts and dry-run evidence are delivered here; a human runs `--apply`** per the runbook in `scripts/repair/README.md`.

## What's in the change

- **`scripts/repair/restore-pl-2526-season.ts`** — dry-run by default, `--apply` to commit. Fetches football-data's completed `?season=2025` archive (380 finished matches), matches every archive match to our fixture row **structurally by (home, away) team pair** (resolved through stable football-data team ids — never by round number or kickoff, both corrupted), asserts a full bijection, then in a single transaction: restores kickoff / score / status / winner / 2025/26 football-data id on all 380 rows, clears the colliding FPL ids (`external_id` + `external_ids.fpl`), restores the 38 round deadlines (earliest kickoff − 90 min, FPL's own convention), and archives the competition. Hard preconditions abort loudly with zero writes, including a wrong-season guard (every archive kickoff must fall in the 2025/26 window + the GW1 opener must be Liverpool 4-2 Bournemouth on 2025-08-15). Single-use: after apply no fixture carries an FPL id, so a re-run fails its precondition.
- **`scripts/repair/inspect-pl-2526-restore.ts`** — SELECT-only inspector: competition status, per-round deadlines, fixture corruption census, full GW1 + GW38 listings, and every game on the competition with picks joined to their fixtures' scores ("Last Day Lightning 26" truthfulness evidence).
- README runbook + shared constants.

## Evidence

### Local rehearsal (scratch Postgres, exact structural replica of the corruption)

Seeded 380 corrupted rows (2026/27 kickoffs, wiped scores, FPL ids 1–380, mixed wrong/true fd ids) from the real archive pairings, then ran inspect → dry-run → apply → inspect → re-run:

- post-apply census: `finished=380`, kickoffs in window `380`, missing scores `0`, FPL ids `0`, fd ids `380`, competition `archived`
- re-run aborted: `✖ PRECONDITION FAILED: no fixture carries an FPL id — the restore appears to have already been applied`

### Prod baseline (read-only inspector)

```
name="Premier League 2025/26" id=a0c8e995-73bd-416f-b4a7-5af6bd4c987c status=active
Fixture census (380 fixtures, 38 rounds):
  status: scheduled=380
  kickoff in 2025/26 window: 0 | outside: 380 | null: 0
  missing scores: 380
  carrying an FPL id: 380 | carrying a football-data id: 380
```

All 110 picks of the completed "Last Day Lightning 26" game currently point at scoreless `scheduled` fixtures dated **2027-05-30**. The already-settled pick results line up with the real 2025/26 GW38 scores in the archive (e.g. `TOT → win` vs the real TOT 1-0 EVE), independently confirming the archive matches what the picks were settled against.

### Prod dry run (read-only; all preconditions pass, nothing written)

<details><summary>Excerpt — census, GW1, GW38, archive step (full 478-line output reproducible via the runbook)</summary>

```
competition: "Premier League 2025/26" (a0c8e995-73bd-416f-b4a7-5af6bd4c987c) status=active

Current state (380 fixtures):
  status: scheduled=380
  kickoff in 2025/26 window: 0 | outside: 380 | null: 0
  missing scores: 380
  carrying an FPL id: 380 | carrying a football-data id: 380

archive OK: 380 finished matches; opener LIV 4-2 BOU on 2025-08-15 ✓

R1 Gameweek 1: deadline 2026-08-21T17:30:00.000Z → 2025-08-15T17:30:00.000Z
  LIV v BOU: kickoff 2026-08-21T19:00:00.000Z → 2025-08-15T19:00:00Z, scheduled — → finished 4-2 (winner=home), fpl id 1 → cleared, fd id 560914 → 537785
  AVL v NEW: kickoff 2026-08-22T16:30:00.000Z → 2025-08-16T11:30:00Z, scheduled — → finished 0-0, fpl id 2 → cleared, fd id 560899 → 537786
  ...
R38 Gameweek 38: deadline 2027-05-30T13:30:00.000Z → 2026-05-24T13:30:00.000Z
  SUN v CHE: kickoff 2027-05-30T15:00:00.000Z → 2026-05-24T15:00:00Z, scheduled — → finished 2-1 (winner=home), fpl id 378 → cleared, fd id 560636 → 538155
  BHA v MUN: kickoff 2027-05-30T15:00:00.000Z → 2026-05-24T15:00:00Z, scheduled — → finished 0-3 (winner=away), fpl id 371 → cleared, fd id 560730 → 538156
  TOT v EVE: kickoff 2027-05-30T15:00:00.000Z → 2026-05-24T15:00:00Z, scheduled — → finished 1-0 (winner=home), fpl id 379 → cleared, fd id 560575 → 538163
  ...

Competition "Premier League 2025/26": status active → archived

DRY RUN — nothing written. Re-run with --apply to commit.
```

</details>

Note the prod baseline confirms the mixed fd-id state the merge left behind (some rows carry 2026/27 ids like `560914`, some kept their true 2025/26 ids like `538158`) — the restore normalises all 380 to the true 2025/26 ids.

## Validation

- `just lint`, `just typecheck`, `just test` (656 passed) — ops scripts are not vitest-tested per the parent spec's testing decisions.
- Refactor after self-review re-verified with a second prod dry run: **byte-identical output**.

## Self-review notes (/code-review vs origin/main)

Acted on: extracted the thrice-duplicated corruption census into `shared.fixtureCensusLines`, carried fixture+archive-match as `pairs` (removes four `as`-casts), renamed the inspector's `ids()` → `extIds`.

Considered and not taken, with reasons:

- **"Deadlines are reconstructed, not restored."** True: FPL doesn't serve past seasons, so the original `event.deadline_time` values can't be re-fetched. The script derives earliest-kickoff-in-round − 90 min — FPL's own deadline convention and the same derivation the football-data adapter uses. Documented in the script header; the dry run prints all 38 for human review. The only divergence case is a gameweek whose earliest fixture was postponed after the original deadline — display-only history either way.
- **Regular-time scores written (not in the ticket's field list).** The sync writes these columns on every fixture update; restoring them from the same archive payload (null for regulation matches) keeps the row shape faithful rather than leaving corrupted-era values.
- **`external_ids` replaced wholesale with `{ football_data: <2025 id> }`.** Intended: only `fpl`/`football_data` keys have ever existed on PL fixtures, and the ticket requires the fpl key gone and the fd key true.
- **Usage headers use `doppler run -p last-person-standing -c prd` while the #119 siblings use `--config prd`.** The explicit form works without a locally-configured Doppler project (this machine has none) and matches the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
