### PR TITLE
Execute 2026/27 rollover on prod: verify GW1, re-enable daily-sync, rewrite ritual docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,18 +94,21 @@ GitHub Actions secrets (repo-level):
 - `VERCEL_PROD_URL` — full https URL of the Vercel production deployment. Used by `live-scores.yml` as the request target.
 - `PROD_DATABASE_URL` — same value as Doppler `prd.DATABASE_URL`. Used by `migrate.yml` to apply Drizzle migrations on push to `main`. Duplicated from Doppler intentionally; revisit if rotation cadence increases.
 
-## PL season rollover (annual ritual)
+## PL season rollover (annual verification ritual)
 
-Every August, the Premier League season changes — 3 promoted teams replace 3 relegated ones. Bootstrap merges FPL data with football-data IDs by `short_name === tla`, plus an alias map `FPL_TO_FD_TLA` in `src/lib/game/bootstrap-competitions.ts` for the rare cases where the two sources disagree on a team's 3-letter code. (As of 2025/26: only Nottingham Forest mismatched — FPL `NFO`, football-data `NOT`.)
+Every August, the Premier League season changes — 3 promoted teams replace 3 relegated ones. The rollover itself is **automatic**: the daily sync (a GitHub Actions workflow, `.github/workflows/daily-sync.yml`, scheduled 04:00 UTC — *not* a Vercel cron; FPL's Cloudflare blocks Vercel egress, so the workflow fetches the FPL payloads and POSTs them to `/api/cron/daily-sync`) detects the season via football-data's `currentSeason` cross-checked against FPL's GW1 deadline (`ensureCurrentPlSeasonCompetition`), creates "Premier League YYYY/YY", and archives the predecessor in one transaction — all before any sync writes. On detection failure it throws `SeasonDetectionError`: zero writes, a failed `cron_run` row, a red Actions job. It never guesses.
 
-After a season rollover:
+The human ritual is **verification only** — nothing to execute:
 
-1. **Re-run bootstrap once** locally with prod creds (or wait for the daily Vercel Cron at 04:00 UTC).
-2. **If `mergeFootballDataIds` throws** with `missing football-data IDs after merge: <list>`, that's the new-season gap. The error names the unmatched team(s).
-3. **Look up the team's football-data tla** at `https://api.football-data.org/v4/competitions/PL/teams` and add a one-line entry to `FPL_TO_FD_TLA`.
-4. **Re-run bootstrap.** Coverage assertion passes; live scoring works for the new team.
+1. **Check the first August daily-sync runs are green**: `gh run list --workflow=daily-sync.yml`.
+2. **Run the read-only inspector** (season-agnostic — it derives the expected season from the sources): `doppler run -p last-person-standing -c prd -- pnpm exec tsx scripts/repair/inspect-pl-rollover.ts`. It verifies the new competition (38 rounds / 380 fixtures / 20 teams), GW1 pairings against both FPL and football-data, team badge + external-id coverage, and that predecessor seasons stay archived and untouched. Exits non-zero on any failed check.
+3. **Add colour entries for promoted clubs** in `src/lib/teams/colours.ts` if the inspector flags any team falling back to grey.
+4. **Confirm a GW1 game can be created** — the new competition's Gameweek 1 must be pickable (future deadline) in the game-creation flow.
 
-Fixture-level coverage gaps are warn-only (rescheduled / late-published matches fill in on subsequent bootstrap runs). Team gaps fail loudly because every team must be matchable for live scoring to work.
+Two failure modes need a human hand, and both fail loudly rather than corrupt:
+
+- **`SeasonDetectionError`** (red run, zero writes): the sources disagree or one is missing data — investigate before anything else; do not hand-create the season.
+- **`mergeFootballDataIds` team-coverage error** (`missing football-data IDs after merge: <list>`): a promoted club's FPL `short_name` and football-data `tla` disagree (as of 2025/26 only Nottingham Forest: FPL `NFO`, fd `NOT`). Add a one-line entry to `FPL_TO_FD_TLA` in `src/lib/game/bootstrap-competitions.ts`, deploy, and let the next sync run. Team gaps fail loudly because every team must be matchable for live scoring; fixture-level gaps are warn-only (rescheduled / late-published matches fill in on subsequent runs).
 
 ## Per-fixture settlement
 

--- a/scripts/repair/README.md
+++ b/scripts/repair/README.md
@@ -14,6 +14,70 @@ All commands run from the repo root. WSL note: run outside any network
 sandbox (Neon DNS is blocked in it); Neon idle-suspends, so retry once on
 an initial `ETIMEDOUT`.
 
+## Issue #122 — 2026/27 rollover execution + GW1 verification
+
+The auto-rollover itself is deployed code (#132): the daily-sync run detects
+the season from football-data's `currentSeason` cross-checked against FPL's
+GW1 deadline, creates "Premier League 2026/27", and archives the predecessor
+— all before any sync writes. This runbook *triggers* that deployed path
+once, verifies GW1-readiness with the read-only inspector, and only then
+re-arms the schedule (manually disabled 2026-08-01 to stop the corruption).
+
+`inspect-pl-rollover.ts` is season-agnostic (it derives the expected season
+from the sources), read-only, and exits non-zero on any failed check — it is
+also the perennial verification tool for every future August (see AGENTS.md
+"PL season rollover").
+
+### Runbook (human, in order)
+
+```bash
+# 0. Pre-flight — sources ready, tla coverage, prod baseline. Expect
+#    "Baseline OK (pre-rollover)" and zero ✖ marks.
+doppler run -p last-person-standing -c prd -- pnpm exec tsx scripts/repair/inspect-pl-rollover.ts
+
+# 1. Run the deployed auto-rollover: mirror the daily-sync workflow by hand
+#    (fetch FPL payloads locally — FPL's Cloudflare blocks Vercel egress —
+#    and POST them to the deployed route). Expect HTTP 200 with a
+#    competitions array; the rollover logs land in Vercel function logs.
+curl -sSf -o /tmp/bootstrap.json https://fantasy.premierleague.com/api/bootstrap-static/
+curl -sSf -o /tmp/fixtures.json https://fantasy.premierleague.com/api/fixtures/
+jq -cn --slurpfile b /tmp/bootstrap.json --slurpfile f /tmp/fixtures.json \
+  '{fpl: {bootstrap: $b[0], fixtures: $f[0]}}' > /tmp/payload.json
+doppler run -p last-person-standing -c prd -- bash -c '
+  curl -sS --fail-with-body -X POST \
+    -H "Authorization: Bearer ${CRON_SECRET}" \
+    -H "Content-Type: application/json" \
+    --data-binary @/tmp/payload.json \
+    -w "\nHTTP %{http_code} in %{time_total}s\n" \
+    https://last-person-standing.app/api/cron/daily-sync'
+
+# 2. Verify — expect "ALL CHECKS PASSED" (38 rounds / 380 fixtures / 20
+#    teams, GW1 pairings matching FPL + football-data, promoted clubs with
+#    football-data crests + colour entries, 2025/26 archived + untouched).
+doppler run -p last-person-standing -c prd -- pnpm exec tsx scripts/repair/inspect-pl-rollover.ts
+
+# 3. UI spot-checks on https://last-person-standing.app:
+#    - Create a classic game on "Premier League 2026/27" → it must attach to
+#      a pickable Gameweek 1 (deadline 2026-08-21 17:30 UTC).
+#    - On the pick screen, Coventry / Hull / Ipswich render real crests and
+#      their club colours (light blue / amber / blue), not the grey fallback.
+
+# 4. Only after 2 + 3 pass: re-enable the daily-sync schedule.
+gh workflow enable daily-sync.yml
+
+# 5. Next morning (schedule fires 04:00 UTC, free tier can lag 30–60 min):
+#    confirm the scheduled run is green, then re-run the inspector — the
+#    2025/26 census must be unchanged (archived competitions are immutable).
+gh run list --workflow=daily-sync.yml --limit 3
+doppler run -p last-person-standing -c prd -- pnpm exec tsx scripts/repair/inspect-pl-rollover.ts
+```
+
+If step 1 or 2 fails: do **not** enable the workflow. A
+`SeasonDetectionError` means the sources disagree (zero writes happened); a
+`mergeFootballDataIds` team-coverage error names the club whose FPL/fd
+3-letter codes mismatch — add it to `FPL_TO_FD_TLA` in
+`src/lib/game/bootstrap-competitions.ts`, deploy, and re-run from step 1.
+
 ## Issue #121 — 2025/26 PL season restore + archive
 
 The pre-#124 nightly sync matched fixtures on globally-unique external

--- a/scripts/repair/README.md
+++ b/scripts/repair/README.md
@@ -54,6 +54,8 @@ doppler run -p last-person-standing -c prd -- bash -c '
 # 2. Verify — expect "ALL CHECKS PASSED" (38 rounds / 380 fixtures / 20
 #    teams, GW1 pairings matching FPL + football-data, promoted clubs with
 #    football-data crests + colour entries, 2025/26 archived + untouched).
+#    Eyeball the printed GW1 list against the ticket's spot-checks:
+#    ARS v COV, HUL v MUN, EVE v CRY, IPS v SUN.
 doppler run -p last-person-standing -c prd -- pnpm exec tsx scripts/repair/inspect-pl-rollover.ts
 
 # 3. UI spot-checks on https://last-person-standing.app:
@@ -178,5 +180,8 @@ grep -ci 'application error\|internal server error' /tmp/lps-game.html
 
 Also confirm the deleted game is gone from the signed-in dashboard listing.
 
-These scripts are single-use: once applied and verified, their
-preconditions can never pass again (each aborts loudly if re-run).
+The mutating scripts are single-use: once applied and verified, their
+preconditions can never pass again (each aborts loudly if re-run). The
+inspectors are read-only and safe to re-run any time —
+`inspect-pl-rollover.ts` in particular is the perennial season-rollover
+verification tool.

--- a/scripts/repair/inspect-pl-rollover.ts
+++ b/scripts/repair/inspect-pl-rollover.ts
@@ -1,0 +1,406 @@
+/**
+ * Read-only GW1-readiness inspector for the automatic PL season rollover
+ * (issue #122; season-agnostic, so it doubles as the annual verification
+ * tool — see AGENTS.md "PL season rollover").
+ *
+ * Derives the expected season from the live sources through the exact code
+ * path the deployed rollover uses (football-data currentSeason cross-checked
+ * against FPL's GW1 deadline), then verifies:
+ *
+ *   1. Sources — season detection succeeds; every FPL team tla-matches a
+ *      football-data team (predicts mergeFootballDataIds coverage); GW1
+ *      pairings agree between the two sources; every fd team has a crest.
+ *   2. DB — the detected season's competition exists, is active, and carries
+ *      38 rounds / 380 fixtures / 20 teams; its GW1 pairings match the
+ *      sources; GW1 is pickable for a new classic game (future deadline);
+ *      every team carries both external ids, a badge, and a colour entry.
+ *   3. DB — every predecessor fpl competition is archived and untouched
+ *      (no fixture carries an FPL id; no kickoff strays into the new season).
+ *
+ * Before the rollover has run, section 1 still executes as a pre-flight and
+ * the current-season DB section reports the baseline instead of failing.
+ * SELECT-only — safe to run against prod at any time.
+ *
+ * Usage (prod):
+ *   doppler run -p last-person-standing -c prd -- pnpm exec tsx scripts/repair/inspect-pl-rollover.ts
+ */
+
+import { asc, eq, inArray } from 'drizzle-orm'
+import { FootballDataAdapter } from '../../src/lib/data/football-data'
+import { FplAdapter } from '../../src/lib/data/fpl'
+import { db } from '../../src/lib/db'
+import { deriveSeasonLabel, fdTlaForFplShortName } from '../../src/lib/game/bootstrap-competitions'
+import { competition, fixture, round, team } from '../../src/lib/schema/competition'
+import { FALLBACK_TEAM_COLOUR, getTeamColour } from '../../src/lib/teams/colours'
+import { heading } from './shared'
+
+const PL_EXPECTED_ROUNDS = 38
+const PL_EXPECTED_FIXTURES = 380
+const PL_EXPECTED_TEAMS = 20
+const PICKABLE_ROUND_STATUSES = ['upcoming', 'open', 'active']
+
+const failures: string[] = []
+
+function check(ok: boolean, label: string): void {
+	console.log(`  ${ok ? '✔' : '✖'} ${label}`)
+	if (!ok) failures.push(label)
+}
+
+function fmt(d: Date | null | undefined): string {
+	return d ? d.toISOString() : '—'
+}
+
+/** Order-insensitive pairing key in football-data tla space. */
+function pairKey(homeTla: string, awayTla: string): string {
+	return `${homeTla} v ${awayTla}`
+}
+
+function diffPairs(label: string, ours: Set<string>, theirs: Set<string>): void {
+	const missing = [...theirs].filter((p) => !ours.has(p))
+	const extra = [...ours].filter((p) => !theirs.has(p))
+	if (missing.length > 0) console.log(`    ${label} missing: ${missing.join(', ')}`)
+	if (extra.length > 0) console.log(`    ${label} extra: ${extra.join(', ')}`)
+}
+
+async function main() {
+	const apiKey = process.env.FOOTBALL_DATA_API_KEY
+	if (!apiKey) {
+		console.error('FOOTBALL_DATA_API_KEY is not set — run under doppler (see usage in header).')
+		process.exit(1)
+	}
+
+	// ── 1. Sources — season detection + GW1 cross-check ──────────────────
+	heading('Sources — season detection (the rollover’s own code path)')
+	const fpl = new FplAdapter()
+	const fd = new FootballDataAdapter('PL', apiKey)
+	// Sequential so FplAdapter's bootstrap cache is primed for the later calls.
+	const fplGw1Deadline = await fpl.fetchGw1Deadline()
+	const fdSeason = await fd.fetchCurrentSeason()
+	console.log(
+		`  football-data currentSeason: ${fdSeason ? `${fdSeason.startDate} → ${fdSeason.endDate}` : '—'}`,
+	)
+	console.log(`  FPL GW1 deadline: ${fmt(fplGw1Deadline)}`)
+	// Throws SeasonDetectionError on any absence or disagreement — the same
+	// loud zero-write abort the deployed rollover takes.
+	const season = deriveSeasonLabel(fdSeason, fplGw1Deadline)
+	console.log(`  derived season label: ${season}`)
+	const now = new Date()
+	check(
+		fplGw1Deadline != null && fplGw1Deadline > now,
+		`GW1 deadline is in the future (${fmt(fplGw1Deadline)})`,
+	)
+
+	heading(`Sources — FPL ↔ football-data team + GW1 cross-check for ${season}`)
+	const fplTeams = await fpl.fetchTeams()
+	const fplRounds = await fpl.fetchRounds()
+	const fdTeams = await fd.fetchTeams()
+	const fdRounds = await fd.fetchRounds()
+
+	check(
+		fplTeams.length === PL_EXPECTED_TEAMS,
+		`FPL lists ${PL_EXPECTED_TEAMS} teams (got ${fplTeams.length})`,
+	)
+	check(
+		fdTeams.length === PL_EXPECTED_TEAMS,
+		`football-data lists ${PL_EXPECTED_TEAMS} teams (got ${fdTeams.length})`,
+	)
+
+	// tla alignment predicts mergeFootballDataIds' loud coverage assertion.
+	const fdTlas = new Set(fdTeams.map((t) => t.shortName))
+	const tlaUnmatched = fplTeams.filter((t) => !fdTlas.has(fdTlaForFplShortName(t.shortName)))
+	check(
+		tlaUnmatched.length === 0,
+		'every FPL team tla-matches a football-data team (via FPL_TO_FD_TLA)' +
+			(tlaUnmatched.length > 0
+				? ` — UNMATCHED: ${tlaUnmatched.map((t) => `${t.shortName} (${t.name})`).join(', ')} — add to FPL_TO_FD_TLA`
+				: ''),
+	)
+
+	const crestless = fdTeams.filter((t) => !t.badgeUrl)
+	check(
+		crestless.length === 0,
+		'every football-data team has a crest URL' +
+			(crestless.length > 0 ? ` — missing: ${crestless.map((t) => t.name).join(', ')}` : ''),
+	)
+
+	const fplGw1 = fplRounds.find((r) => r.number === 1)
+	const fdGw1 = fdRounds.find((r) => r.number === 1)
+	const fplShortById = new Map(fplTeams.map((t) => [t.externalId, t.shortName]))
+	const fdShortById = new Map(fdTeams.map((t) => [t.externalId, t.shortName]))
+	const fplGw1Pairs = new Set(
+		(fplGw1?.fixtures ?? []).map((f) =>
+			pairKey(
+				fdTlaForFplShortName(fplShortById.get(f.homeTeamExternalId) ?? '?'),
+				fdTlaForFplShortName(fplShortById.get(f.awayTeamExternalId) ?? '?'),
+			),
+		),
+	)
+	const fdGw1Pairs = new Set(
+		(fdGw1?.fixtures ?? []).map((f) =>
+			pairKey(
+				fdShortById.get(f.homeTeamExternalId) ?? '?',
+				fdShortById.get(f.awayTeamExternalId) ?? '?',
+			),
+		),
+	)
+	console.log(`  GW1 pairings (football-data, by kickoff):`)
+	for (const f of [...(fdGw1?.fixtures ?? [])].sort(
+		(a, b) => (a.kickoff?.getTime() ?? 0) - (b.kickoff?.getTime() ?? 0),
+	)) {
+		console.log(
+			`    ${fdShortById.get(f.homeTeamExternalId)} v ${fdShortById.get(f.awayTeamExternalId)} kickoff=${fmt(f.kickoff)}`,
+		)
+	}
+	check(
+		fplGw1Pairs.size === PL_EXPECTED_FIXTURES / PL_EXPECTED_ROUNDS,
+		`GW1 has ${PL_EXPECTED_FIXTURES / PL_EXPECTED_ROUNDS} fixtures on FPL (got ${fplGw1Pairs.size})`,
+	)
+	const sourcesAgree =
+		fplGw1Pairs.size === fdGw1Pairs.size && [...fplGw1Pairs].every((p) => fdGw1Pairs.has(p))
+	check(sourcesAgree, 'GW1 pairings agree between FPL and football-data')
+	if (!sourcesAgree) diffPairs('FPL vs football-data', fplGw1Pairs, fdGw1Pairs)
+
+	// ── 2. DB — the detected season's competition ─────────────────────────
+	heading(`Prod DB — "Premier League ${season}"`)
+	const fplComps = await db.select().from(competition).where(eq(competition.dataSource, 'fpl'))
+	const current = fplComps.find((c) => c.season === season)
+	const predecessors = fplComps.filter((c) => c.season !== season)
+	const predecessorTlas = new Set<string>()
+
+	if (!current) {
+		const active = fplComps.filter((c) => c.status === 'active')
+		console.log(
+			`  No fpl competition with season ${season} — the rollover has NOT run yet (pre-execution baseline).`,
+		)
+		console.log(
+			`  fpl competitions present: ${fplComps.map((c) => `"${c.name}" (${c.status})`).join(', ') || 'none'}`,
+		)
+		check(
+			active.length === 0,
+			'no active fpl competition awaiting archive (predecessors already archived)',
+		)
+	} else {
+		check(current.status === 'active', `competition status is active (got ${current.status})`)
+		check(
+			current.name === `Premier League ${season}`,
+			`competition name is "Premier League ${season}" (got "${current.name}")`,
+		)
+
+		const rounds = await db
+			.select()
+			.from(round)
+			.where(eq(round.competitionId, current.id))
+			.orderBy(asc(round.number))
+		const fixtures =
+			rounds.length > 0
+				? await db
+						.select()
+						.from(fixture)
+						.where(
+							inArray(
+								fixture.roundId,
+								rounds.map((r) => r.id),
+							),
+						)
+				: []
+		check(
+			rounds.length === PL_EXPECTED_ROUNDS,
+			`${PL_EXPECTED_ROUNDS} rounds (got ${rounds.length})`,
+		)
+		check(
+			fixtures.length === PL_EXPECTED_FIXTURES,
+			`${PL_EXPECTED_FIXTURES} fixtures (got ${fixtures.length})`,
+		)
+
+		const teamIds = new Set<string>()
+		for (const f of fixtures) {
+			teamIds.add(f.homeTeamId)
+			teamIds.add(f.awayTeamId)
+		}
+		const teams =
+			teamIds.size > 0
+				? await db
+						.select()
+						.from(team)
+						.where(inArray(team.id, [...teamIds]))
+				: []
+		const teamById = new Map(teams.map((t) => [t.id, t]))
+		check(
+			teams.length === PL_EXPECTED_TEAMS,
+			`${PL_EXPECTED_TEAMS} teams on the competition (got ${teams.length})`,
+		)
+
+		// GW1: pickable + pairings match both sources.
+		const gw1 = rounds.find((r) => r.number === 1)
+		const gw1Fixtures = gw1 ? fixtures.filter((f) => f.roundId === gw1.id) : []
+		check(
+			gw1 != null &&
+				PICKABLE_ROUND_STATUSES.includes(gw1.status) &&
+				gw1.deadline != null &&
+				gw1.deadline > now,
+			`GW1 is pickable for a new classic game (status=${gw1?.status ?? '—'}, deadline=${fmt(gw1?.deadline)})`,
+		)
+		const dbTla = (teamId: string) => {
+			const t = teamById.get(teamId)
+			return t ? fdTlaForFplShortName(t.shortName) : '?'
+		}
+		const dbGw1Pairs = new Set(
+			gw1Fixtures.map((f) => pairKey(dbTla(f.homeTeamId), dbTla(f.awayTeamId))),
+		)
+		console.log(`  GW1 fixtures in DB (by kickoff):`)
+		for (const f of [...gw1Fixtures].sort(
+			(a, b) => (a.kickoff?.getTime() ?? 0) - (b.kickoff?.getTime() ?? 0),
+		)) {
+			const ids = f.externalIds as Record<string, string | number> | null
+			console.log(
+				`    ${teamById.get(f.homeTeamId)?.shortName} v ${teamById.get(f.awayTeamId)?.shortName}` +
+					` kickoff=${fmt(f.kickoff)} status=${f.status} fplId=${ids?.fpl ?? f.externalId ?? '—'} fdId=${ids?.football_data ?? '—'}`,
+			)
+		}
+		const dbAgreesFd =
+			dbGw1Pairs.size === fdGw1Pairs.size && [...dbGw1Pairs].every((p) => fdGw1Pairs.has(p))
+		check(dbAgreesFd, 'DB GW1 pairings match football-data (and, transitively, FPL)')
+		if (!dbAgreesFd) diffPairs('DB vs football-data', dbGw1Pairs, fdGw1Pairs)
+
+		// Team coverage: both external ids, a badge, a colour entry.
+		const extIds = (t: (typeof teams)[number]) =>
+			t.externalIds as Record<string, string | number> | null
+		const missingFpl = teams.filter((t) => extIds(t)?.fpl == null)
+		const missingFd = teams.filter((t) => extIds(t)?.football_data == null)
+		check(
+			missingFpl.length === 0,
+			'every team carries an FPL id' +
+				(missingFpl.length > 0
+					? ` — missing: ${missingFpl.map((t) => t.shortName).join(', ')}`
+					: ''),
+		)
+		check(
+			missingFd.length === 0,
+			'every team carries a football-data id (live scoring works)' +
+				(missingFd.length > 0 ? ` — missing: ${missingFd.map((t) => t.shortName).join(', ')}` : ''),
+		)
+		const badgeless = teams.filter((t) => !t.badgeUrl)
+		check(
+			badgeless.length === 0,
+			'every team has a badge URL' +
+				(badgeless.length > 0 ? ` — missing: ${badgeless.map((t) => t.shortName).join(', ')}` : ''),
+		)
+		const colourless = teams.filter((t) => getTeamColour(t.shortName) === FALLBACK_TEAM_COLOUR)
+		check(
+			colourless.length === 0,
+			'every team has a TEAM_COLOURS entry (src/lib/teams/colours.ts)' +
+				(colourless.length > 0
+					? ` — falling back to grey: ${colourless.map((t) => t.shortName).join(', ')}`
+					: ''),
+		)
+
+		// Promoted clubs (not in any predecessor season's team set): the badge
+		// must be a football-data crest — the FPL CDN 404s for them.
+		for (const pred of predecessors) {
+			const predRounds = await db
+				.select({ id: round.id })
+				.from(round)
+				.where(eq(round.competitionId, pred.id))
+			const predFixtures =
+				predRounds.length > 0
+					? await db
+							.select({ homeTeamId: fixture.homeTeamId, awayTeamId: fixture.awayTeamId })
+							.from(fixture)
+							.where(
+								inArray(
+									fixture.roundId,
+									predRounds.map((r) => r.id),
+								),
+							)
+					: []
+			const predTeamIds = new Set(predFixtures.flatMap((f) => [f.homeTeamId, f.awayTeamId]))
+			const predTeams =
+				predTeamIds.size > 0
+					? await db
+							.select()
+							.from(team)
+							.where(inArray(team.id, [...predTeamIds]))
+					: []
+			for (const t of predTeams) predecessorTlas.add(t.shortName)
+		}
+		const promoted = teams.filter((t) => !predecessorTlas.has(t.shortName))
+		console.log(
+			`  promoted clubs (new vs predecessor seasons): ${promoted.map((t) => t.shortName).join(', ') || '—'}`,
+		)
+		for (const t of promoted) {
+			console.log(
+				`    ${t.shortName} ${t.name}: badge=${t.badgeUrl ?? '—'} colour=${getTeamColour(t.shortName)}`,
+			)
+		}
+	}
+
+	// ── 3. DB — predecessors archived + untouched ─────────────────────────
+	heading('Prod DB — predecessor fpl seasons archived + untouched')
+	if (predecessors.length === 0) console.log('  (none)')
+	for (const pred of predecessors) {
+		console.log(`  "${pred.name}" (season ${pred.season}, id ${pred.id})`)
+		check(pred.status === 'archived', `${pred.season}: status is archived (got ${pred.status})`)
+		const predRounds = await db
+			.select({ id: round.id })
+			.from(round)
+			.where(eq(round.competitionId, pred.id))
+		const predFixtures =
+			predRounds.length > 0
+				? await db
+						.select()
+						.from(fixture)
+						.where(
+							inArray(
+								fixture.roundId,
+								predRounds.map((r) => r.id),
+							),
+						)
+				: []
+		const statusCounts = new Map<string, number>()
+		for (const f of predFixtures) statusCounts.set(f.status, (statusCounts.get(f.status) ?? 0) + 1)
+		console.log(
+			`    fixtures=${predFixtures.length} status: ${[...statusCounts].map(([s, n]) => `${s}=${n}`).join(' ')}` +
+				` | missing scores: ${predFixtures.filter((f) => f.homeScore == null).length}`,
+		)
+		// The 2026/27-corruption signature: colliding FPL ids and new-season
+		// kickoffs on an old season's rows. Both must stay at zero forever.
+		const withFplId = predFixtures.filter(
+			(f) =>
+				f.externalId != null ||
+				(f.externalIds as Record<string, string | number> | null)?.fpl != null,
+		)
+		check(
+			withFplId.length === 0,
+			`${pred.season}: no fixture carries an FPL id (got ${withFplId.length})`,
+		)
+		const seasonStart = fdSeason ? new Date(fdSeason.startDate) : null
+		const strayKickoffs = seasonStart
+			? predFixtures.filter((f) => f.kickoff != null && f.kickoff >= seasonStart)
+			: []
+		check(
+			strayKickoffs.length === 0,
+			`${pred.season}: no kickoff on/after the ${season} season start (got ${strayKickoffs.length})`,
+		)
+	}
+
+	// ── Verdict ───────────────────────────────────────────────────────────
+	console.log()
+	if (failures.length > 0) {
+		console.error(`✖ ${failures.length} check(s) FAILED:`)
+		for (const f of failures) console.error(`  - ${f}`)
+		process.exit(1)
+	}
+	if (!current) {
+		console.log(
+			`Baseline OK (pre-rollover): sources are ready for ${season}; the DB is awaiting the rollover run.`,
+		)
+	} else {
+		console.log(`ALL CHECKS PASSED — "Premier League ${season}" is GW1-ready.`)
+	}
+	process.exit(0)
+}
+
+main().catch((err) => {
+	console.error('Inspect failed:', err)
+	process.exit(1)
+})

--- a/scripts/repair/inspect-pl-rollover.ts
+++ b/scripts/repair/inspect-pl-rollover.ts
@@ -14,11 +14,13 @@
  *      38 rounds / 380 fixtures / 20 teams; its GW1 pairings match the
  *      sources; GW1 is pickable for a new classic game (future deadline);
  *      every team carries both external ids, a badge, and a colour entry.
- *   3. DB — every predecessor fpl competition is archived and untouched
- *      (no fixture carries an FPL id; no kickoff strays into the new season).
+ *   3. DB — predecessor fpl competitions are untouched: archived ones pass a
+ *      strict census (complete, fully finished, no kickoff straying into the
+ *      new season; the 2025/26 restore's no-FPL-id signature stays zeroed).
  *
  * Before the rollover has run, section 1 still executes as a pre-flight and
- * the current-season DB section reports the baseline instead of failing.
+ * the DB sections report the baseline instead of failing — a predecessor
+ * that is still active pre-rollover is normal, not an error.
  * SELECT-only — safe to run against prod at any time.
  *
  * Usage (prod):
@@ -32,12 +34,20 @@ import { db } from '../../src/lib/db'
 import { deriveSeasonLabel, fdTlaForFplShortName } from '../../src/lib/game/bootstrap-competitions'
 import { competition, fixture, round, team } from '../../src/lib/schema/competition'
 import { FALLBACK_TEAM_COLOUR, getTeamColour } from '../../src/lib/teams/colours'
-import { heading } from './shared'
+import { heading, PL_2526_SEASON } from './shared'
+
+type FixtureRow = typeof fixture.$inferSelect
 
 const PL_EXPECTED_ROUNDS = 38
 const PL_EXPECTED_FIXTURES = 380
 const PL_EXPECTED_TEAMS = 20
+// Mirrors game creation's candidate statuses (src/app/api/games/route.ts):
+// a round is pickable iff its status is one of these AND its deadline is in
+// the future.
 const PICKABLE_ROUND_STATUSES = ['upcoming', 'open', 'active']
+// mergeFootballDataIds writes football-data crests; the FPL badge CDN 404s
+// for newly promoted clubs, so their badge must live on this host.
+const FD_CREST_HOST = 'crests.football-data.org'
 
 const failures: string[] = []
 
@@ -50,7 +60,8 @@ function fmt(d: Date | null | undefined): string {
 	return d ? d.toISOString() : '—'
 }
 
-/** Order-insensitive pairing key in football-data tla space. */
+/** Home-first pairing key in football-data tla space — a flipped home/away
+ * is a real mismatch, so orientation is part of the key. */
 function pairKey(homeTla: string, awayTla: string): string {
 	return `${homeTla} v ${awayTla}`
 }
@@ -165,19 +176,48 @@ async function main() {
 	const fplComps = await db.select().from(competition).where(eq(competition.dataSource, 'fpl'))
 	const current = fplComps.find((c) => c.season === season)
 	const predecessors = fplComps.filter((c) => c.season !== season)
-	const predecessorTlas = new Set<string>()
+
+	// Each predecessor's fixtures + team short names, loaded once — used for
+	// both promoted-club detection (section 2) and the untouched census
+	// (section 3).
+	const predecessorData = new Map<string, { fixtures: FixtureRow[]; tlas: Set<string> }>()
+	for (const pred of predecessors) {
+		const predRounds = await db
+			.select({ id: round.id })
+			.from(round)
+			.where(eq(round.competitionId, pred.id))
+		const predFixtures =
+			predRounds.length > 0
+				? await db
+						.select()
+						.from(fixture)
+						.where(
+							inArray(
+								fixture.roundId,
+								predRounds.map((r) => r.id),
+							),
+						)
+				: []
+		const predTeamIds = new Set(predFixtures.flatMap((f) => [f.homeTeamId, f.awayTeamId]))
+		const predTeams =
+			predTeamIds.size > 0
+				? await db
+						.select({ shortName: team.shortName })
+						.from(team)
+						.where(inArray(team.id, [...predTeamIds]))
+				: []
+		predecessorData.set(pred.id, {
+			fixtures: predFixtures,
+			tlas: new Set(predTeams.map((t) => t.shortName)),
+		})
+	}
 
 	if (!current) {
-		const active = fplComps.filter((c) => c.status === 'active')
 		console.log(
 			`  No fpl competition with season ${season} — the rollover has NOT run yet (pre-execution baseline).`,
 		)
 		console.log(
 			`  fpl competitions present: ${fplComps.map((c) => `"${c.name}" (${c.status})`).join(', ') || 'none'}`,
-		)
-		check(
-			active.length === 0,
-			'no active fpl competition awaiting archive (predecessors already archived)',
 		)
 	} else {
 		check(current.status === 'active', `competition status is active (got ${current.status})`)
@@ -295,34 +335,8 @@ async function main() {
 		)
 
 		// Promoted clubs (not in any predecessor season's team set): the badge
-		// must be a football-data crest — the FPL CDN 404s for them.
-		for (const pred of predecessors) {
-			const predRounds = await db
-				.select({ id: round.id })
-				.from(round)
-				.where(eq(round.competitionId, pred.id))
-			const predFixtures =
-				predRounds.length > 0
-					? await db
-							.select({ homeTeamId: fixture.homeTeamId, awayTeamId: fixture.awayTeamId })
-							.from(fixture)
-							.where(
-								inArray(
-									fixture.roundId,
-									predRounds.map((r) => r.id),
-								),
-							)
-					: []
-			const predTeamIds = new Set(predFixtures.flatMap((f) => [f.homeTeamId, f.awayTeamId]))
-			const predTeams =
-				predTeamIds.size > 0
-					? await db
-							.select()
-							.from(team)
-							.where(inArray(team.id, [...predTeamIds]))
-					: []
-			for (const t of predTeams) predecessorTlas.add(t.shortName)
-		}
+		// must be a football-data crest — the FPL badge CDN 404s for them.
+		const predecessorTlas = new Set([...predecessorData.values()].flatMap((d) => [...d.tlas]))
 		const promoted = teams.filter((t) => !predecessorTlas.has(t.shortName))
 		console.log(
 			`  promoted clubs (new vs predecessor seasons): ${promoted.map((t) => t.shortName).join(', ') || '—'}`,
@@ -332,6 +346,14 @@ async function main() {
 				`    ${t.shortName} ${t.name}: badge=${t.badgeUrl ?? '—'} colour=${getTeamColour(t.shortName)}`,
 			)
 		}
+		const promotedWrongBadge = promoted.filter((t) => !t.badgeUrl?.includes(FD_CREST_HOST))
+		check(
+			promotedWrongBadge.length === 0,
+			`every promoted club's badge is a football-data crest (${FD_CREST_HOST})` +
+				(promotedWrongBadge.length > 0
+					? ` — wrong: ${promotedWrongBadge.map((t) => t.shortName).join(', ')}`
+					: ''),
+		)
 	}
 
 	// ── 3. DB — predecessors archived + untouched ─────────────────────────
@@ -339,40 +361,59 @@ async function main() {
 	if (predecessors.length === 0) console.log('  (none)')
 	for (const pred of predecessors) {
 		console.log(`  "${pred.name}" (season ${pred.season}, id ${pred.id})`)
-		check(pred.status === 'archived', `${pred.season}: status is archived (got ${pred.status})`)
-		const predRounds = await db
-			.select({ id: round.id })
-			.from(round)
-			.where(eq(round.competitionId, pred.id))
-		const predFixtures =
-			predRounds.length > 0
-				? await db
-						.select()
-						.from(fixture)
-						.where(
-							inArray(
-								fixture.roundId,
-								predRounds.map((r) => r.id),
-							),
-						)
-				: []
+		// Post-rollover every predecessor must be archived. Pre-rollover a
+		// still-active predecessor is the normal state — the rollover is what
+		// archives it — so it's reported, not failed.
+		if (current) {
+			check(pred.status === 'archived', `${pred.season}: status is archived (got ${pred.status})`)
+		} else {
+			console.log(
+				`    status=${pred.status}${pred.status === 'active' ? ' (awaiting rollover archive)' : ''}`,
+			)
+		}
+		const predFixtures = predecessorData.get(pred.id)?.fixtures ?? []
 		const statusCounts = new Map<string, number>()
 		for (const f of predFixtures) statusCounts.set(f.status, (statusCounts.get(f.status) ?? 0) + 1)
+		const missingScores = predFixtures.filter((f) => f.homeScore == null).length
 		console.log(
 			`    fixtures=${predFixtures.length} status: ${[...statusCounts].map(([s, n]) => `${s}=${n}`).join(' ')}` +
-				` | missing scores: ${predFixtures.filter((f) => f.homeScore == null).length}`,
+				` | missing scores: ${missingScores}`,
 		)
-		// The 2026/27-corruption signature: colliding FPL ids and new-season
-		// kickoffs on an old season's rows. Both must stay at zero forever.
+		// Archived competitions are immutable — a drifting census means a sync
+		// wrote into frozen history.
+		if (pred.status === 'archived') {
+			const finished = statusCounts.get('finished') ?? 0
+			check(
+				predFixtures.length === PL_EXPECTED_FIXTURES,
+				`${pred.season}: census intact — ${PL_EXPECTED_FIXTURES} fixtures (got ${predFixtures.length})`,
+			)
+			check(
+				finished === predFixtures.length,
+				`${pred.season}: census intact — every fixture finished (got ${finished}/${predFixtures.length})`,
+			)
+			check(
+				missingScores === 0,
+				`${pred.season}: census intact — no missing scores (got ${missingScores})`,
+			)
+		}
+		// The #121 restore cleared 2025/26's colliding FPL ids; that signature
+		// must stay zeroed. Not generic: seasons archived after the #124
+		// competition-scoped sync fix legitimately keep their own FPL ids.
 		const withFplId = predFixtures.filter(
 			(f) =>
 				f.externalId != null ||
 				(f.externalIds as Record<string, string | number> | null)?.fpl != null,
 		)
-		check(
-			withFplId.length === 0,
-			`${pred.season}: no fixture carries an FPL id (got ${withFplId.length})`,
-		)
+		if (pred.season === PL_2526_SEASON) {
+			check(
+				withFplId.length === 0,
+				`${pred.season}: no fixture carries an FPL id (got ${withFplId.length})`,
+			)
+		} else {
+			console.log(`    fixtures carrying an FPL id: ${withFplId.length}`)
+		}
+		// New-season kickoffs on an old season's rows — the 2026-08-01
+		// corruption mode — can never be legitimate, archived or not.
 		const seasonStart = fdSeason ? new Date(fdSeason.startDate) : null
 		const strayKickoffs = seasonStart
 			? predFixtures.filter((f) => f.kickoff != null && f.kickoff >= seasonStart)

--- a/src/lib/game/bootstrap-competitions.ts
+++ b/src/lib/game/bootstrap-competitions.ts
@@ -264,7 +264,7 @@ const FPL_TO_FD_TLA: Record<string, string> = {
 	NFO: 'NOT',
 }
 
-function fdTlaForFplShortName(fplShortName: string): string {
+export function fdTlaForFplShortName(fplShortName: string): string {
 	return FPL_TO_FD_TLA[fplShortName] ?? fplShortName
 }
 


### PR DESCRIPTION
Closes #122

Per the repo's established gate (scripts/repair/README.md: "the agent delivers the scripts and dry-run evidence; a human runs the execution"), this PR delivers the verification tooling, the human runbook, and read-only baseline evidence. The prod execution itself (trigger the deployed rollover, UI checks, `gh workflow enable`) remains human sign-off — runbook below.

## What's in the diff

- **`scripts/repair/inspect-pl-rollover.ts`** — read-only GW1-readiness inspector, **season-agnostic** so it doubles as the perennial August verification tool. It derives the expected season through the rollover's own code path (fd `currentSeason` × FPL GW1 deadline via `deriveSeasonLabel`), pre-flights FPL↔football-data team-tla + GW1-pairing agreement, then verifies prod: competition active with 38 rounds / 380 fixtures / 20 teams, GW1 pairings matching both sources, GW1 pickable (mirrors game creation's rule), badge / colour / external-id coverage incl. promoted-club fd crests, and predecessors archived + census-intact. Exits non-zero on any failed check; pre-rollover it reports a baseline instead of failing.
- **`scripts/repair/README.md`** — the #122 runbook (human, in order): pre-flight → trigger the deployed rollover by mirroring the daily-sync workflow's payload POST → inspector → UI spot-checks (GW1 classic game; COV/HUL/IPS badges + colours) → **only then** `gh workflow enable daily-sync.yml` → next-morning green run + census re-check.
- **`AGENTS.md`** — rollover ritual rewritten as verification-only; corrects the stale "daily Vercel Cron" claim (it's the daily-sync **GitHub Actions** workflow, 04:00 UTC, which fetches FPL payloads and POSTs them to `/api/cron/daily-sync` because FPL's Cloudflare blocks Vercel egress).
- **`src/lib/game/bootstrap-competitions.ts`** — one-word change: export `fdTlaForFplShortName` so the inspector uses the exact alias mapping `mergeFootballDataIds` uses.

## Baseline evidence (read-only, run against prod 2026-08-02)

- Season detection is ready: fd currentSeason **2026-08-21 → 2027-05-30**, FPL GW1 deadline **2026-08-21T17:30:00Z** → derived label **2026/27** (matches the ticket's hard deadline).
- All 20 FPL teams tla-match football-data — **no new `FPL_TO_FD_TLA` entry needed** despite COV/HUL/IPS being promoted; every fd team has a crest URL.
- GW1 pairings **agree between FPL and football-data** and match the ticket's spot-checks: ARS v COV, HUL v MUN, EVE v CRY, IPS v SUN (+ 6 more).
- Prod DB is cleanly pre-rollover: no 2026/27 competition yet; **2025/26 archived with census intact** (380 fixtures, 380 finished, 0 missing scores, 0 FPL ids, 0 stray kickoffs).
- COV/HUL/IPS colour entries already exist in `src/lib/teams/colours.ts` (it covers through 2026/27).

Full inspector output attached as a comment on #122's thread via this PR.

## Runbook for the human sign-off (full version in scripts/repair/README.md)

1. `doppler run -p last-person-standing -c prd -- pnpm exec tsx scripts/repair/inspect-pl-rollover.ts` → expect "Baseline OK (pre-rollover)".
2. Trigger the deployed rollover: fetch FPL payloads locally and POST to `https://last-person-standing.app/api/cron/daily-sync` with `CRON_SECRET` (exact commands in the README — mirrors the workflow byte-for-byte).
3. Re-run the inspector → expect "ALL CHECKS PASSED".
4. UI: create a GW1 classic game (pickable, deadline 2026-08-21 17:30 UTC); check COV/HUL/IPS crests + colours.
5. `gh workflow enable daily-sync.yml`; next morning confirm the scheduled run is green and re-run the inspector (2025/26 census unchanged).

## Self-review notes (two-axis review vs origin/main, spec #122)

Findings acted on: pre-rollover baseline no longer fails on a legitimately-active predecessor (and the no-FPL-id check is scoped to the 2025/26 restore signature — post-#124 archived seasons keep their own FPL ids); archived predecessors get hard census checks instead of print-only; promoted-club badges asserted to be `crests.football-data.org` URLs; predecessor fixtures fetched once; `pairKey` comment corrected; README "single-use" closer scoped to mutating scripts.

Findings declined, with reasons:
- *Hardcode the ticket's four named pairings as assertions* — deliberately not: the tool is season-agnostic and the hard check (FPL↔fd↔DB pairing-set equality, all 10 fixtures) is strictly stronger; the runbook names the four pairings as the human eyeball step.
- *Extract a shared `PICKABLE_ROUND_STATUSES` constant with `api/games/route.ts`* — declined as over-coupling a repair script into app code; the inspector carries a comment pointing at the source of truth instead.
- *Generalise `shared.fixtureCensusLines` for reuse* — declined: that helper encodes the #121 corruption census (2025/26 kickoff window); reworking it and its two existing callers for a lighter status summary isn't worth the churn.

## Acceptance criteria mapping

- Active "Premier League 2026/27" with 38/380, GW1 matching both sources → **inspector hard checks** (post-execution).
- 2025/26 archived + untouched by subsequent syncs → **inspector hard checks** (archived-status, strict census, restore signature, stray kickoffs) + runbook step 5 re-check after the first scheduled sync.
- COV/HUL/IPS badges + fallback colours + creatable GW1 classic game → inspector (fd-crest + colour-entry + pickability checks) + runbook UI step.
- Daily-sync re-enabled, next run green → runbook steps 4–5 (human-gated).
- AGENTS.md ritual verification-only, cron wording corrected → in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)